### PR TITLE
Improve cross-platform compatibility for CLI and camera controls

### DIFF
--- a/openwave/_io/cli.py
+++ b/openwave/_io/cli.py
@@ -9,9 +9,15 @@ import argparse
 import os
 import sys
 import subprocess
+import platform
 from pathlib import Path
 
-from simple_term_menu import TerminalMenu
+# Conditional import for simple_term_menu (not available on Windows)
+try:
+    from simple_term_menu import TerminalMenu
+    HAS_INTERACTIVE_MENU = True
+except (ImportError, NotImplementedError):
+    HAS_INTERACTIVE_MENU = False
 
 
 def get_experiments_list():
@@ -207,6 +213,7 @@ def show_menu_simple(experiments):
 def show_menu_interactive(experiments):
     """
     Display an interactive menu using arrow keys for Xperiment selection.
+    Only available on Unix-like systems (Linux, macOS).
 
     Args:
         experiments: List of tuples containing (display_name, file_path)
@@ -214,6 +221,10 @@ def show_menu_interactive(experiments):
     Returns:
         str: Path to the selected xperiment file
     """
+    if not HAS_INTERACTIVE_MENU:
+        # Fallback to simple menu if interactive menu not available
+        return show_menu_simple(experiments)
+
     # Build menu with collection headers marked as non-selectable
     menu_options = []
     file_path_map = {}  # Maps option index to file path

--- a/openwave/_io/render.py
+++ b/openwave/_io/render.py
@@ -137,8 +137,12 @@ def handle_camera():
     # Handle mouse input for orbiting
     mouse_pos = window.get_cursor_pos()
 
-    # Check for right mouse button drag
-    if window.is_pressed(ti.ui.RMB):
+    # Check for orbit controls: right-click drag OR shift+left-click drag (for trackpads)
+    is_orbiting = window.is_pressed(ti.ui.RMB) or (
+        window.is_pressed(ti.ui.LMB) and window.is_pressed(ti.ui.SHIFT)
+    )
+
+    if is_orbiting:
         if last_mouse_pos is not None:
             # Calculate mouse delta
             dx = mouse_pos[0] - last_mouse_pos[0]
@@ -205,7 +209,7 @@ def cam_instructions():
     """Overlay camera movement instructions."""
     global cam_x, cam_y, cam_z
     with gui.sub_window("CAMERA MOVEMENT", 0.87, 0.88, 0.13, 0.12) as sub:
-        sub.text("Orbit: right-click + drag")
+        sub.text("Orbit: RMB or Shift+LMB")
         sub.text("Zoom: Q/Z keys")
         sub.text("Pan: Arrow keys")
         sub.text("Cam Pos: %.2f, %.2f, %.2f" % (cam_x, cam_y, cam_z), color=config.LIGHT_BLUE[1])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "matplotlib>=3.8,<4.0",
   "taichi>=1.6,<2.0",
   "pyautogui>=0.9,<1.0",
-  "simple-term-menu>=1.6.0,<2.0"
+  "simple-term-menu>=1.6.0,<2.0; sys_platform != 'win32'"
 ]
 
 [project.scripts]


### PR DESCRIPTION
Added conditional import for simple_term_menu to support Windows in CLI, with fallback to a simple menu if interactive menu is unavailable. Updated camera orbit controls to support both right-click drag and shift+left-click drag for trackpad users, and clarified instructions. Adjusted pyproject.toml to exclude simple-term-menu dependency on Windows.