### PR TITLE
clarify wave amplitude and displacement

### DIFF
--- a/openwave/spacetime/medium_level0.py
+++ b/openwave/spacetime/medium_level0.py
@@ -152,6 +152,7 @@ class BCCLattice:
         # This scales 1e-17 m values to ~10 am, well within f32 range
         self.position_am = ti.Vector.field(3, dtype=ti.f32, shape=self.total_granules)
         self.equilibrium_am = ti.Vector.field(3, dtype=ti.f32, shape=self.total_granules)  # rest
+        self.amplitude_am = ti.field(dtype=ti.f32, shape=self.total_granules)  # granule amplitude
         self.velocity_am = ti.Vector.field(3, dtype=ti.f32, shape=self.total_granules)
         self.granule_type = ti.field(dtype=ti.i32, shape=self.total_granules)
         self.front_octant = ti.field(dtype=ti.i32, shape=self.total_granules)
@@ -627,6 +628,7 @@ class SCLattice:
         # This scales 1e-17 m values to ~10 am, well within f32 range
         self.position_am = ti.Vector.field(3, dtype=ti.f32, shape=self.total_granules)
         self.equilibrium_am = ti.Vector.field(3, dtype=ti.f32, shape=self.total_granules)  # rest
+        self.amplitude_am = ti.field(dtype=ti.f32, shape=self.total_granules)  # granule amplitude
         self.velocity_am = ti.Vector.field(3, dtype=ti.f32, shape=self.total_granules)
         self.granule_type = ti.field(dtype=ti.i32, shape=self.total_granules)
         self.front_octant = ti.field(dtype=ti.i32, shape=self.total_granules)

--- a/openwave/xperiments/level0_granule_based/spacetime_vibration.py
+++ b/openwave/xperiments/level0_granule_based/spacetime_vibration.py
@@ -82,7 +82,7 @@ COLOR_THEME = "OCEAN"
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge)
 
-# DATA SAMPLING & DIAGNOSTICS ==================================
+# DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
 
@@ -250,7 +250,7 @@ def render_xperiment(lattice):
     granule_type = True  # Granule type coloring toggle
     ironbow = False  # Ironbow (displacement) coloring toggle
 
-    # Time tracking for radial harmonic oscillation of all granules
+    # Time tracking for harmonic oscillation of all granules
     elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics

--- a/openwave/xperiments/level0_granule_based/spacetime_vibration.py
+++ b/openwave/xperiments/level0_granule_based/spacetime_vibration.py
@@ -83,7 +83,7 @@ lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge)
 
 # DATA SAMPLING & DIAGNOSTICS ==================================
-max_displacement = 0.0  # Initialize granule max displacement (data sampling variable)
+peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
 
 # ================================================================
@@ -188,7 +188,7 @@ def color_menu():
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
             with render.gui.sub_window("displacement", 0.92, 0.70, 0.08, 0.06) as sub:
-                sub.text(f"0       {max_displacement:.0e}m")
+                sub.text(f"0       {peak_amplitude:.0e}m")
 
 
 # ================================================================
@@ -237,7 +237,7 @@ def render_xperiment(lattice):
     global granule_type, ironbow
     global elapsed_t, frame
     global normalized_position
-    global max_displacement
+    global peak_amplitude
 
     # Initialize UI control variables
     show_axis = False  # Toggle to show/hide axis lines
@@ -291,6 +291,7 @@ def render_xperiment(lattice):
             ewave.oscillate_granules(
                 lattice.position_am,  # Granule positions in attometers
                 lattice.equilibrium_am,  # Rest positions for all granules
+                lattice.amplitude_am,  # Granule amplitude in am
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
                 NUM_SOURCES,  # Number of active wave sources
@@ -307,7 +308,7 @@ def render_xperiment(lattice):
             # Update data sampling every 30 frames to reduce overhead
             if frame % 30 == 0:
                 ewave.update_lattice_energy(lattice)  # Update energy based on wave amplitude
-                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETER
+                peak_amplitude = ewave.peak_amplitude_am[None] * constants.ATTOMETER
 
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:

--- a/openwave/xperiments/level0_granule_based/spherical_wave.py
+++ b/openwave/xperiments/level0_granule_based/spherical_wave.py
@@ -62,7 +62,7 @@ lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge)
 
 # DATA SAMPLING & DIAGNOSTICS ==================================
-max_displacement = 0.0  # Initialize granule max displacement (data sampling variable)
+peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
 
 # ================================================================
@@ -167,7 +167,7 @@ def color_menu():
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
             with render.gui.sub_window("displacement", 0.92, 0.70, 0.08, 0.06) as sub:
