### PR TITLE
refactor time variable and minor updates

### DIFF
--- a/openwave/spacetime/wave_engine_level0.py
+++ b/openwave/spacetime/wave_engine_level0.py
@@ -38,7 +38,7 @@ avg_amplitude_am = None  # RMS amplitude for energy calculation (peak * 0.707)
 
 
 # ================================================================
-# Energy-Wave Source Kernel (energy injection, harmonic oscillation, rhythm)
+# Energy-Wave Source Kernel (energy charge, harmonic oscillation, rhythm)
 # ================================================================
 
 
@@ -123,11 +123,11 @@ def oscillate_granules(
     velocity_am: ti.template(),  # type: ignore
     granule_var_color: ti.template(),  # type: ignore
     num_sources: ti.i32,  # type: ignore
-    t: ti.f32,  # type: ignore
+    elapsed_t: ti.f32,  # type: ignore
     freq_boost: ti.f32,  # type: ignore
     amp_boost: ti.f32,  # type: ignore
 ):
-    """Injects energy into all granules from multiple wave sources using wave superposition.
+    """Charges energy into all granules from multiple wave sources using wave superposition.
 
     Each granule receives wave contributions from all active wave sources. Waves are summed
     (superposed) to create interference patterns - constructive where waves align in phase,
@@ -187,7 +187,7 @@ def oscillate_granules(
         velocity_am: Velocity field for all granules (modified in-place, in attometers/second)
         granule_var_color: Color field for IRONBOW displacement visualization
         num_sources: Number of wave sources
-        t: Current simulation time (accumulated, seconds)
+        elapsed_t: Current simulation time (accumulated, seconds)
         freq_boost: Frequency multiplier (applied after slow_mo)
         amp_boost: Amplitude multiplier (for visibility in scaled lattices)
     """
@@ -247,13 +247,13 @@ def oscillate_granules(
             # MAIN EQUATION OF MOTION
             # Wave displacement from this source: A(r)·cos(ωt + φ)·direction
             source_displacement_am_magnitude = amplitude_am_at_r_cap * ti.cos(
-                omega * t + total_phase
+                omega * elapsed_t + total_phase
             )
             source_displacement_am = source_displacement_am_magnitude * direction
 
             # Wave velocity from this source: -A(r)·ω·sin(ωt + φ)·direction
             velocity_am_magnitude = (
-                -amplitude_am_at_r_cap * omega * ti.sin(omega * t + total_phase)
+                -amplitude_am_at_r_cap * omega * ti.sin(omega * elapsed_t + total_phase)
             )
             source_velocity_am = velocity_am_magnitude * direction
 

--- a/openwave/xperiments/level0_granule_based/_docs/spherical_wave.md
+++ b/openwave/xperiments/level0_granule_based/_docs/spherical_wave.md
@@ -141,7 +141,7 @@ During implementation testing, granules at distances less than 1λ from the wave
 The observed instability reveals important physics about what happens near the wave source (r < λ):
 
 1. **Source Region Physics** (r < λ):
-   - This is the source region where energy is being injected
+   - This is the source region where energy is being Charged
    - Wave structure is not yet fully formed
    - Near-field effects dominate over far-field radiation
    - Simple 1/r amplitude falloff does not apply

--- a/openwave/xperiments/level0_granule_based/spacetime_vibration.py
+++ b/openwave/xperiments/level0_granule_based/spacetime_vibration.py
@@ -136,11 +136,11 @@ def data_dashboard():
 
         sub.text("\n--- TIME MICROSCOPE ---", color=config.LIGHT_BLUE[1])
         slowed_mo = config.SLOW_MO / freq_boost
-        fps = 0 if t == 0 else frame / t
+        fps = 0 if elapsed_t == 0 else frame / elapsed_t
         sub.text(f"Frames Rendered: {frame}")
-        sub.text(f"Real Time: {t / slowed_mo:.2e}s ({fps * slowed_mo:.0e} FPS)")
+        sub.text(f"Real Time: {elapsed_t / slowed_mo:.2e}s ({fps * slowed_mo:.0e} FPS)")
         sub.text(f"(1 real second = {slowed_mo / (60*60*24*365):.0e}y of sim time)")
-        sub.text(f"Sim Time (slow-mo): {t:.2f}s ({fps:.0f} FPS)")
+        sub.text(f"Sim Time (slow-mo): {elapsed_t:.2f}s ({fps:.0f} FPS)")
 
 
 def controls():
@@ -225,7 +225,7 @@ def render_xperiment(lattice):
     global radius_factor, freq_boost, amp_boost, paused
     global granule_type, ironbow
     global normalized_position
-    global t, frame
+    global elapsed_t, frame
 
     # Initialize variables
     show_axis = False  # Toggle to show/hide axis lines
@@ -240,7 +240,7 @@ def render_xperiment(lattice):
     palette_vertices, palette_colors = config.get_ironbow_palette()  # Prep ironbow palette
 
     # Time tracking for radial harmonic oscillation of all granules
-    t = 0.0
+    elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics
 
@@ -274,7 +274,7 @@ def render_xperiment(lattice):
             current_time = time.time()
             dt_real = current_time - last_time
             last_time = current_time
-            t += dt_real  # Use real elapsed time instead of fixed DT
+            elapsed_t += dt_real  # Use real elapsed time instead of fixed DT
 
             # Apply radial harmonic oscillation to all granules from multiple wave sources
             # Each granule receives wave contributions from all active sources
@@ -285,7 +285,7 @@ def render_xperiment(lattice):
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
                 NUM_SOURCES,  # Number of active wave sources
-                t,
+                elapsed_t,
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
             )
@@ -301,7 +301,7 @@ def render_xperiment(lattice):
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:
                 diagnostics.print_wave_diagnostics(
-                    t,
+                    elapsed_t,
                     frame,
                     print_interval=100,  # Print every 100 frames
                 )

--- a/openwave/xperiments/level0_granule_based/spherical_wave.py
+++ b/openwave/xperiments/level0_granule_based/spherical_wave.py
@@ -115,11 +115,11 @@ def data_dashboard():
 
         sub.text("\n--- TIME MICROSCOPE ---", color=config.LIGHT_BLUE[1])
         slowed_mo = config.SLOW_MO / freq_boost
-        fps = 0 if t == 0 else frame / t
+        fps = 0 if elapsed_t == 0 else frame / elapsed_t
         sub.text(f"Frames Rendered: {frame}")
-        sub.text(f"Real Time: {t / slowed_mo:.2e}s ({fps * slowed_mo:.0e} FPS)")
+        sub.text(f"Real Time: {elapsed_t / slowed_mo:.2e}s ({fps * slowed_mo:.0e} FPS)")
         sub.text(f"(1 real second = {slowed_mo / (60*60*24*365):.0e}y of sim time)")
-        sub.text(f"Sim Time (slow-mo): {t:.2f}s ({fps:.0f} FPS)")
+        sub.text(f"Sim Time (slow-mo): {elapsed_t:.2f}s ({fps:.0f} FPS)")
 
 
 def controls():
@@ -204,7 +204,7 @@ def render_xperiment(lattice):
     global radius_factor, freq_boost, amp_boost, paused
     global granule_type, ironbow
     global normalized_position
-    global t, frame
+    global elapsed_t, frame
 
     # Initialize variables
     show_axis = True  # Toggle to show/hide axis lines
@@ -219,7 +219,7 @@ def render_xperiment(lattice):
     palette_vertices, palette_colors = config.get_ironbow_palette()  # Prep ironbow palette
 
     # Time tracking for radial harmonic oscillation of all granules
-    t = 0.0
+    elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics
 
@@ -253,7 +253,7 @@ def render_xperiment(lattice):
             current_time = time.time()
             dt_real = current_time - last_time
             last_time = current_time
-            t += dt_real  # Use real elapsed time instead of fixed DT
+            elapsed_t += dt_real  # Use real elapsed time instead of fixed DT
 
             # Apply radial harmonic oscillation to all granules from multiple wave sources
             # Each granule receives wave contributions from all active sources
@@ -264,7 +264,7 @@ def render_xperiment(lattice):
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
                 NUM_SOURCES,  # Number of active wave sources
-                t,
+                elapsed_t,
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
             )
@@ -280,7 +280,7 @@ def render_xperiment(lattice):
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:
                 diagnostics.print_wave_diagnostics(
-                    t,
+                    elapsed_t,
                     frame,
                     print_interval=100,  # Print every 100 frames
                 )

--- a/openwave/xperiments/level0_granule_based/standing_wave.py
+++ b/openwave/xperiments/level0_granule_based/standing_wave.py
@@ -128,11 +128,11 @@ def data_dashboard():
 
         sub.text("\n--- TIME MICROSCOPE ---", color=config.LIGHT_BLUE[1])
         slowed_mo = config.SLOW_MO / freq_boost
-        fps = 0 if t == 0 else frame / t
+        fps = 0 if elapsed_t == 0 else frame / elapsed_t
         sub.text(f"Frames Rendered: {frame}")
-        sub.text(f"Real Time: {t / slowed_mo:.2e}s ({fps * slowed_mo:.0e} FPS)")
+        sub.text(f"Real Time: {elapsed_t / slowed_mo:.2e}s ({fps * slowed_mo:.0e} FPS)")
         sub.text(f"(1 real second = {slowed_mo / (60*60*24*365):.0e}y of sim time)")
-        sub.text(f"Sim Time (slow-mo): {t:.2f}s ({fps:.0f} FPS)")
+        sub.text(f"Sim Time (slow-mo): {elapsed_t:.2f}s ({fps:.0f} FPS)")
 
 
 def controls():
@@ -217,7 +217,7 @@ def render_xperiment(lattice):
     global radius_factor, freq_boost, amp_boost, paused
     global granule_type, ironbow
     global normalized_position
-    global t, frame
+    global elapsed_t, frame
 
     # Initialize variables
     show_axis = False  # Toggle to show/hide axis lines
@@ -232,7 +232,7 @@ def render_xperiment(lattice):
     palette_vertices, palette_colors = config.get_ironbow_palette()  # Prep ironbow palette
 
     # Time tracking for radial harmonic oscillation of all granules
-    t = 0.0
+    elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics
 
@@ -266,7 +266,7 @@ def render_xperiment(lattice):
             current_time = time.time()
             dt_real = current_time - last_time
             last_time = current_time
-            t += dt_real  # Use real elapsed time instead of fixed DT
+            elapsed_t += dt_real  # Use real elapsed time instead of fixed DT
 
             # Apply radial harmonic oscillation to all granules from multiple wave sources
             # Each granule receives wave contributions from all active sources
@@ -277,7 +277,7 @@ def render_xperiment(lattice):
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
                 NUM_SOURCES,  # Number of active wave sources
-                t,
+                elapsed_t,
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
             )
@@ -293,7 +293,7 @@ def render_xperiment(lattice):
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:
                 diagnostics.print_wave_diagnostics(
-                    t,
+                    elapsed_t,
                     frame,
                     print_interval=100,  # Print every 100 frames
                 )

--- a/openwave/xperiments/level0_granule_based/wave_interference.py
+++ b/openwave/xperiments/level0_granule_based/wave_interference.py
@@ -131,11 +131,11 @@ def data_dashboard():
 
         sub.text("\n--- TIME MICROSCOPE ---", color=config.LIGHT_BLUE[1])
         slowed_mo = config.SLOW_MO / freq_boost
-        fps = 0 if t == 0 else frame / t
+        fps = 0 if elapsed_t == 0 else frame / elapsed_t
         sub.text(f"Frames Rendered: {frame}")
-        sub.text(f"Real Time: {t / slowed_mo:.2e}s ({fps * slowed_mo:.0e} FPS)")
+        sub.text(f"Real Time: {elapsed_t / slowed_mo:.2e}s ({fps * slowed_mo:.0e} FPS)")
         sub.text(f"(1 real second = {slowed_mo / (60*60*24*365):.0e}y of sim time)")
-        sub.text(f"Sim Time (slow-mo): {t:.2f}s ({fps:.0f} FPS)")
+        sub.text(f"Sim Time (slow-mo): {elapsed_t:.2f}s ({fps:.0f} FPS)")
 
 
 def controls():
@@ -220,7 +220,7 @@ def render_xperiment(lattice):
     global radius_factor, freq_boost, amp_boost, paused
     global granule_type, ironbow
     global normalized_position
-    global t, frame
+    global elapsed_t, frame
 
     # Initialize variables
     show_axis = False  # Toggle to show/hide axis lines
@@ -235,7 +235,7 @@ def render_xperiment(lattice):
     palette_vertices, palette_colors = config.get_ironbow_palette()  # Prep ironbow palette
 
     # Time tracking for radial harmonic oscillation of all granules
-    t = 0.0
+    elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics
 
@@ -269,7 +269,7 @@ def render_xperiment(lattice):
             current_time = time.time()
             dt_real = current_time - last_time
             last_time = current_time
-            t += dt_real  # Use real elapsed time instead of fixed DT
+            elapsed_t += dt_real  # Use real elapsed time instead of fixed DT
 
             # Apply radial harmonic oscillation to all granules from multiple wave sources
             # Each granule receives wave contributions from all active sources
@@ -280,7 +280,7 @@ def render_xperiment(lattice):
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
                 NUM_SOURCES,  # Number of active wave sources
-                t,
+                elapsed_t,
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
             )
@@ -296,7 +296,7 @@ def render_xperiment(lattice):
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:
                 diagnostics.print_wave_diagnostics(
-                    t,
+                    elapsed_t,
                     frame,
                     print_interval=100,  # Print every 100 frames
                 )

--- a/openwave/xperiments/level0_granule_based/wave_pulse.py
+++ b/openwave/xperiments/level0_granule_based/wave_pulse.py
@@ -115,11 +115,11 @@ def data_dashboard():
 
         sub.text("\n--- TIME MICROSCOPE ---", color=config.LIGHT_BLUE[1])
         slowed_mo = config.SLOW_MO / freq_boost
-        fps = 0 if t == 0 else frame / t
+        fps = 0 if elapsed_t == 0 else frame / elapsed_t
         sub.text(f"Frames Rendered: {frame}")
-        sub.text(f"Real Time: {t / slowed_mo:.2e}s ({fps * slowed_mo:.0e} FPS)")
+        sub.text(f"Real Time: {elapsed_t / slowed_mo:.2e}s ({fps * slowed_mo:.0e} FPS)")
         sub.text(f"(1 real second = {slowed_mo / (60*60*24*365):.0e}y of sim time)")
-        sub.text(f"Sim Time (slow-mo): {t:.2f}s ({fps:.0f} FPS)")
+        sub.text(f"Sim Time (slow-mo): {elapsed_t:.2f}s ({fps:.0f} FPS)")
 
 
 def controls():
@@ -204,7 +204,7 @@ def render_xperiment(lattice):
     global radius_factor, freq_boost, amp_boost, paused
     global granule_type, ironbow
     global normalized_position
-    global t, frame
+    global elapsed_t, frame
 
     # Initialize variables
     show_axis = True  # Toggle to show/hide axis lines
@@ -219,7 +219,7 @@ def render_xperiment(lattice):
     palette_vertices, palette_colors = config.get_ironbow_palette()  # Prep ironbow palette
 
     # Time tracking for radial harmonic oscillation of all granules
-    t = 0.0
+    elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics
 
@@ -253,7 +253,7 @@ def render_xperiment(lattice):
             current_time = time.time()
             dt_real = current_time - last_time
             last_time = current_time
-            t += dt_real  # Use real elapsed time instead of fixed DT
+            elapsed_t += dt_real  # Use real elapsed time instead of fixed DT
 
             # Apply radial harmonic oscillation to all granules from multiple wave sources
             # Each granule receives wave contributions from all active sources
@@ -264,7 +264,7 @@ def render_xperiment(lattice):
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
                 NUM_SOURCES,  # Number of active wave sources
-                t,
+                elapsed_t,
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
             )
@@ -280,7 +280,7 @@ def render_xperiment(lattice):
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:
                 diagnostics.print_wave_diagnostics(
-                    t,
+                    elapsed_t,
                     frame,
                     print_interval=100,  # Print every 100 frames
                 )

--- a/openwave/xperiments/level0_granule_based/xwaves.py
+++ b/openwave/xperiments/level0_granule_based/xwaves.py
@@ -136,11 +136,11 @@ def data_dashboard():
 
         sub.text("\n--- TIME MICROSCOPE ---", color=config.LIGHT_BLUE[1])
         slowed_mo = config.SLOW_MO / freq_boost
-        fps = 0 if t == 0 else frame / t
+        fps = 0 if elapsed_t == 0 else frame / elapsed_t
         sub.text(f"Frames Rendered: {frame}")
-        sub.text(f"Real Time: {t / slowed_mo:.2e}s ({fps * slowed_mo:.0e} FPS)")
+        sub.text(f"Real Time: {elapsed_t / slowed_mo:.2e}s ({fps * slowed_mo:.0e} FPS)")
         sub.text(f"(1 real second = {slowed_mo / (60*60*24*365):.0e}y of sim time)")
-        sub.text(f"Sim Time (slow-mo): {t:.2f}s ({fps:.0f} FPS)")
+        sub.text(f"Sim Time (slow-mo): {elapsed_t:.2f}s ({fps:.0f} FPS)")
 
 
 def controls():
@@ -225,7 +225,7 @@ def render_xperiment(lattice):
     global radius_factor, freq_boost, amp_boost, paused
     global granule_type, ironbow
     global normalized_position
-    global t, frame
+    global elapsed_t, frame
 
     # Initialize variables
     show_axis = False  # Toggle to show/hide axis lines
@@ -240,7 +240,7 @@ def render_xperiment(lattice):
     palette_vertices, palette_colors = config.get_ironbow_palette()  # Prep ironbow palette
 
     # Time tracking for radial harmonic oscillation of all granules
-    t = 0.0
+    elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics
 
@@ -274,7 +274,7 @@ def render_xperiment(lattice):
             current_time = time.time()
             dt_real = current_time - last_time
             last_time = current_time
-            t += dt_real  # Use real elapsed time instead of fixed DT
+            elapsed_t += dt_real  # Use real elapsed time instead of fixed DT
 
             # Apply radial harmonic oscillation to all granules from multiple wave sources
             # Each granule receives wave contributions from all active sources
@@ -285,7 +285,7 @@ def render_xperiment(lattice):
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
                 NUM_SOURCES,  # Number of active wave sources
-                t,
+                elapsed_t,
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
             )
@@ -301,7 +301,7 @@ def render_xperiment(lattice):
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:
                 diagnostics.print_wave_diagnostics(
-                    t,
+                    elapsed_t,
                     frame,
                     print_interval=100,  # Print every 100 frames
                 )

--- a/openwave/xperiments/level0_granule_based/yin_yang.py
+++ b/openwave/xperiments/level0_granule_based/yin_yang.py
@@ -130,11 +130,11 @@ def data_dashboard():
 
         sub.text("\n--- TIME MICROSCOPE ---", color=config.LIGHT_BLUE[1])
         slowed_mo = config.SLOW_MO / freq_boost
-        fps = 0 if t == 0 else frame / t
+        fps = 0 if elapsed_t == 0 else frame / elapsed_t
         sub.text(f"Frames Rendered: {frame}")
-        sub.text(f"Real Time: {t / slowed_mo:.2e}s ({fps * slowed_mo:.0e} FPS)")
+        sub.text(f"Real Time: {elapsed_t / slowed_mo:.2e}s ({fps * slowed_mo:.0e} FPS)")
         sub.text(f"(1 real second = {slowed_mo / (60*60*24*365):.0e}y of sim time)")
-        sub.text(f"Sim Time (slow-mo): {t:.2f}s ({fps:.0f} FPS)")
+        sub.text(f"Sim Time (slow-mo): {elapsed_t:.2f}s ({fps:.0f} FPS)")
 
 
 def controls():
@@ -219,7 +219,7 @@ def render_xperiment(lattice):
     global radius_factor, freq_boost, amp_boost, paused
     global granule_type, ironbow
     global normalized_position
-    global t, frame
+    global elapsed_t, frame
 
     # Initialize variables
     show_axis = False  # Toggle to show/hide axis lines
@@ -234,7 +234,7 @@ def render_xperiment(lattice):
     palette_vertices, palette_colors = config.get_ironbow_palette()  # Prep ironbow palette
 
     # Time tracking for radial harmonic oscillation of all granules
-    t = 0.0
+    elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics
 
@@ -268,7 +268,7 @@ def render_xperiment(lattice):
             current_time = time.time()
             dt_real = current_time - last_time
             last_time = current_time
-            t += dt_real  # Use real elapsed time instead of fixed DT
+            elapsed_t += dt_real  # Use real elapsed time instead of fixed DT
 
             # Apply radial harmonic oscillation to all granules from multiple wave sources
             # Each granule receives wave contributions from all active sources
@@ -279,7 +279,7 @@ def render_xperiment(lattice):
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
                 NUM_SOURCES,  # Number of active wave sources
-                t,
+                elapsed_t,
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
             )
@@ -295,7 +295,7 @@ def render_xperiment(lattice):
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:
                 diagnostics.print_wave_diagnostics(
-                    t,
+                    elapsed_t,
                     frame,
                     print_interval=100,  # Print every 100 frames
                 )

--- a/openwave/xperiments/level1_field_based/_docs/00_LEVEL1_PLAN.md
+++ b/openwave/xperiments/level1_field_based/_docs/00_LEVEL1_PLAN.md
@@ -61,7 +61,7 @@ This document provides a high-level overview of LEVEL-1 field-based simulation a
 - No true wave source
 - Continuous wave source with propagation by phase shift
 - Reflection by another "source"
-- Cannot model: energy injected once, conserved propagation
+- Cannot model: energy Charged once, conserved propagation
 
 **LEVEL-1 Solution**: True wave propagation with energy conservation
 
@@ -99,14 +99,14 @@ This document provides a high-level overview of LEVEL-1 field-based simulation a
 
 ## Main Questions for LEVEL-1
 
-### Energy Injection
+### Energy Charging
 
-**Question**: How to inject initial energy into field?
+**Question**: How to Charge initial energy into field?
 
 **Approaches**:
 
 - Point source initialization
-- Plane wave injection
+- Plane wave Charge
 - Multiple source superposition
 - Pulse vs continuous sources
 

--- a/openwave/xperiments/level1_field_based/_docs/00_LEVEL1_PLAN.md
+++ b/openwave/xperiments/level1_field_based/_docs/00_LEVEL1_PLAN.md
@@ -251,12 +251,14 @@ This document provides a high-level overview of LEVEL-1 field-based simulation a
 
 For implementation details, see:
 
-1. **[01_WAVE_FIELD.md](./01_WAVE_FIELD.md)** - Grid structure, voxels, indices, positioning
-2. **[02_WAVE_PROPERTIES.md](./02_WAVE_PROPERTIES.md)** - Scalar/vector properties, storage
-3. **[03_WAVE_ENGINE.md](./03_WAVE_ENGINE.md)** - Wave propagation, PDEs, interference, reflection
-4. **[05_MATTER.md](./05_MATTER.md)** - Wave centers, MAP, particle dynamics
-5. **[04_VISUALIZATION.md](./04_VISUALIZATION.md)** - Rendering techniques for fields and particles
-6. **[06_FORCE_MOTION.md](./06_FORCE_MOTION.md)** - How forces emerge from waves
+1. **[01_WAVE_FIELD.md](./01_WAVE_FIELD.md)** - Cell-centered grid architecture with position mapping
+2. **[02_WAVE_PROPERTIES.md](./02_WAVE_PROPERTIES.md)** - Scalar/vector properties and energy oscillation physics
+3. **[03_WAVE_ENGINE.md](./03_WAVE_ENGINE.md)** - Energy injection, propagation, and wave mechanics
+4. **[04_VISUALIZATION.md](./04_VISUALIZATION.md)** - Taichi rendering methods for waves and particles
+5. **[05_MATTER.md](./05_MATTER.md)** - Particle structure and wave centers
+6. **[06_FORCE_MOTION.md](./06_FORCE_MOTION.md)** - MAP principle and particle dynamics
+7. **[07_PHOTON_HEAT.md](./07_PHOTON_HEAT.md)** - Light and thermal behavior
+8. **[08_NUMERICAL_ANALYSIS.md](./08_NUMERICAL_ANALYSIS.md)** - Computational methods
 
 ### Supporting Research Documentation
 

--- a/openwave/xperiments/level1_field_based/_docs/02_WAVE_PROPERTIES.md
+++ b/openwave/xperiments/level1_field_based/_docs/02_WAVE_PROPERTIES.md
@@ -292,10 +292,10 @@ Key wave equation relationships:
 
 ```python
 # Wave equation fundamentals
-f = c / wavelength              # Frequency from speed and wavelength
-omega = 2 * pi * f              # Angular frequency
-k = 2 * pi / wavelength         # Wave number
-xi = 1 / wavelength             # Spatial frequency
+f = c / λ              # Frequency from speed and wavelength
+ω = 2 * pi * f         # Angular frequency
+k = 2 * pi / λ         # Wave number
+xi = 1 / λ             # Spatial frequency
 
 # Energy relationships
 E_total = E_kinetic + E_potential   # Total energy (conserved)

--- a/openwave/xperiments/level1_field_based/_docs/02_WAVE_PROPERTIES.md
+++ b/openwave/xperiments/level1_field_based/_docs/02_WAVE_PROPERTIES.md
@@ -29,7 +29,7 @@ Wave field attributes represent physical quantities and wave disturbances stored
 ### Wave Medium
 
 - MEDIUM-DENSITY (ρ): propagates momentum, carries energy, defines wave-speed
-- WAVE-SOURCE: defines frequency, rhythm, vibration and injects energy
+- WAVE-SOURCE: defines frequency, rhythm, vibration and charges energy
 
 ### Wave Form
 

--- a/openwave/xperiments/level1_field_based/_docs/03_WAVE_ENGINE.md
+++ b/openwave/xperiments/level1_field_based/_docs/03_WAVE_ENGINE.md
@@ -23,6 +23,7 @@
    - [Standing Waves](#standing-waves)
    - [Traveling Waves](#traveling-waves)
    - [Multi-Frequency Superposition](#multi-frequency-superposition)
+   - [Source Characteristics and Frequency Propagation](#source-characteristics-and-frequency-propagation)
 1. [Computational Implementation](#computational-implementation)
    - [Wave Sources](#wave-sources)
    - [Interference Calculations](#interference-calculations)
@@ -511,6 +512,78 @@ Nodes at: `x = nλ/2` (n = 0, 1, 2, ...)
 **Beat Frequency**:
 
 When two close frequencies interfere: `f_beat = |f₁ - f₂|`
+
+### Source Characteristics and Frequency Propagation
+
+**Wave Sources**:
+
+- Energy Charging points in the field
+- Each source has specific frequency
+- Sources can be:
+  - External (initial conditions)
+  - Particles (wave reflection = re-emission)
+  - Electrons (EM wave generation)
+
+**Frequency of Source**:
+
+- Determines wavelength: λ = c/f
+- Determines energy density: E ∝ f
+- Propagates with wave: frequency is carried property
+
+**Frequency as Field Property**:
+
+- Each point in field can have associated frequency
+- Frequency propagates with wave amplitude
+- Multiple frequencies can coexist (superposition)
+
+**Multi-Frequency Fields**:
+
+```python
+# Optional: store frequency per voxel
+frequency = ti.field(dtype=ti.f32, shape=(nx, ny, nz))
+
+# When wave propagates, frequency propagates too
+@ti.kernel
+def propagate_frequency():
+    for i, j, k in frequency:
+        # Frequency advects with wave direction
+        # Similar to amplitude propagation
+```
+
+**Frequency Mixing**:
+
+- Different sources → different frequencies
+- Frequencies combine at each point
+- Interference patterns depend on frequency
+- Beat frequencies emerge naturally
+
+**Multiple Source Interference**:
+
+- Waves from multiple sources add linearly
+- Each source contributes its amplitude and frequency
+- Total field = sum of all source contributions
+
+**Complex Patterns**:
+
+- Standing waves from interference
+- Beat patterns from close frequencies
+- Constructive/destructive interference regions
+- Forces emerge from combined amplitude gradients
+
+**Example - Two Sources**:
+
+```python
+# Source 1: frequency f1, position r1
+# Source 2: frequency f2, position r2
+
+amplitude_total[x,y,z] = (
+    A1 * sin(k1*|r-r1| - ω1*t) +
+    A2 * sin(k2*|r-r2| - ω2*t)
+)
+
+# If f1 ≈ f2: beat patterns
+# If f1 = f2: standing waves (constructive/destructive)
+```
 
 ## Computational Implementation
 

--- a/openwave/xperiments/level1_field_based/_docs/03_WAVE_ENGINE.md
+++ b/openwave/xperiments/level1_field_based/_docs/03_WAVE_ENGINE.md
@@ -3,9 +3,9 @@
 ## Table of Contents
 
 1. [Overview](#overview)
-1. [Energy Wave Injection](#energy-wave-injection)
+1. [Energy Wave Inital Charge](#energy-wave-initial-charge)
    - [Initial Energy Requirement](#initial-energy-requirement)
-   - [Injection Methods](#injection-methods)
+   - [Charging Methods](#charging-methods)
    - [Stabilization Phase](#stabilization-phase)
    - [Wave Evolution](#wave-evolution)
 1. [Wave Propagation Engine](#wave-propagation-engine)
@@ -37,17 +37,17 @@ The **Wave Engine** is the core computational system that propagates wave distur
 
 **Key Principle**: Waves propagate through the grid by transferring amplitude, phase, and energy to neighboring voxels according to wave equations and Huygens' principle.
 
-## Energy Wave Injection
+## Energy Wave Initial Charge
 
 ### Initial Energy Requirement
 
-Before wave propagation, reflection, interference, and all subsequent dynamics can occur, **energy must be injected** into the simulation domain. This initial energy establishes the wave field that will then evolve according to the wave equations.
+Before wave propagation, reflection, interference, and all subsequent dynamics can occur, **energy must be charged** into the simulation domain. This initial energy establishes the wave field that will then evolve according to the wave equations.
 
 **Energy Equation Constraint**:
 
-- Total energy injected must match the **energy equation value** defined in `equations.py`
+- Total energy charged must match the **energy equation value** defined in `equations.py`
 - Energy density must be appropriate for the simulation domain volume
-- Energy is conserved throughout simulation after injection
+- Energy is conserved throughout simulation after initial charge
 
 **Formula**:
 
@@ -61,22 +61,22 @@ energy_density = <from EWT equations>  # Energy per cubic meter
 E_total_required = energy_density * (nx * ny * nz * dx**3)
 ```
 
-**Critical Requirement**: The amount of energy injected determines:
+**Critical Requirement**: The amount of energy charged determines:
 
 - Wave amplitude levels
 - Force magnitudes (F = -∇A)
 - Particle dynamics
 - Realistic physics behavior
 
-### Injection Methods
+### Charging Methods
 
-**1. Point Source Injection**:
+**1. Point Source Charge**:
 
 ```python
 @ti.kernel
-def inject_point_source(pos_x: ti.i32, pos_y: ti.i32, pos_z: ti.i32,
+def charge_point_source(pos_x: ti.i32, pos_y: ti.i32, pos_z: ti.i32,
                         energy: ti.f32, frequency: ti.f32):
-    """Inject energy at a single point with specific frequency."""
+    """Charge energy at a single point with specific frequency."""
     # Initialize amplitude at source point
     omega = 2.0 * pi * frequency
     amplitude[pos_x, pos_y, pos_z] = compute_amplitude_from_energy(energy)
@@ -88,12 +88,12 @@ def inject_point_source(pos_x: ti.i32, pos_y: ti.i32, pos_z: ti.i32,
     wave_direction[pos_x, pos_y, pos_z] = ti.Vector([0.0, 0.0, 0.0])  # Will be set by propagation
 ```
 
-**2. Plane Wave Injection**:
+**2. Plane Wave Charge**:
 
 ```python
 @ti.kernel
-def inject_plane_wave(direction: ti.math.vec3, energy: ti.f32, wavelength: ti.f32):
-    """Inject uniform plane wave across domain."""
+def charge_plane_wave(direction: ti.math.vec3, energy: ti.f32, wavelength: ti.f32):
+    """Charge uniform plane wave across domain."""
     k = 2.0 * pi / wavelength  # Wave number
 
     for i, j, k_idx in amplitude:
@@ -105,12 +105,12 @@ def inject_plane_wave(direction: ti.math.vec3, energy: ti.f32, wavelength: ti.f3
         wave_direction[i, j, k_idx] = direction.normalized()
 ```
 
-**3. Spherical Wave Injection**:
+**3. Spherical Wave Charge**:
 
 ```python
 @ti.kernel
-def inject_spherical_wave(center: ti.math.vec3, energy: ti.f32, wavelength: ti.f32):
-    """Inject spherical wave from center point."""
+def charge_spherical_wave(center: ti.math.vec3, energy: ti.f32, wavelength: ti.f32):
+    """Charge spherical wave from center point."""
     k = 2.0 * pi / wavelength
 
     for i, j, k_idx in amplitude:
@@ -124,23 +124,23 @@ def inject_spherical_wave(center: ti.math.vec3, energy: ti.f32, wavelength: ti.f
             wave_direction[i, j, k_idx] = r_vec.normalized()  # Radial
 ```
 
-**4. Multiple Source Injection**:
+**4. Multiple Source Charge**:
 
 ```python
-# Inject energy from multiple points
+# Charge energy from multiple points
 for source in source_positions:
-    inject_point_source(source.x, source.y, source.z,
+    charge_point_source(source.x, source.y, source.z,
                        E_total / num_sources, frequency)
 ```
 
 ### Stabilization Phase
 
-After initial energy injection, the wave field requires a **stabilization period** before reaching steady-state dynamics.
+After initial energy Charge, the wave field requires a **stabilization period** before reaching steady-state dynamics.
 
 **Stabilization Process**:
 
 1. **Initial State** (t = 0):
-   - Energy concentrated at injection points/regions
+   - Energy concentrated at Charge points/regions
    - Clear propagation path/direction from sources
    - No interference patterns yet
 
@@ -179,7 +179,7 @@ After initial energy injection, the wave field requires a **stabilization period
 
 - Waves have clear propagation direction from sources
 - Wavefronts are coherent (plane, spherical, etc.)
-- Energy flows outward from injection points
+- Energy flows outward from Charging points
 - Minimal interference
 
 **Phase 2: Boundary Reflections** (Early Time)
@@ -237,8 +237,8 @@ def verify_energy_conservation() -> ti.f32:
         total += (E_k + E_p) * dx**3  # Energy per voxel
     return total
 
-# Should match E_total_injected (within numerical tolerance)
-assert abs(verify_energy_conservation() - E_total_injected) < tolerance
+# Should match E_total_Charged (within numerical tolerance)
+assert abs(verify_energy_conservation() - E_total_Charge) < tolerance
 ```
 
 ## Wave Propagation Engine
@@ -355,7 +355,7 @@ E_total = Σ (E_kinetic[i,j,k] + E_potential[i,j,k])
 
 **Implementation Requirements**:
 
-- Energy injected once at initialization
+- Energy Charged once at initialization
 - No energy creation or destruction during propagation
 - Energy only redistributes through wave motion
 - Numerical scheme must preserve energy (symplectic integrator preferred)
@@ -494,12 +494,12 @@ Nodes at: `x = nλ/2` (n = 0, 1, 2, ...)
 **Implementation**:
 
 - Natural result of wave equation propagation
-- Source injects energy with specific frequency
+- Source Charges energy with specific frequency
 - Wave propagates outward at speed c
 
 ### Multi-Frequency Superposition
 
-**Multiple Frequencies**: Different wave sources can inject different frequencies.
+**Multiple Frequencies**: Different wave sources can Charge different frequencies.
 
 **Behavior**:
 
@@ -516,7 +516,7 @@ When two close frequencies interfere: `f_beat = |f₁ - f₂|`
 
 ### Wave Sources
 
-**Energy Injection Points**:
+**Energy Charging Points**:
 
 - Initialize amplitude at specific voxels
 - Set initial phase and frequency
@@ -527,16 +527,16 @@ When two close frequencies interfere: `f_beat = |f₁ - f₂|`
 
 1. **Point source**: Single voxel, spherical waves
 2. **Plane wave source**: Line/plane of voxels, uniform propagation
-3. **Pulsed source**: Time-limited energy injection
+3. **Pulsed source**: Time-limited energy Charge
 4. **Continuous source**: Ongoing oscillation (for testing)
 
 **Implementation**:
 
 ```python
 @ti.kernel
-def inject_wave_source(x: ti.i32, y: ti.i32, z: ti.i32,
+def charge_wave_source(x: ti.i32, y: ti.i32, z: ti.i32,
                        freq: ti.f32, phase: ti.f32, t: ti.f32):
-    """Inject sinusoidal wave at source location."""
+    """Charge sinusoidal wave at source location."""
     omega = 2.0 * pi * freq
     amplitude[x, y, z] += A_source * ti.sin(omega * t + phase)
 ```

--- a/openwave/xperiments/level1_field_based/_docs/04_VISUALIZATION.md
+++ b/openwave/xperiments/level1_field_based/_docs/04_VISUALIZATION.md
@@ -24,7 +24,7 @@
 1. [Electron Visualization](#electron-visualization)
    - [Spin Representation](#spin-representation)
    - [Formation Events](#formation-events)
-   - [Energy Injection Animation](#energy-injection-animation)
+   - [Energy Charging Animation](#energy-charging-animation)
 1. [Reference Infrastructure](#reference-infrastructure)
    - [Grid Lines](#grid-lines)
    - [Coordinate Indicators](#coordinate-indicators)
@@ -575,11 +575,11 @@ def detect_electron_formation():
                 trigger_formation_event(p1, p2)
 ```
 
-### Energy Injection Animation
+### Energy Charging Animation
 
 **Show Transformation**:
 
-- Visualize energy being injected
+- Visualize energy being Charged
 - Wave pattern changes
 - Color shifts during transformation
 - Particle properties update

--- a/openwave/xperiments/level1_field_based/_docs/05_MATTER.md
+++ b/openwave/xperiments/level1_field_based/_docs/05_MATTER.md
@@ -63,7 +63,7 @@ In LEVEL-1, **particles are wave centers** that reflect waves back into the medi
 
 - **Fundamental particles**: Hundreds to thousands (not millions)
 - Example: 1 neutrino = 1 wave center
-- Example: 1 electron = 2 wave centers ("click" together)
+- Example: 1 electron = 10 wave centers ("click" together)
 - Example: 1 proton = complex multi-center structure
 
 **Comparison to LEVEL-0**:
@@ -195,7 +195,7 @@ def compute_particle_mass(p: ti.i32) -> ti.f32:
 
 **Examples**:
 
-- **Electron**: 2 wave centers in specific configuration
+- **Electron**: 10 wave centers in specific configuration
 - **Proton**: Complex multi-center structure
 - **Neutron**: Different multi-center arrangement
 
@@ -210,9 +210,9 @@ def compute_particle_mass(p: ti.i32) -> ti.f32:
 
 **Conditions**:
 
-- Specific approach velocity
+- Specific approach velocity / kinetic energy
+- Other Specific energy configuration, external force
 - Specific wave phase relationship
-- Specific energy configuration
 
 **Visualization**:
 

--- a/openwave/xperiments/level1_field_based/_docs/06_FORCE_MOTION.md
+++ b/openwave/xperiments/level1_field_based/_docs/06_FORCE_MOTION.md
@@ -6,6 +6,7 @@
 1. [Fundamental Principle](#fundamental-principle)
    - [All Forces from Waves](#all-forces-from-waves)
    - [Wave Derivations](#wave-derivations)
+1. [Motion Equations](#motion-equations)
 1. [Force Field Types](#force-field-types)
    - [Gravitational Field](#gravitational-field)
    - [Electric Field](#electric-field)
@@ -14,10 +15,6 @@
 1. [The Electron's Special Role](#the-electrons-special-role)
    - [Wave Transformation](#wave-transformation)
    - [EM Wave Generation](#em-wave-generation)
-1. [Wave Propagation Properties](#wave-propagation-properties)
-   - [Source Characteristics](#source-characteristics)
-   - [Frequency Propagation](#frequency-propagation)
-   - [Multiple Source Interference](#multiple-source-interference)
 1. [Measurable vs Point Properties](#measurable-vs-point-properties)
    - [Point Properties](#point-properties)
    - [Derived Properties](#derived-properties)
@@ -77,36 +74,38 @@ Force is the negative gradient of amplitude. Particles move toward regions of lo
 - Superposition creates complex force fields
 - Force on particle A from particle B = effect of B's reflected waves on A
 
+## Motion Equations
+
+```bash
+p = m * v (momentum is conserved in collisions, Newton's cradle)
+F = m * a (Newton's 2nd law)
+
+Derivatives
+v = dx/dt
+a = dv/dt = d2x/dt2
+F = dp/dt (force is diff of momentum)
+F = -dU/dt (force is diff of potential)
+
+Work / Energy
+W = F * d
+
+OSCILLATING MOTION
+HARMONIC OSCLLIATOR (equation of motion)
+Fs = -k * x = m * a (Hooke's + Newton's)
+m * dx/dt = -k * x (differential equation)
+
+solution, function of position over time
+x(t) = A * cos(ω * t)
+x(t) = A * cos(2pi*f * t)
+
+ω = sqrt(k / m) (angular frequency)
+f = ω / 2pi (frequency)
+T = 2pi / ω (period)
+
+U = 1/2 * k * x**2
+```
+
 ## Force Field Types
-
-### Gravitational Field
-
-**Gravitational Force from Waves**:
-
-- Mass = trapped energy in standing waves around particle
-- More mass = more wave energy = stronger wave reflections
-- Reflected waves create amplitude gradient around massive particles
-- Other particles experience force from this gradient
-
-**Mechanism**:
-
-1. Massive particle traps waves (standing wave pattern)
-2. Trapped waves reflect incoming waves from other sources
-3. Reflection creates amplitude minimum near massive particle
-4. Other particles attracted toward amplitude minimum (MAP)
-5. Result: Gravitational attraction
-
-**Why Always Attractive?**:
-
-- Wave reflection creates amplitude minimum (node region)
-- All particles seek amplitude minimum (MAP)
-- Therefore all particles attracted to massive objects
-
-**1/r² Law**:
-
-- Amplitude from spherical source/reflector ∝ 1/r
-- Force ∝ amplitude gradient ∝ d/dr(1/r) ∝ 1/r²
-- Natural consequence of spherical wave geometry
 
 ### Electric Field
 
@@ -149,6 +148,35 @@ Force is the negative gradient of amplitude. Particles move toward regions of lo
 - Moving charge experiences wave pattern from other moving charges
 - Force depends on relative velocities (Lorentz force)
 - Cross-product nature (v × B) from wave directional effects
+
+### Gravitational Field
+
+**Gravitational Force from Waves**:
+
+- Mass = trapped energy in standing waves around particle
+- More mass = more wave energy = stronger wave reflections
+- Reflected waves create amplitude gradient around massive particles
+- Other particles experience force from this gradient
+
+**Mechanism**:
+
+1. Massive particle traps waves (standing wave pattern)
+2. Trapped waves reflect incoming waves from other sources
+3. Reflection creates amplitude minimum near massive particle
+4. Other particles attracted toward amplitude minimum (MAP)
+5. Result: Gravitational attraction
+
+**Why Always Attractive?**:
+
+- Wave reflection creates amplitude minimum (node region)
+- All particles seek amplitude minimum (MAP)
+- Therefore all particles attracted to massive objects
+
+**1/r² Law**:
+
+- Amplitude from spherical source/reflector ∝ 1/r
+- Force ∝ amplitude gradient ∝ d/dr(1/r) ∝ 1/r²
+- Natural consequence of spherical wave geometry
 
 ### Electromagnetic Waves
 
@@ -204,84 +232,6 @@ Force is the negative gradient of amplitude. Particles move toward regions of lo
 - Accelerating electrons → EM radiation (synchrotron, antenna)
 - Electron transitions in atoms → photons (specific frequencies)
 - All light/radio/X-rays from electron oscillations
-
-## Wave Propagation Properties
-
-### Source Characteristics
-
-**Wave Sources**:
-
-- Energy Charging points in the field
-- Each source has specific frequency
-- Sources can be:
-  - External (initial conditions)
-  - Particles (wave reflection = re-emission)
-  - Electrons (EM wave generation)
-
-**Frequency of Source**:
-
-- Determines wavelength: λ = c/f
-- Determines energy density: E ∝ f
-- Propagates with wave: frequency is carried property
-
-### Frequency Propagation
-
-**Frequency as Field Property**:
-
-- Each point in field can have associated frequency
-- Frequency propagates with wave amplitude
-- Multiple frequencies can coexist (superposition)
-
-**Multi-Frequency Fields**:
-
-```python
-# Optional: store frequency per voxel
-frequency = ti.field(dtype=ti.f32, shape=(nx, ny, nz))
-
-# When wave propagates, frequency propagates too
-@ti.kernel
-def propagate_frequency():
-    for i, j, k in frequency:
-        # Frequency advects with wave direction
-        # Similar to amplitude propagation
-```
-
-**Frequency Mixing**:
-
-- Different sources → different frequencies
-- Frequencies combine at each point
-- Interference patterns depend on frequency
-- Beat frequencies emerge naturally
-
-### Multiple Source Interference
-
-**Superposition**:
-
-- Waves from multiple sources add linearly
-- Each source contributes its amplitude and frequency
-- Total field = sum of all source contributions
-
-**Complex Patterns**:
-
-- Standing waves from interference
-- Beat patterns from close frequencies
-- Constructive/destructive interference regions
-- Forces emerge from combined amplitude gradients
-
-**Example - Two Sources**:
-
-```python
-# Source 1: frequency f1, position r1
-# Source 2: frequency f2, position r2
-
-amplitude_total[x,y,z] = (
-    A1 * sin(k1*|r-r1| - ω1*t) +
-    A2 * sin(k2*|r-r2| - ω2*t)
-)
-
-# If f1 ≈ f2: beat patterns
-# If f1 = f2: standing waves (constructive/destructive)
-```
 
 ## Measurable vs Point Properties
 
@@ -606,23 +556,23 @@ def interpolate_force(pos: ti.math.vec3) -> ti.math.vec3:
 2. Test with simple wave patterns
 3. Verify MAP (particles seek amplitude minimum)
 
-**Phase 2 - Gravitational Analog**:
-
-1. Create particles with mass (trapped wave energy)
-2. Observe attraction between particles
-3. Verify 1/r² force law
-
-**Phase 3 - Electric Analog**:
+**Phase 2 - Electric Analog**:
 
 1. Implement different particle types (charges)
 2. Create attractive and repulsive patterns
 3. Test like/opposite charge interactions
 
-**Phase 4 - Magnetic Analog**:
+**Phase 3 - Magnetic Analog**:
 
 1. Add velocity-dependent forces
 2. Implement moving particle wave patterns
 3. Test Lorentz-like force (v × B analog)
+
+**Phase 4 - Gravitational Analog**:
+
+1. Create particles with mass (trapped wave energy)
+2. Observe attraction between particles
+3. Verify 1/r² force law
 
 ### Research Requirements
 

--- a/openwave/xperiments/level1_field_based/_docs/06_FORCE_MOTION.md
+++ b/openwave/xperiments/level1_field_based/_docs/06_FORCE_MOTION.md
@@ -211,7 +211,7 @@ Force is the negative gradient of amplitude. Particles move toward regions of lo
 
 **Wave Sources**:
 
-- Energy injection points in the field
+- Energy Charging points in the field
 - Each source has specific frequency
 - Sources can be:
   - External (initial conditions)

--- a/openwave/xperiments/level1_field_based/_docs/support_material/L1field_QFT.md
+++ b/openwave/xperiments/level1_field_based/_docs/support_material/L1field_QFT.md
@@ -112,7 +112,7 @@ All fields (electric, magnetic, gravitational) are derivations of wave fields
 **OpenWave L1:**
 
 ```text
-Energy injected once, totally conserved throughout universe
+Energy Charged once, totally conserved throughout universe
 Energy density per volume stored in field
 Amplitude reduces with radius (1/r), but total energy constant
 Field evolution governed by wave equations (PDEs)

--- a/openwave/xperiments/level1_field_based/_docs/support_material/wave_spherical.md
+++ b/openwave/xperiments/level1_field_based/_docs/support_material/wave_spherical.md
@@ -151,7 +151,7 @@ During implementation testing, granules at distances less than 1λ from the wave
 The observed instability reveals important physics about what happens near the wave source (r < λ):
 
 1. **Source Region Physics** (r < λ):
-   - This is the source region where energy is being injected
+   - This is the source region where energy is being Charged
    - Wave structure is not yet fully formed
    - Near-field effects dominate over far-field radiation
    - Simple 1/r amplitude falloff does not apply


### PR DESCRIPTION
This pull request refactors the time tracking variable from `t` to `elapsed_t` across the wave engine and all Level 0 granule-based experiment modules. The change improves clarity by making time management more explicit and consistent throughout the codebase and documentation. Additionally, terminology in comments and docs is updated to use "energy charge" instead of "energy injection," aligning language with the underlying physical model.

**Time tracking and variable consistency:**

* Replaced all instances of the variable `t` with `elapsed_t` in experiment scripts (`spacetime_vibration.py`, `spherical_wave.py`, `standing_wave.py`, `wave_interference.py`) for simulation time tracking, dashboard display, diagnostics, and wave calculations. [[1]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL228-R228) [[2]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L207-R207) [[3]](diffhunk://#diff-8db97d00a08512954d58ea87d77947aebd0a637a04326fddc47ad4938a0fcf8cL220-R220) [[4]](diffhunk://#diff-17cb3f5a9c0aa1525889c636303957d14610cd2ad92140ba32e1a740c8e37d66L223-R223)
* Updated initialization, accumulation, and usage of the time variable to use `elapsed_t` instead of `t` for real elapsed time in all experiment modules. [[1]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL243-R243) [[2]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL277-R277) [[3]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L222-R222) [[4]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L256-R256) [[5]](diffhunk://#diff-8db97d00a08512954d58ea87d77947aebd0a637a04326fddc47ad4938a0fcf8cL235-R235) [[6]](diffhunk://#diff-8db97d00a08512954d58ea87d77947aebd0a637a04326fddc47ad4938a0fcf8cL269-R269) [[7]](diffhunk://#diff-17cb3f5a9c0aa1525889c636303957d14610cd2ad92140ba32e1a740c8e37d66L238-R238) [[8]](diffhunk://#diff-17cb3f5a9c0aa1525889c636303957d14610cd2ad92140ba32e1a740c8e37d66L272-R272)
* Modified function calls and dashboard displays to use `elapsed_t` for frame rate and simulation time calculations. [[1]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL139-R143) [[2]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L118-R122) [[3]](diffhunk://#diff-8db97d00a08512954d58ea87d77947aebd0a637a04326fddc47ad4938a0fcf8cL131-R135) [[4]](diffhunk://#diff-17cb3f5a9c0aa1525889c636303957d14610cd2ad92140ba32e1a740c8e37d66L134-R138)

**Wave engine and documentation terminology:**

* In `wave_engine_level0.py`, changed function parameter and documentation references from `t` to `elapsed_t`, and updated comments to use "energy charge" instead of "energy injection." [[1]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL126-R130) [[2]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL190-R190) [[3]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL250-R256)
* Updated the main equation of motion and velocity calculations to use `elapsed_t` for time-dependent wave computations.
* Revised documentation in `spherical_wave.md` to use "energy Charged" instead of "energy being injected" for the source region description.

**Experiment logic and diagnostics:**

* Changed all relevant function calls to use `elapsed_t` for passing simulation time to wave calculation and diagnostic routines. [[1]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL288-R288) [[2]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL304-R304) [[3]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L267-R267) [[4]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L283-R283) [[5]](diffhunk://#diff-8db97d00a08512954d58ea87d77947aebd0a637a04326fddc47ad4938a0fcf8cL280-R280) [[6]](diffhunk://#diff-8db97d00a08512954d58ea87d77947aebd0a637a04326fddc47ad4938a0fcf8cL296-R296) [[7]](diffhunk://#diff-17cb3f5a9c0aa1525889c636303957d14610cd2ad92140ba32e1a740c8e37d66L283-R283) [[8]](diffhunk://#diff-17cb3f5a9c0aa1525889c636303957d14610cd2ad92140ba32e1a740c8e37d66L299-R299)