### PR TITLE
Refine color menu UI and palette labeling

### DIFF
--- a/openwave/_io/render.py
+++ b/openwave/_io/render.py
@@ -30,6 +30,7 @@ def init_UI(universe_size=[1.0, 1.0, 1.0], tick_spacing=0.25, cam_init_pos=[2.0,
     pkg_name = "OPENWAVE"
     title = pkg_name + " (v" + pkg_version + ")"
     width, height = pyautogui.size()
+    # width, height = 1470, 956  # uncomment to test on min resolution
 
     window = ti.ui.Window(title, (width, height), vsync=True)
     camera = ti.ui.Camera()  # Camera object for 3D view control

--- a/openwave/xperiments/level0_granule_medium/spacetime_vibration.py
+++ b/openwave/xperiments/level0_granule_medium/spacetime_vibration.py
@@ -168,26 +168,26 @@ def color_menu():
     """Render color selection menu."""
     global granule_type, ironbow
 
-    with render.gui.sub_window("COLOR MENU", 0.87, 0.75, 0.13, 0.12) as sub:
-        if sub.checkbox("Ironbow (displacement)", ironbow):
+    with render.gui.sub_window("COLOR MENU", 0.87, 0.76, 0.13, 0.12) as sub:
+        if sub.checkbox("Displacement (Ironbow)", ironbow):
             ironbow = True
             granule_type = False
-        if sub.checkbox("Granule Type Color", granule_type):
+        if sub.checkbox("Granule Type (Color)", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default Color", not (granule_type or ironbow)):
+        if sub.checkbox("Medium Default (Color)", not (granule_type or ironbow)):
             granule_type = False
             ironbow = False
 
     # Display ironbow gradient palette
     # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
     if ironbow == True:
-        with render.gui.sub_window("GRADIENT", 0.93, 0.61, 0.07, 0.13) as palette:
-            palette.text("@@@ - high", color=(1.0, 1.0, 0.96))  # yellow-white
+        with render.gui.sub_window("IRONBOW", 0.94, 0.64, 0.06, 0.12) as palette:
+            palette.text("@@@: high", color=(1.0, 1.0, 0.96))  # yellow-white
             palette.text("@@@", color=(0.90, 0.27, 0.09))  # red-orange
             palette.text("@@@", color=(0.57, 0.0, 0.61))  # magenta
             palette.text("@@@", color=(0.125, 0.0, 0.54))  # dark blue
-            palette.text("@@@ - Low", color=(0.0, 0.0, 0.04))  # black
+            # palette.text("@@@ - Low", color=(0.0, 0.0, 0.04))  # black
 
 
 # ================================================================

--- a/openwave/xperiments/level0_granule_medium/spherical_wave.py
+++ b/openwave/xperiments/level0_granule_medium/spherical_wave.py
@@ -147,26 +147,26 @@ def color_menu():
     """Render color selection menu."""
     global granule_type, ironbow
 
-    with render.gui.sub_window("COLOR MENU", 0.87, 0.75, 0.13, 0.12) as sub:
-        if sub.checkbox("Ironbow (displacement)", ironbow):
+    with render.gui.sub_window("COLOR MENU", 0.87, 0.76, 0.13, 0.12) as sub:
+        if sub.checkbox("Displacement (Ironbow)", ironbow):
             ironbow = True
             granule_type = False
-        if sub.checkbox("Granule Type Color", granule_type):
+        if sub.checkbox("Granule Type (Color)", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default Color", not (granule_type or ironbow)):
+        if sub.checkbox("Medium Default (Color)", not (granule_type or ironbow)):
             granule_type = False
             ironbow = False
 
     # Display ironbow gradient palette
     # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
     if ironbow == True:
-        with render.gui.sub_window("GRADIENT", 0.93, 0.61, 0.07, 0.13) as palette:
-            palette.text("@@@ - high", color=(1.0, 1.0, 0.96))  # yellow-white
+        with render.gui.sub_window("IRONBOW", 0.94, 0.64, 0.06, 0.12) as palette:
+            palette.text("@@@: high", color=(1.0, 1.0, 0.96))  # yellow-white
             palette.text("@@@", color=(0.90, 0.27, 0.09))  # red-orange
             palette.text("@@@", color=(0.57, 0.0, 0.61))  # magenta
             palette.text("@@@", color=(0.125, 0.0, 0.54))  # dark blue
-            palette.text("@@@ - Low", color=(0.0, 0.0, 0.04))  # black
+            # palette.text("@@@ - Low", color=(0.0, 0.0, 0.04))  # black
 
 
 # ================================================================

--- a/openwave/xperiments/level0_granule_medium/standing_wave.py
+++ b/openwave/xperiments/level0_granule_medium/standing_wave.py
@@ -160,26 +160,26 @@ def color_menu():
     """Render color selection menu."""
     global granule_type, ironbow
 
-    with render.gui.sub_window("COLOR MENU", 0.87, 0.75, 0.13, 0.12) as sub:
-        if sub.checkbox("Ironbow (displacement)", ironbow):
+    with render.gui.sub_window("COLOR MENU", 0.87, 0.76, 0.13, 0.12) as sub:
+        if sub.checkbox("Displacement (Ironbow)", ironbow):
             ironbow = True
             granule_type = False
-        if sub.checkbox("Granule Type Color", granule_type):
+        if sub.checkbox("Granule Type (Color)", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default Color", not (granule_type or ironbow)):
+        if sub.checkbox("Medium Default (Color)", not (granule_type or ironbow)):
             granule_type = False
             ironbow = False
 
     # Display ironbow gradient palette
     # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
     if ironbow == True:
-        with render.gui.sub_window("GRADIENT", 0.93, 0.61, 0.07, 0.13) as palette:
-            palette.text("@@@ - high", color=(1.0, 1.0, 0.96))  # yellow-white
+        with render.gui.sub_window("IRONBOW", 0.94, 0.65, 0.06, 0.11) as palette:
+            palette.text("@@@: high", color=(1.0, 1.0, 0.96))  # yellow-white
             palette.text("@@@", color=(0.90, 0.27, 0.09))  # red-orange
             palette.text("@@@", color=(0.57, 0.0, 0.61))  # magenta
             palette.text("@@@", color=(0.125, 0.0, 0.54))  # dark blue
-            palette.text("@@@ - Low", color=(0.0, 0.0, 0.04))  # black
+            # palette.text("@@@ - Low", color=(0.0, 0.0, 0.04))  # black
 
 
 # ================================================================

--- a/openwave/xperiments/level0_granule_medium/wave_interference.py
+++ b/openwave/xperiments/level0_granule_medium/wave_interference.py
@@ -163,26 +163,26 @@ def color_menu():
     """Render color selection menu."""
     global granule_type, ironbow
 
-    with render.gui.sub_window("COLOR MENU", 0.87, 0.75, 0.13, 0.12) as sub:
-        if sub.checkbox("Ironbow (displacement)", ironbow):
+    with render.gui.sub_window("COLOR MENU", 0.87, 0.76, 0.13, 0.12) as sub:
+        if sub.checkbox("Displacement (Ironbow)", ironbow):
             ironbow = True
             granule_type = False
-        if sub.checkbox("Granule Type Color", granule_type):
+        if sub.checkbox("Granule Type (Color)", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default Color", not (granule_type or ironbow)):
+        if sub.checkbox("Medium Default (Color)", not (granule_type or ironbow)):
             granule_type = False
             ironbow = False
 
     # Display ironbow gradient palette
     # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
     if ironbow == True:
-        with render.gui.sub_window("GRADIENT", 0.93, 0.61, 0.07, 0.13) as palette:
-            palette.text("@@@ - high", color=(1.0, 1.0, 0.96))  # yellow-white
+        with render.gui.sub_window("IRONBOW", 0.94, 0.64, 0.06, 0.12) as palette:
+            palette.text("@@@: high", color=(1.0, 1.0, 0.96))  # yellow-white
             palette.text("@@@", color=(0.90, 0.27, 0.09))  # red-orange
             palette.text("@@@", color=(0.57, 0.0, 0.61))  # magenta
             palette.text("@@@", color=(0.125, 0.0, 0.54))  # dark blue
-            palette.text("@@@ - Low", color=(0.0, 0.0, 0.04))  # black
+            # palette.text("@@@ - Low", color=(0.0, 0.0, 0.04))  # black
 
 
 # ================================================================

--- a/openwave/xperiments/level0_granule_medium/wave_pulse.py
+++ b/openwave/xperiments/level0_granule_medium/wave_pulse.py
@@ -147,26 +147,26 @@ def color_menu():
     """Render color selection menu."""
     global granule_type, ironbow
 
-    with render.gui.sub_window("COLOR MENU", 0.87, 0.75, 0.13, 0.12) as sub:
-        if sub.checkbox("Ironbow (displacement)", ironbow):
+    with render.gui.sub_window("COLOR MENU", 0.87, 0.76, 0.13, 0.12) as sub:
+        if sub.checkbox("Displacement (Ironbow)", ironbow):
             ironbow = True
             granule_type = False
-        if sub.checkbox("Granule Type Color", granule_type):
+        if sub.checkbox("Granule Type (Color)", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default Color", not (granule_type or ironbow)):
+        if sub.checkbox("Medium Default (Color)", not (granule_type or ironbow)):
             granule_type = False
             ironbow = False
 
     # Display ironbow gradient palette
     # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
     if ironbow == True:
-        with render.gui.sub_window("GRADIENT", 0.93, 0.61, 0.07, 0.13) as palette:
-            palette.text("@@@ - high", color=(1.0, 1.0, 0.96))  # yellow-white
+        with render.gui.sub_window("IRONBOW", 0.94, 0.64, 0.06, 0.12) as palette:
+            palette.text("@@@: high", color=(1.0, 1.0, 0.96))  # yellow-white
             palette.text("@@@", color=(0.90, 0.27, 0.09))  # red-orange
             palette.text("@@@", color=(0.57, 0.0, 0.61))  # magenta
             palette.text("@@@", color=(0.125, 0.0, 0.54))  # dark blue
-            palette.text("@@@ - Low", color=(0.0, 0.0, 0.04))  # black
+            # palette.text("@@@ - Low", color=(0.0, 0.0, 0.04))  # black
 
 
 # ================================================================

--- a/openwave/xperiments/level0_granule_medium/xwaves.py
+++ b/openwave/xperiments/level0_granule_medium/xwaves.py
@@ -168,26 +168,26 @@ def color_menu():
     """Render color selection menu."""
     global granule_type, ironbow
 
-    with render.gui.sub_window("COLOR MENU", 0.87, 0.75, 0.13, 0.12) as sub:
-        if sub.checkbox("Ironbow (displacement)", ironbow):
+    with render.gui.sub_window("COLOR MENU", 0.87, 0.76, 0.13, 0.12) as sub:
+        if sub.checkbox("Displacement (Ironbow)", ironbow):
             ironbow = True
             granule_type = False
-        if sub.checkbox("Granule Type Color", granule_type):
+        if sub.checkbox("Granule Type (Color)", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default Color", not (granule_type or ironbow)):
+        if sub.checkbox("Medium Default (Color)", not (granule_type or ironbow)):
             granule_type = False
             ironbow = False
 
     # Display ironbow gradient palette
     # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
     if ironbow == True:
-        with render.gui.sub_window("GRADIENT", 0.93, 0.61, 0.07, 0.13) as palette:
-            palette.text("@@@ - high", color=(1.0, 1.0, 0.96))  # yellow-white
+        with render.gui.sub_window("IRONBOW", 0.94, 0.64, 0.06, 0.12) as palette:
+            palette.text("@@@: high", color=(1.0, 1.0, 0.96))  # yellow-white
             palette.text("@@@", color=(0.90, 0.27, 0.09))  # red-orange
             palette.text("@@@", color=(0.57, 0.0, 0.61))  # magenta
             palette.text("@@@", color=(0.125, 0.0, 0.54))  # dark blue
-            palette.text("@@@ - Low", color=(0.0, 0.0, 0.04))  # black
+            # palette.text("@@@ - Low", color=(0.0, 0.0, 0.04))  # black
 
 
 # ================================================================

--- a/openwave/xperiments/level0_granule_medium/yin_yang.py
+++ b/openwave/xperiments/level0_granule_medium/yin_yang.py
@@ -162,26 +162,26 @@ def color_menu():
     """Render color selection menu."""
     global granule_type, ironbow
 
-    with render.gui.sub_window("COLOR MENU", 0.87, 0.75, 0.13, 0.12) as sub:
-        if sub.checkbox("Ironbow (displacement)", ironbow):
+    with render.gui.sub_window("COLOR MENU", 0.87, 0.76, 0.13, 0.12) as sub:
+        if sub.checkbox("Displacement (Ironbow)", ironbow):
             ironbow = True
             granule_type = False
-        if sub.checkbox("Granule Type Color", granule_type):
+        if sub.checkbox("Granule Type (Color)", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default Color", not (granule_type or ironbow)):
+        if sub.checkbox("Medium Default (Color)", not (granule_type or ironbow)):
             granule_type = False
             ironbow = False
 
     # Display ironbow gradient palette
     # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
     if ironbow == True:
-        with render.gui.sub_window("GRADIENT", 0.93, 0.61, 0.07, 0.13) as palette:
-            palette.text("@@@ - high", color=(1.0, 1.0, 0.96))  # yellow-white
+        with render.gui.sub_window("IRONBOW", 0.94, 0.64, 0.06, 0.12) as palette:
+            palette.text("@@@: high", color=(1.0, 1.0, 0.96))  # yellow-white
             palette.text("@@@", color=(0.90, 0.27, 0.09))  # red-orange
             palette.text("@@@", color=(0.57, 0.0, 0.61))  # magenta
             palette.text("@@@", color=(0.125, 0.0, 0.54))  # dark blue
-            palette.text("@@@ - Low", color=(0.0, 0.0, 0.04))  # black
+            # palette.text("@@@ - Low", color=(0.0, 0.0, 0.04))  # black
 
 
 # ================================================================


### PR DESCRIPTION
Updated color menu checkbox labels for clarity and consistency across all level0_granule_medium experiment modules. Adjusted sub-window positions and renamed the gradient palette window to 'IRONBOW', improving UI layout and labeling. Commented out the low-end black label in the ironbow palette for a cleaner display. Added a test resolution comment in render.py for easier UI testing.