-                sub.text(f"0       {max_displacement:.0e}m")
+                sub.text(f"0       {peak_amplitude:.0e}m")
 
 
 # ================================================================
@@ -216,7 +216,7 @@ def render_xperiment(lattice):
     global granule_type, ironbow
     global elapsed_t, frame
     global normalized_position
-    global max_displacement
+    global peak_amplitude
 
     # Initialize UI control variables
     show_axis = True  # Toggle to show/hide axis lines
@@ -270,6 +270,7 @@ def render_xperiment(lattice):
             ewave.oscillate_granules(
                 lattice.position_am,  # Granule positions in attometers
                 lattice.equilibrium_am,  # Rest positions for all granules
+                lattice.amplitude_am,  # Granule amplitude in am
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
                 NUM_SOURCES,  # Number of active wave sources
@@ -286,7 +287,7 @@ def render_xperiment(lattice):
             # Update data sampling every 30 frames to reduce overhead
             if frame % 30 == 0:
                 ewave.update_lattice_energy(lattice)  # Update energy based on wave amplitude
-                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETER
+                peak_amplitude = ewave.peak_amplitude_am[None] * constants.ATTOMETER
 
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:

--- a/openwave/xperiments/level0_granule_based/spherical_wave.py
+++ b/openwave/xperiments/level0_granule_based/spherical_wave.py
@@ -61,7 +61,7 @@ COLOR_THEME = "OCEAN"
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge)
 
-# DATA SAMPLING & DIAGNOSTICS ==================================
+# DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
 
@@ -229,7 +229,7 @@ def render_xperiment(lattice):
     granule_type = False  # Granule type coloring toggle
     ironbow = False  # Ironbow (displacement) coloring toggle
 
-    # Time tracking for radial harmonic oscillation of all granules
+    # Time tracking for harmonic oscillation of all granules
     elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics

--- a/openwave/xperiments/level0_granule_based/standing_wave.py
+++ b/openwave/xperiments/level0_granule_based/standing_wave.py
@@ -74,7 +74,7 @@ COLOR_THEME = "OCEAN"
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge)
 
-# DATA SAMPLING & DIAGNOSTICS ==================================
+# DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
 
@@ -242,7 +242,7 @@ def render_xperiment(lattice):
     granule_type = False  # Granule type coloring toggle
     ironbow = True  # Ironbow (displacement) coloring toggle
 
-    # Time tracking for radial harmonic oscillation of all granules
+    # Time tracking for harmonic oscillation of all granules
     elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics

--- a/openwave/xperiments/level0_granule_based/standing_wave.py
+++ b/openwave/xperiments/level0_granule_based/standing_wave.py
@@ -75,7 +75,7 @@ lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge)
 
 # DATA SAMPLING & DIAGNOSTICS ==================================
-max_displacement = 0.0  # Initialize granule max displacement (data sampling variable)
+peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
 
 # ================================================================
@@ -180,7 +180,7 @@ def color_menu():
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
             with render.gui.sub_window("displacement", 0.92, 0.70, 0.08, 0.06) as sub:
-                sub.text(f"0       {max_displacement:.0e}m")
+                sub.text(f"0       {peak_amplitude:.0e}m")
 
 
 # ================================================================
@@ -229,7 +229,7 @@ def render_xperiment(lattice):
     global granule_type, ironbow
     global elapsed_t, frame
     global normalized_position
-    global max_displacement
+    global peak_amplitude
 
     # Initialize UI control variables
     show_axis = False  # Toggle to show/hide axis lines
@@ -283,6 +283,7 @@ def render_xperiment(lattice):
             ewave.oscillate_granules(
                 lattice.position_am,  # Granule positions in attometers
                 lattice.equilibrium_am,  # Rest positions for all granules
+                lattice.amplitude_am,  # Granule amplitude in am
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
                 NUM_SOURCES,  # Number of active wave sources
@@ -299,7 +300,7 @@ def render_xperiment(lattice):
             # Update data sampling every 30 frames to reduce overhead
             if frame % 30 == 0:
                 ewave.update_lattice_energy(lattice)  # Update energy based on wave amplitude
-                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETER
+                peak_amplitude = ewave.peak_amplitude_am[None] * constants.ATTOMETER
 
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:

--- a/openwave/xperiments/level0_granule_based/wave_interference.py
+++ b/openwave/xperiments/level0_granule_based/wave_interference.py
@@ -78,7 +78,7 @@ lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge)
 
 # DATA SAMPLING & DIAGNOSTICS ==================================
