### PR TITLE
Rename ATTOMETTER to ATTOMETER for consistency

### DIFF
--- a/docs/dev/coding_standards.rst
+++ b/docs/dev/coding_standards.rst
@@ -202,7 +202,7 @@ Comment for:
 
    # Use attometer units for f32 precision
    # This scales 1e-17 m values to ~10 am
-   position_am = position / constants.ATTOMETTER
+   position_am = position / constants.ATTOMETER
 
 When Not to Comment
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/dev/performance.rst
+++ b/docs/dev/performance.rst
@@ -83,7 +83,7 @@ Data Structures
    field = ti.field(dtype=ti.f32, shape=N)
 
    # Use attometer units for precision
-   position_am = position / constants.ATTOMETTER
+   position_am = position / constants.ATTOMETER
 
 Minimize Allocations
 ~~~~~~~~~~~~~~~~~~~~

--- a/openwave/common/constants.py
+++ b/openwave/common/constants.py
@@ -11,7 +11,7 @@ All values use SI units (kg, m, s) for consistency.
 # WAVE-MEDIUM
 # ================================================================
 MEDIUM_DENSITY = 3.506335701e22  # kg / m^3, wave-medium density (ρ)
-ATTOMETTER = 1e-18  # m, attometer length scale (for memory efficiency in simulations)
+ATTOMETER = 1e-18  # m, attometer length scale (for memory efficiency in simulations)
 
 # ================================================================
 # ENERGY-WAVE

--- a/openwave/spacetime/medium_level0.py
+++ b/openwave/spacetime/medium_level0.py
@@ -82,7 +82,7 @@ class BCCLattice:
         # This preserves crystal structure. Only the NUMBER of cells varies per axis.
         unit_cell_volume = init_universe_volume / (self.target_granules / 2)  # BCC = 2 /unit-cell
         self.unit_cell_edge = unit_cell_volume ** (1 / 3)  # a^3 = volume
-        self.unit_cell_edge_am = self.unit_cell_edge / constants.ATTOMETTER
+        self.unit_cell_edge_am = self.unit_cell_edge / constants.ATTOMETER
 
         # Calculate grid dimensions (number of unit cells per dimension) - asymmetric
         self.raw_size = [
@@ -104,16 +104,16 @@ class BCCLattice:
             self.grid_size[2] * self.unit_cell_edge,
         ]
         self.universe_size_am = [
-            self.universe_size[0] / constants.ATTOMETTER,
-            self.universe_size[1] / constants.ATTOMETTER,
-            self.universe_size[2] / constants.ATTOMETTER,
+            self.universe_size[0] / constants.ATTOMETER,
+            self.universe_size[1] / constants.ATTOMETER,
+            self.universe_size[2] / constants.ATTOMETER,
         ]
         self.max_universe_edge = max(
             self.grid_size[0] * self.unit_cell_edge,
             self.grid_size[1] * self.unit_cell_edge,
             self.grid_size[2] * self.unit_cell_edge,
         )
