### PR TITLE
Add .gitattributes to exclude files from exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+# Exclude documentation from releases
+README.md export-ignore
+WELCOME.md export-ignore
+CLAUDE.md export-ignore
+CONTRIBUTING.md export-ignore
+CODE_OF_CONDUCT.md export-ignore
+TRADEMARK export-ignore
+THIRD-PARTY-NOTICES export-ignore
+
+# Exclude documentation directories
+/docs export-ignore
+/dev_docs export-ignore
+/images export-ignore
+/research_requirements export-ignore
+
+# Exclude test directory
+/tests export-ignore
+
+# Exclude build artifacts
+/OPENWAVE.egg-info export-ignore
+MANIFEST.in export-ignore
+
+# Exclude development files
+.gitignore export-ignore
+.gitattributes export-ignore
+/.github export-ignore
+/.claude export-ignore
+.DS_Store export-ignore
+imgui.ini export-ignore


### PR DESCRIPTION
Introduces a .gitattributes file to exclude documentation, test directories, build artifacts, and development files from release exports. This helps ensure only necessary files are included in distributed packages.