-max_displacement = 0.0  # Initialize granule max displacement (data sampling variable)
+peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
 
 # ================================================================
@@ -183,7 +183,7 @@ def color_menu():
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
             with render.gui.sub_window("displacement", 0.92, 0.70, 0.08, 0.06) as sub:
-                sub.text(f"0       {max_displacement:.0e}m")
+                sub.text(f"0       {peak_amplitude:.0e}m")
 
 
 # ================================================================
@@ -232,7 +232,7 @@ def render_xperiment(lattice):
     global granule_type, ironbow
     global elapsed_t, frame
     global normalized_position
-    global max_displacement
+    global peak_amplitude
 
     # Initialize UI control variables
     show_axis = False  # Toggle to show/hide axis lines
@@ -286,6 +286,7 @@ def render_xperiment(lattice):
             ewave.oscillate_granules(
                 lattice.position_am,  # Granule positions in attometers
                 lattice.equilibrium_am,  # Rest positions for all granules
+                lattice.amplitude_am,  # Granule amplitude in am
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
                 NUM_SOURCES,  # Number of active wave sources
@@ -302,7 +303,7 @@ def render_xperiment(lattice):
             # Update data sampling every 30 frames to reduce overhead
             if frame % 30 == 0:
                 ewave.update_lattice_energy(lattice)  # Update energy based on wave amplitude
-                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETER
+                peak_amplitude = ewave.peak_amplitude_am[None] * constants.ATTOMETER
 
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:

--- a/openwave/xperiments/level0_granule_based/wave_interference.py
+++ b/openwave/xperiments/level0_granule_based/wave_interference.py
@@ -77,7 +77,7 @@ COLOR_THEME = "OCEAN"
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge)
 
-# DATA SAMPLING & DIAGNOSTICS ==================================
+# DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
 
@@ -245,7 +245,7 @@ def render_xperiment(lattice):
     granule_type = False  # Granule type coloring toggle
     ironbow = True  # Ironbow (displacement) coloring toggle
 
-    # Time tracking for radial harmonic oscillation of all granules
+    # Time tracking for harmonic oscillation of all granules
     elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics

--- a/openwave/xperiments/level0_granule_based/wave_pulse.py
+++ b/openwave/xperiments/level0_granule_based/wave_pulse.py
@@ -61,7 +61,7 @@ COLOR_THEME = "OCEAN"
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge)
 
-# DATA SAMPLING & DIAGNOSTICS ==================================
+# DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = True  # Toggle wave diagnostics (speed & wavelength measurements)
 
@@ -229,7 +229,7 @@ def render_xperiment(lattice):
     granule_type = False  # Granule type coloring toggle
     ironbow = False  # Ironbow (displacement) coloring toggle
 
-    # Time tracking for radial harmonic oscillation of all granules
+    # Time tracking for harmonic oscillation of all granules
     elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics

--- a/openwave/xperiments/level0_granule_based/wave_pulse.py
+++ b/openwave/xperiments/level0_granule_based/wave_pulse.py
@@ -62,7 +62,7 @@ lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge)
 
 # DATA SAMPLING & DIAGNOSTICS ==================================
-max_displacement = 0.0  # Initialize granule max displacement (data sampling variable)
+peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = True  # Toggle wave diagnostics (speed & wavelength measurements)
 
 # ================================================================
@@ -167,7 +167,7 @@ def color_menu():
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
             with render.gui.sub_window("displacement", 0.92, 0.70, 0.08, 0.06) as sub:
-                sub.text(f"0       {max_displacement:.0e}m")
+                sub.text(f"0       {peak_amplitude:.0e}m")
 
 
 # ================================================================
@@ -216,7 +216,7 @@ def render_xperiment(lattice):
     global granule_type, ironbow
     global elapsed_t, frame
     global normalized_position
-    global max_displacement
+    global peak_amplitude
 
     # Initialize UI control variables
     show_axis = True  # Toggle to show/hide axis lines
@@ -270,6 +270,7 @@ def render_xperiment(lattice):
             ewave.oscillate_granules(
                 lattice.position_am,  # Granule positions in attometers
                 lattice.equilibrium_am,  # Rest positions for all granules
+                lattice.amplitude_am,  # Granule amplitude in am
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
                 NUM_SOURCES,  # Number of active wave sources
@@ -286,7 +287,7 @@ def render_xperiment(lattice):
             # Update data sampling every 30 frames to reduce overhead
             if frame % 30 == 0:
                 ewave.update_lattice_energy(lattice)  # Update energy based on wave amplitude
-                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETER
+                peak_amplitude = ewave.peak_amplitude_am[None] * constants.ATTOMETER
 
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:

--- a/openwave/xperiments/level0_granule_based/xwaves.py
+++ b/openwave/xperiments/level0_granule_based/xwaves.py
@@ -83,7 +83,7 @@ lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge)
 
 # DATA SAMPLING & DIAGNOSTICS ==================================