-        self.max_universe_edge_am = self.max_universe_edge / constants.ATTOMETTER
+        self.max_universe_edge_am = self.max_universe_edge / constants.ATTOMETER
         self.max_grid_size = max(
             self.grid_size[0],
             self.grid_size[1],
@@ -404,7 +404,7 @@ class BCCLattice:
                     self.granule_type_color[idx] = probe_color
 
         # Convert energy wavelength and call GPU kernel for field circles
-        wavelength_am = constants.EWAVE_LENGTH / constants.ATTOMETTER
+        wavelength_am = constants.EWAVE_LENGTH / constants.ATTOMETER
         self._mark_sliced_plane_objects(wavelength_am, num_circles)
 
     @ti.kernel
@@ -558,7 +558,7 @@ class SCLattice:
         # This preserves crystal structure. Only the NUMBER of cells varies per axis.
         unit_cell_volume = init_universe_volume / self.target_granules  # SC = 1 /unit-cell
         self.unit_cell_edge = unit_cell_volume ** (1 / 3)  # a^3 = volume
-        self.unit_cell_edge_am = self.unit_cell_edge / constants.ATTOMETTER
+        self.unit_cell_edge_am = self.unit_cell_edge / constants.ATTOMETER
 
         # Calculate grid dimensions (number of unit cells per dimension) - asymmetric
         self.raw_size = [
@@ -580,16 +580,16 @@ class SCLattice:
             self.grid_size[2] * self.unit_cell_edge,
         ]
         self.universe_size_am = [
-            self.universe_size[0] / constants.ATTOMETTER,
-            self.universe_size[1] / constants.ATTOMETTER,
-            self.universe_size[2] / constants.ATTOMETTER,
+            self.universe_size[0] / constants.ATTOMETER,
+            self.universe_size[1] / constants.ATTOMETER,
+            self.universe_size[2] / constants.ATTOMETER,
         ]
         self.max_universe_edge = max(
             self.grid_size[0] * self.unit_cell_edge,
             self.grid_size[1] * self.unit_cell_edge,
             self.grid_size[2] * self.unit_cell_edge,
         )
-        self.max_universe_edge_am = self.max_universe_edge / constants.ATTOMETTER
+        self.max_universe_edge_am = self.max_universe_edge / constants.ATTOMETER
         self.max_grid_size = max(
             self.grid_size[0],
             self.grid_size[1],
@@ -833,7 +833,7 @@ class SCLattice:
                     self.granule_type_color[idx] = probe_color
 
         # Convert energy wavelength and call GPU kernel for field circles
-        wavelength_am = constants.EWAVE_LENGTH / constants.ATTOMETTER
+        wavelength_am = constants.EWAVE_LENGTH / constants.ATTOMETER
         self._mark_sliced_plane_objects(wavelength_am, num_circles)
 
     @ti.kernel

--- a/openwave/spacetime/wave_engine_level0.py
+++ b/openwave/spacetime/wave_engine_level0.py
@@ -18,8 +18,8 @@ from openwave.common import equations
 # ================================================================
 # Energy-Wave Oscillation Parameters
 # ================================================================
-amplitude_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETTER  # am, oscillation amplitude
-wavelength_am = constants.EWAVE_LENGTH / constants.ATTOMETTER  # in attometers
+amplitude_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETER  # am, oscillation amplitude
+wavelength_am = constants.EWAVE_LENGTH / constants.ATTOMETER  # in attometers
 frequency = constants.EWAVE_SPEED / constants.EWAVE_LENGTH  # Hz, energy-wave frequency
 
 # ================================================================
@@ -312,7 +312,7 @@ def update_lattice_energy(lattice):
         lattice: Lattice instance with universe_volume and energy fields
     """
     lattice.energy = equations.energy_wave_equation(
-        volume=lattice.universe_volume, amplitude=avg_amplitude_am[None] * constants.ATTOMETTER
+        volume=lattice.universe_volume, amplitude=avg_amplitude_am[None] * constants.ATTOMETER
     )
     lattice.energy_kWh = equations.J_to_kWh(lattice.energy)  # in KWh
     lattice.energy_years = lattice.energy_kWh / (183230 * 1e9)  # global energy use

--- a/openwave/xperiments/_archives/radial_wave/energy_wave_radial.py
+++ b/openwave/xperiments/_archives/radial_wave/energy_wave_radial.py
@@ -16,8 +16,8 @@ from openwave.common import constants
 # ================================================================
 # Energy-Wave Oscillation Parameters
 # ================================================================
-amplitude_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETTER  # am, oscillation amplitude
-wavelength_am = constants.EWAVE_LENGTH / constants.ATTOMETTER  # in attometers
+amplitude_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETER  # am, oscillation amplitude
+wavelength_am = constants.EWAVE_LENGTH / constants.ATTOMETER  # in attometers
 frequency = constants.EWAVE_SPEED / constants.EWAVE_LENGTH  # Hz, energy-wave frequency
 
 

--- a/openwave/xperiments/_archives/radial_wave/medium_bccgranule.py
+++ b/openwave/xperiments/_archives/radial_wave/medium_bccgranule.py
@@ -78,7 +78,7 @@ class BCCLattice:
         # Set universe properties (simulation domain)
         self.target_granules = config.TARGET_GRANULES
         self.universe_edge = universe_edge
-        self.universe_edge_am = universe_edge / constants.ATTOMETTER  # in attometers
+        self.universe_edge_am = universe_edge / constants.ATTOMETER  # in attometers
         universe_volume = universe_edge**3
 
         # Compute initial unit-cell properties (before rounding and lattice symmetry)
@@ -94,7 +94,7 @@ class BCCLattice:
 
         # Recompute unit-cell edge length based on rounded grid size and scale factor
         self.unit_cell_edge = universe_edge / self.grid_size  # adjusted unit cell edge length
-        self.unit_cell_edge_am = self.unit_cell_edge / constants.ATTOMETTER  # in attometers
+        self.unit_cell_edge_am = self.unit_cell_edge / constants.ATTOMETER  # in attometers
         self.scale_factor = self.unit_cell_edge / (
             2 * ti.math.e * constants.PLANCK_LENGTH
         )  # linear scale factor from Planck length, increases computability
@@ -446,7 +446,7 @@ class BCCLattice:
                         self.granule_color[idx] = probe_color
 
         # Convert energy wavelength and call GPU kernel for field circles
-        wavelength_am = constants.EWAVE_LENGTH / constants.ATTOMETTER
+        wavelength_am = constants.EWAVE_LENGTH / constants.ATTOMETER
         self._mark_sliced_plane_objects(wavelength_am, num_circles)
 
     @ti.kernel

--- a/openwave/xperiments/_archives/spring_mass/energy_wave_spring_euler.py
+++ b/openwave/xperiments/_archives/spring_mass/energy_wave_spring_euler.py
@@ -12,7 +12,7 @@ from openwave.common import constants
 # ================================================================
 # Energy-Wave Oscillation Parameters
 # ================================================================
-amplitude_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETTER  # am, oscillation amplitude
+amplitude_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETER  # am, oscillation amplitude
 frequency = constants.EWAVE_SPEED / constants.EWAVE_LENGTH  # Hz, energy-wave frequency
 
 
@@ -227,7 +227,7 @@ def propagate_ewave(
             neighbors.links,
             neighbors.links_count,
             neighbors.rest_length_am,  # rest_length in am
-            stiffness * constants.ATTOMETTER,  # stiffness in N/am
+            stiffness * constants.ATTOMETER,  # stiffness in N/am
             lattice.acceleration_am,  # output acceleration in am/s^2
         )
 

--- a/openwave/xperiments/_archives/spring_mass/energy_wave_spring_leap.py
+++ b/openwave/xperiments/_archives/spring_mass/energy_wave_spring_leap.py
@@ -12,7 +12,7 @@ from openwave.common import constants
 # ================================================================
 # Energy-Wave Oscillation Parameters
 # ================================================================
-amplitude_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETTER  # am, oscillation amplitude
+amplitude_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETER  # am, oscillation amplitude
 frequency = constants.EWAVE_SPEED / constants.EWAVE_LENGTH  # Hz, energy-wave frequency
 
 
@@ -239,7 +239,7 @@ def propagate_ewave(
             neighbors.links,
             neighbors.links_count,
             neighbors.rest_length_am,  # rest_length in am
-            stiffness * constants.ATTOMETTER,  # stiffness in N/am
+            stiffness * constants.ATTOMETER,  # stiffness in N/am
             lattice.acceleration_am,  # output acceleration in am/s^2
         )
 
@@ -266,7 +266,7 @@ def propagate_ewave(
             neighbors.links,
             neighbors.links_count,
             neighbors.rest_length_am,  # rest_length in am
-            stiffness * constants.ATTOMETTER,  # stiffness in N/am
+            stiffness * constants.ATTOMETER,  # stiffness in N/am
             lattice.acceleration_am,  # output a(t+dt) in am/s^2
         )
 

--- a/openwave/xperiments/_archives/spring_mass/energy_wave_xpbd.py
+++ b/openwave/xperiments/_archives/spring_mass/energy_wave_xpbd.py
@@ -23,7 +23,7 @@ from openwave.common import constants
 # ================================================================
 # Energy-Wave Oscillation Parameters
 # ================================================================
-amplitude_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETTER  # am, oscillation amplitude
+amplitude_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETER  # am, oscillation amplitude
 frequency = constants.EWAVE_SPEED / constants.EWAVE_LENGTH  # Hz, energy-wave frequency
 
 
@@ -339,7 +339,7 @@ def propagate_ewave(
             neighbors.links,
             neighbors.links_count,
             neighbors.rest_length_am,
-            stiffness * constants.ATTOMETTER,  # Convert to N/am for attometer units
+            stiffness * constants.ATTOMETER,  # Convert to N/am for attometer units
             lattice.granule_type,
             dt_sub,
             omega,
@@ -444,7 +444,7 @@ def probe_wave_diagnostics(
         distance_traveled_am = (
             wave_data["max_distance_am"] - _diagnostic_state["first_measurement"]["distance_am"]
         )
-        distance_traveled_m = distance_traveled_am * constants.ATTOMETTER
+        distance_traveled_m = distance_traveled_am * constants.ATTOMETER
 
         # Convert simulation time to real time (account for SLOW_MO)
         # SLOW_MO slows down time, so to get real time: divide by SLOW_MO
@@ -486,7 +486,7 @@ def probe_wave_diagnostics(
             )
 
         if wavelength_data["num_peaks"] >= 1:  # Show even single peak
-            wavelength_m = wavelength_data["wavelength_am"] * constants.ATTOMETTER
+            wavelength_m = wavelength_data["wavelength_am"] * constants.ATTOMETER
             expected_wavelength_m = 2 * neighbors.rest_length  # λ_lattice = 2L
             wavelength_error = (
                 abs(wavelength_m - expected_wavelength_m) / expected_wavelength_m * 100
@@ -509,7 +509,7 @@ def probe_wave_diagnostics(
                 print(f"Reference lengths:")
                 print(f"  Unit cell edge:    {lattice.unit_cell_edge_am:.1f} am")
                 print(f"  Rest length (L):   {neighbors.rest_length_am:.1f} am")
-                print(f"  EWAVE_LENGTH:      {constants.EWAVE_LENGTH/constants.ATTOMETTER:.1f} am")
+                print(f"  EWAVE_LENGTH:      {constants.EWAVE_LENGTH/constants.ATTOMETER:.1f} am")
                 print(f"")
                 print(
                     f"Measured / Unit cell: {wavelength_data['wavelength_am']/lattice.unit_cell_edge_am:.2f}x"
@@ -518,7 +518,7 @@ def probe_wave_diagnostics(
                     f"Measured / 2L:        {wavelength_data['wavelength_am']/(2*neighbors.rest_length_am):.2f}x"
                 )
                 print(
-                    f"Measured / λ: {wavelength_data['wavelength_am']/(constants.EWAVE_LENGTH/constants.ATTOMETTER):.2f}x"
+                    f"Measured / λ: {wavelength_data['wavelength_am']/(constants.EWAVE_LENGTH/constants.ATTOMETER):.2f}x"
                 )
             else:
                 print(

--- a/openwave/xperiments/_archives/spring_mass/medium_bccgranule.py
+++ b/openwave/xperiments/_archives/spring_mass/medium_bccgranule.py
@@ -78,7 +78,7 @@ class BCCLattice:
         # Set universe properties (simulation domain)
         self.target_granules = config.TARGET_GRANULES
         self.universe_edge = universe_edge
-        self.universe_edge_am = universe_edge / constants.ATTOMETTER  # in attometers
+        self.universe_edge_am = universe_edge / constants.ATTOMETER  # in attometers
         universe_volume = universe_edge**3
 
         # Compute initial unit-cell properties (before rounding and lattice symmetry)
@@ -94,7 +94,7 @@ class BCCLattice:
 
         # Recompute unit-cell edge length based on rounded grid size and scale factor
         self.unit_cell_edge = universe_edge / self.grid_size  # adjusted unit cell edge length
-        self.unit_cell_edge_am = self.unit_cell_edge / constants.ATTOMETTER  # in attometers
+        self.unit_cell_edge_am = self.unit_cell_edge / constants.ATTOMETER  # in attometers
         self.scale_factor = self.unit_cell_edge / (
             2 * ti.math.e * constants.PLANCK_LENGTH
         )  # linear scale factor from Planck length, increases computability
@@ -447,7 +447,7 @@ class BCCLattice:
                         self.granule_color[idx] = probe_color
 
         # Convert energy wavelength and call GPU kernel for field circles
-        wavelength_am = constants.EWAVE_LENGTH / constants.ATTOMETTER
+        wavelength_am = constants.EWAVE_LENGTH / constants.ATTOMETER
         self._mark_sliced_plane_objects(wavelength_am, num_circles)
 
     @ti.kernel

--- a/openwave/xperiments/level0_granule_based/spacetime_vibration.py
+++ b/openwave/xperiments/level0_granule_based/spacetime_vibration.py
@@ -304,7 +304,7 @@ def render_xperiment(lattice):
             # Update data sampling every 30 frames to reduce overhead
             if frame % 30 == 0:
                 ewave.update_lattice_energy(lattice)  # Update energy based on wave amplitude
-                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETTER
+                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETER
 
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:

--- a/openwave/xperiments/level0_granule_based/spherical_wave.py
+++ b/openwave/xperiments/level0_granule_based/spherical_wave.py
@@ -283,7 +283,7 @@ def render_xperiment(lattice):
             # Update data sampling every 30 frames to reduce overhead
             if frame % 30 == 0:
                 ewave.update_lattice_energy(lattice)  # Update energy based on wave amplitude
-                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETTER
+                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETER
 
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:

--- a/openwave/xperiments/level0_granule_based/standing_wave.py
+++ b/openwave/xperiments/level0_granule_based/standing_wave.py
@@ -296,7 +296,7 @@ def render_xperiment(lattice):
             # Update data sampling every 30 frames to reduce overhead
             if frame % 30 == 0:
                 ewave.update_lattice_energy(lattice)  # Update energy based on wave amplitude
-                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETTER
+                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETER
 
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:

--- a/openwave/xperiments/level0_granule_based/wave_interference.py
+++ b/openwave/xperiments/level0_granule_based/wave_interference.py
@@ -299,7 +299,7 @@ def render_xperiment(lattice):
             # Update data sampling every 30 frames to reduce overhead
             if frame % 30 == 0:
                 ewave.update_lattice_energy(lattice)  # Update energy based on wave amplitude
-                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETTER
+                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETER
 
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:

--- a/openwave/xperiments/level0_granule_based/wave_pulse.py
+++ b/openwave/xperiments/level0_granule_based/wave_pulse.py
@@ -283,7 +283,7 @@ def render_xperiment(lattice):
             # Update data sampling every 30 frames to reduce overhead
             if frame % 30 == 0:
                 ewave.update_lattice_energy(lattice)  # Update energy based on wave amplitude
-                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETTER
+                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETER
 
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:

--- a/openwave/xperiments/level0_granule_based/xwaves.py
+++ b/openwave/xperiments/level0_granule_based/xwaves.py
@@ -304,7 +304,7 @@ def render_xperiment(lattice):
             # Update data sampling every 30 frames to reduce overhead
             if frame % 30 == 0:
                 ewave.update_lattice_energy(lattice)  # Update energy based on wave amplitude
-                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETTER
+                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETER
 
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:

--- a/openwave/xperiments/level0_granule_based/yin_yang.py
+++ b/openwave/xperiments/level0_granule_based/yin_yang.py
@@ -298,7 +298,7 @@ def render_xperiment(lattice):
             # Update data sampling every 30 frames to reduce overhead
             if frame % 30 == 0:
                 ewave.update_lattice_energy(lattice)  # Update energy based on wave amplitude
-                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETTER
+                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETER
 
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:

--- a/openwave/xperiments/level1_field_based/_docs/support_material/wave_spherical_plot.py
+++ b/openwave/xperiments/level1_field_based/_docs/support_material/wave_spherical_plot.py
@@ -37,8 +37,8 @@ wavelength = constants.EWAVE_LENGTH  # m, energy-wave length (λ)
 r_reference = wavelength  # Reference radius = 1λ
 
 # Convert to attometers for plotting
-A0_am = A0 / constants.ATTOMETTER  # attometers
-wavelength_am = wavelength / constants.ATTOMETTER  # attometers
+A0_am = A0 / constants.ATTOMETER  # attometers
+wavelength_am = wavelength / constants.ATTOMETER  # attometers
 
 # ================================================================
 # Amplitude Functions
@@ -114,9 +114,9 @@ fig, ax = plt.subplots(figsize=(12, 8))
 # ================================================================
 
 # Convert to attometers for y-axis
-A_uncapped_am = A_uncapped / constants.ATTOMETTER
-A_capped_am = A_capped / constants.ATTOMETTER
-r_am = r / constants.ATTOMETTER
+A_uncapped_am = A_uncapped / constants.ATTOMETER
+A_capped_am = A_capped / constants.ATTOMETER
+r_am = r / constants.ATTOMETER
 
 # A = r line (the cap boundary) - plot first so it's in background
 ax.plot(r / wavelength, r_am, "k:", linewidth=1.5, alpha=0.5, label="A = r (cap limit)")
@@ -163,12 +163,12 @@ ax.axvline(
 
 # Amplitude at r = 1λ
 A_at_1lambda = amplitude_with_cap(wavelength)
-A_at_1lambda_am = A_at_1lambda / constants.ATTOMETTER
+A_at_1lambda_am = A_at_1lambda / constants.ATTOMETER
 ax.plot(1.0, A_at_1lambda_am, "ro", markersize=10, label=f"A(1λ) = {A_at_1lambda/A0:.1f}A₀")
 
 # Amplitude at r = 2λ
 A_at_2lambda = amplitude_with_cap(2 * wavelength)
-A_at_2lambda_am = A_at_2lambda / constants.ATTOMETTER
+A_at_2lambda_am = A_at_2lambda / constants.ATTOMETER
 ax.plot(2.0, A_at_2lambda_am, "go", markersize=10, label=f"A(2λ) = {A_at_2lambda/A0:.1f}A₀")
 
 # Annotate regions (adjusted for 2 am y-axis scale)


### PR DESCRIPTION
Replaces all instances of the constant name ATTOMETTER with ATTOMETER across documentation and codebase for clarity and consistency. Updates all references and calculations to use the corrected spelling.