-max_displacement = 0.0  # Initialize granule max displacement (data sampling variable)
+peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
 
 # ================================================================
@@ -188,7 +188,7 @@ def color_menu():
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
             with render.gui.sub_window("displacement", 0.92, 0.70, 0.08, 0.06) as sub:
-                sub.text(f"0       {max_displacement:.0e}m")
+                sub.text(f"0       {peak_amplitude:.0e}m")
 
 
 # ================================================================
@@ -237,7 +237,7 @@ def render_xperiment(lattice):
     global granule_type, ironbow
     global elapsed_t, frame
     global normalized_position
-    global max_displacement
+    global peak_amplitude
 
     # Initialize UI control variables
     show_axis = False  # Toggle to show/hide axis lines
@@ -291,6 +291,7 @@ def render_xperiment(lattice):
             ewave.oscillate_granules(
                 lattice.position_am,  # Granule positions in attometers
                 lattice.equilibrium_am,  # Rest positions for all granules
+                lattice.amplitude_am,  # Granule amplitude in am
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
                 NUM_SOURCES,  # Number of active wave sources
@@ -307,7 +308,7 @@ def render_xperiment(lattice):
             # Update data sampling every 30 frames to reduce overhead
             if frame % 30 == 0:
                 ewave.update_lattice_energy(lattice)  # Update energy based on wave amplitude
-                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETER
+                peak_amplitude = ewave.peak_amplitude_am[None] * constants.ATTOMETER
 
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:

--- a/openwave/xperiments/level0_granule_based/xwaves.py
+++ b/openwave/xperiments/level0_granule_based/xwaves.py
@@ -82,7 +82,7 @@ COLOR_THEME = "DESERT"
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge)
 
-# DATA SAMPLING & DIAGNOSTICS ==================================
+# DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
 
@@ -250,7 +250,7 @@ def render_xperiment(lattice):
     granule_type = True  # Granule type coloring toggle
     ironbow = False  # Ironbow (displacement) coloring toggle
 
-    # Time tracking for radial harmonic oscillation of all granules
+    # Time tracking for harmonic oscillation of all granules
     elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics

--- a/openwave/xperiments/level0_granule_based/yin_yang.py
+++ b/openwave/xperiments/level0_granule_based/yin_yang.py
@@ -77,7 +77,7 @@ lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge)
 
 # DATA SAMPLING & DIAGNOSTICS ==================================
-max_displacement = 0.0  # Initialize granule max displacement (data sampling variable)
+peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
 
 # ================================================================
@@ -182,7 +182,7 @@ def color_menu():
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
             with render.gui.sub_window("displacement", 0.92, 0.70, 0.08, 0.06) as sub:
-                sub.text(f"0       {max_displacement:.0e}m")
+                sub.text(f"0       {peak_amplitude:.0e}m")
 
 
 # ================================================================
@@ -231,7 +231,7 @@ def render_xperiment(lattice):
     global granule_type, ironbow
     global elapsed_t, frame
     global normalized_position
-    global max_displacement
+    global peak_amplitude
 
     # Initialize UI control variables
     show_axis = False  # Toggle to show/hide axis lines
@@ -285,6 +285,7 @@ def render_xperiment(lattice):
             ewave.oscillate_granules(
                 lattice.position_am,  # Granule positions in attometers
                 lattice.equilibrium_am,  # Rest positions for all granules
+                lattice.amplitude_am,  # Granule amplitude in am
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
                 NUM_SOURCES,  # Number of active wave sources
@@ -301,7 +302,7 @@ def render_xperiment(lattice):
             # Update data sampling every 30 frames to reduce overhead
             if frame % 30 == 0:
                 ewave.update_lattice_energy(lattice)  # Update energy based on wave amplitude
-                max_displacement = ewave.max_displacement_am_tracker[None] * constants.ATTOMETER
+                peak_amplitude = ewave.peak_amplitude_am[None] * constants.ATTOMETER
 
             # Wave diagnostics (minimal footprint)
             if WAVE_DIAGNOSTICS:

--- a/openwave/xperiments/level0_granule_based/yin_yang.py
+++ b/openwave/xperiments/level0_granule_based/yin_yang.py
@@ -76,7 +76,7 @@ COLOR_THEME = "OCEAN"
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge)
 
-# DATA SAMPLING & DIAGNOSTICS ==================================
+# DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
 
@@ -244,7 +244,7 @@ def render_xperiment(lattice):
     granule_type = True  # Granule type coloring toggle
     ironbow = False  # Ironbow (displacement) coloring toggle
 
-    # Time tracking for radial harmonic oscillation of all granules
+    # Time tracking for harmonic oscillation of all granules
     elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics

--- a/openwave/xperiments/level1_field_based/_docs/04_VISUALIZATION.md
+++ b/openwave/xperiments/level1_field_based/_docs/04_VISUALIZATION.md
@@ -55,6 +55,8 @@ LEVEL-1 visualization systems convert wave field data into observable visual rep
    - **Spray/Cloud Visualization**: Tiny particles display standing waves
    - **Standing Wave Rings**: Positioned at λ/2 intervals around wave centers
    - **Particle Radius**: Visualize one or two wavelengths around particles
+   - **Mesh Wireframe**: Use mesh wireframe to view see tru effects (sphere)
+   - **Target Lock**: Use small green>red squares (canvas.lines) to track positions
 
 3. **VECTOR/FLOW VISUALIZATION**:
    - **Taichi Lines**: Display vector fields (force, direction, amplitude gradient)


### PR DESCRIPTION
This pull request refactors how wave amplitude and displacement are tracked and named throughout the spacetime simulation codebase. The changes improve clarity by consistently using the term `peak_amplitude` instead of `max_displacement`, and introduce a dedicated per-granule amplitude field for more accurate diagnostics and analysis. The updates affect both the core wave engine and all experimental scripts, ensuring uniformity and easier maintenance going forward.

**Core wave engine improvements:**

* Renamed global variables in `openwave/spacetime/wave_engine_level0.py` from `amplitude_am` and `max_displacement_am_tracker` to `base_amplitude_am` and `peak_amplitude_am` for clearer distinction between base and peak values, and updated all related usages. [[1]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL21-R21) [[2]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL36-R36) [[3]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL80-R83) [[4]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL282-R302)
* Added a new per-granule field `amplitude_am` to the `BCCLattice` class in `openwave/spacetime/medium_level0.py` for tracking individual granule amplitudes, and updated the `oscillate_granules` function signature and documentation to accept this field. [[1]](diffhunk://#diff-a1d03c4ac0417a2333f0626af21ef55105994e9f2aead28872ed00e0758ea54dR155) [[2]](diffhunk://#diff-a1d03c4ac0417a2333f0626af21ef55105994e9f2aead28872ed00e0758ea54dR631) [[3]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aR123) [[4]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aR188) [[5]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aR276-R279)

**Experimental script consistency:**

* Replaced all instances of `max_displacement` with `peak_amplitude` in experimental scripts (`spacetime_vibration.py`, `spherical_wave.py`, `standing_wave.py`) for variable naming consistency and updated UI displays accordingly. [[1]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL85-R86) [[2]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL191-R191) [[3]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL240-R240) [[4]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL253-R253) [[5]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL310-R311) [[6]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L64-R65) [[7]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L170-R170) [[8]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L219-R219) [[9]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L232-R232) [[10]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L289-R290) [[11]](diffhunk://#diff-8db97d00a08512954d58ea87d77947aebd0a637a04326fddc47ad4938a0fcf8cL77-R78) [[12]](diffhunk://#diff-8db97d00a08512954d58ea87d77947aebd0a637a04326fddc47ad4938a0fcf8cL183-R183) [[13]](diffhunk://#diff-8db97d00a08512954d58ea87d77947aebd0a637a04326fddc47ad4938a0fcf8cL232-R232) [[14]](diffhunk://#diff-8db97d00a08512954d58ea87d77947aebd0a637a04326fddc47ad4938a0fcf8cL245-R245)
* Updated all experimental scripts to pass the new `amplitude_am` field to the `oscillate_granules` function for improved diagnostics and future extensibility. [[1]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dR294) [[2]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230R273) [[3]](diffhunk://#diff-8db97d00a08512954d58ea87d77947aebd0a637a04326fddc47ad4938a0fcf8cR286)

**Documentation and code comments:**

* Revised function and variable comments to reflect the new terminology and clarify the distinction between base amplitude, peak amplitude, and per-granule amplitude tracking. [[1]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aR188) [[2]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL253-R253) [[3]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L232-R232) [[4]](diffhunk://#diff-8db97d00a08512954d58ea87d77947aebd0a637a04326fddc47ad4938a0fcf8cL245-R245)

These changes collectively make the codebase more readable and maintainable, especially for diagnostics and future feature development.