### PR TITLE
Xperiments better encapsulation of functions

### DIFF
--- a/openwave/spacetime/medium_level0.py
+++ b/openwave/spacetime/medium_level0.py
@@ -26,13 +26,18 @@ class BCCGranule:
     Each granule has a defined radius and mass.
     """
 
-    def __init__(self, unit_cell_edge: float):
+    def __init__(self, unit_cell_edge: float, max_universe_edge: float):
         """Initialize scaled-up granule properties based on scaled-up unit cell edge length.
+        Normalize granule radius to 0-1 range for GGUI rendering.
 
         Args:
             unit_cell_edge: Edge length of the BCC unit-cell in meters.
+            max_universe_edge: Maximum edge length of the universe for normalization.
         """
         self.radius = unit_cell_edge / (2 * ti.math.e)  # radius = unit cell edge / 2e
+        self.radius_screen = max(
+            self.radius / max_universe_edge, 0.0001
+        )  # Ensure minimum 0.01% of screen radius for visibility
         self.mass = (
             constants.MEDIUM_DENSITY * unit_cell_edge**3 / 2
         )  # mass = medium density * scaled unit cell volume / 2 granules per BCC unit-cell
@@ -301,6 +306,7 @@ class BCCLattice:
             # Normalize to 0-1 range (positions are in attometers, scale them back)
             if enable_slice == 1 and self.front_octant[i] == 1:
                 # Block-slicing enabled: hide front octant granules by moving to origin
+                # hide front 1/8th of the lattice for see-through effect
                 self.position_screen[i] = ti.Vector([0.0, 0.0, 0.0])
             else:
                 # Normal rendering: normalize to 0-1 range
@@ -518,13 +524,18 @@ class SCGranule:
     Each granule has a defined radius and mass.
     """
 
-    def __init__(self, unit_cell_edge: float):
+    def __init__(self, unit_cell_edge: float, max_universe_edge: float):
         """Initialize scaled-up granule properties based on scaled-up unit cell edge length.
+        Normalize granule radius to 0-1 range for GGUI rendering.
 
         Args:
             unit_cell_edge: Edge length of the SC unit-cell in meters.
+            max_universe_edge: Maximum edge length of the universe for normalization.
         """
         self.radius = unit_cell_edge / (2 * ti.math.e)  # radius = unit cell edge / 2e
+        self.radius_screen = max(
+            self.radius / max_universe_edge, 0.0001
+        )  # Ensure minimum 0.01% of screen radius for visibility
         self.mass = constants.MEDIUM_DENSITY * unit_cell_edge**3  # medium density * cell volume
 
 
@@ -762,6 +773,7 @@ class SCLattice:
             # Normalize to 0-1 range (positions are in attometers, scale them back)
             if enable_slice == 1 and self.front_octant[i] == 1:
                 # Block-slicing enabled: hide front octant granules by moving to origin
+                # hide front 1/8th of the lattice for see-through effect
                 self.position_screen[i] = ti.Vector([0.0, 0.0, 0.0])
             else:
                 # Normal rendering: normalize to 0-1 range

--- a/openwave/spacetime/medium_level0.py
+++ b/openwave/spacetime/medium_level0.py
@@ -151,6 +151,7 @@ class BCCLattice:
         # position, velocity in attometers for f32 precision
         # This scales 1e-17 m values to ~10 am, well within f32 range
         self.position_am = ti.Vector.field(3, dtype=ti.f32, shape=self.total_granules)
+        self.position_screen = ti.Vector.field(3, dtype=ti.f32, shape=self.total_granules)
         self.equilibrium_am = ti.Vector.field(3, dtype=ti.f32, shape=self.total_granules)  # rest
         self.amplitude_am = ti.field(dtype=ti.f32, shape=self.total_granules)  # granule amplitude
         self.velocity_am = ti.Vector.field(3, dtype=ti.f32, shape=self.total_granules)
@@ -292,6 +293,18 @@ class BCCLattice:
                 )
                 else 0
             )
+
+    @ti.kernel
+    def normalize_to_screen(self, enable_slice: ti.i32):  # type: ignore
+        """Normalize lattice positions to 0-1 range for GGUI rendering."""
+        for i in range(self.total_granules):
+            # Normalize to 0-1 range (positions are in attometers, scale them back)
+            if enable_slice == 1 and self.front_octant[i] == 1:
+                # Block-slicing enabled: hide front octant granules by moving to origin
+                self.position_screen[i] = ti.Vector([0.0, 0.0, 0.0])
+            else:
+                # Normal rendering: normalize to 0-1 range
+                self.position_screen[i] = self.position_am[i] / self.max_universe_edge_am
 
     def set_granule_type_colorBCC(self, theme="OCEAN"):
         """Assign colors to granules based on their classified type and color theme.
@@ -627,6 +640,7 @@ class SCLattice:
         # position, velocity in attometers for f32 precision
         # This scales 1e-17 m values to ~10 am, well within f32 range
         self.position_am = ti.Vector.field(3, dtype=ti.f32, shape=self.total_granules)
+        self.position_screen = ti.Vector.field(3, dtype=ti.f32, shape=self.total_granules)
         self.equilibrium_am = ti.Vector.field(3, dtype=ti.f32, shape=self.total_granules)  # rest
         self.amplitude_am = ti.field(dtype=ti.f32, shape=self.total_granules)  # granule amplitude
         self.velocity_am = ti.Vector.field(3, dtype=ti.f32, shape=self.total_granules)
@@ -740,6 +754,18 @@ class SCLattice:
                 )
                 else 0
             )
+
+    @ti.kernel
+    def normalize_to_screen(self, enable_slice: ti.i32):  # type: ignore
+        """Normalize lattice positions to 0-1 range for GGUI rendering."""
+        for i in range(self.total_granules):
+            # Normalize to 0-1 range (positions are in attometers, scale them back)
+            if enable_slice == 1 and self.front_octant[i] == 1:
+                # Block-slicing enabled: hide front octant granules by moving to origin
+                self.position_screen[i] = ti.Vector([0.0, 0.0, 0.0])
+            else:
+                # Normal rendering: normalize to 0-1 range
+                self.position_screen[i] = self.position_am[i] / self.max_universe_edge_am
 
     def set_granule_type_colorSC(self, theme="OCEAN"):
         """Assign colors to granules based on their classified type and color theme.

--- a/openwave/xperiments/level0_granule_based/spacetime_vibration.py
+++ b/openwave/xperiments/level0_granule_based/spacetime_vibration.py
@@ -80,7 +80,7 @@ COLOR_THEME = "OCEAN"
 
 # Instantiate the lattice and granule objects (chose BCC or SC Lattice type)
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
-granule = medium.BCCGranule(lattice.unit_cell_edge)
+granule = medium.BCCGranule(lattice.unit_cell_edge, lattice.max_universe_edge)
 
 # DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
@@ -191,20 +191,6 @@ def color_menu():
 
 
 # ================================================================
-# Xperiment Normalization to Screen Coordinates
-# ================================================================
-
-
-def normalize_granule():
-    """Normalize granule radius to 0-1 range for GGUI rendering"""
-    global normalized_radius
-
-    normalized_radius = max(
-        granule.radius / lattice.max_universe_edge, 0.0001
-    )  # Ensure minimum 0.01% of screen radius for visibility
-
-
-# ================================================================
 # Xperiment Rendering
 # ================================================================
 
@@ -239,10 +225,6 @@ def render_xperiment(lattice):
     elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics
-
-    # Initialize normalized position (0-1 range for GGUI) & block-slicing
-    # block-slicing: hide front 1/8th of the lattice for see-through effect
-    normalize_granule()
 
     # Convert phase from degrees to radians for physics calculations
     # Conversion: radians = degrees × π/180
@@ -311,13 +293,13 @@ def render_xperiment(lattice):
         if granule_type:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
         elif ironbow:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
             # Display ironbow gradient palette
@@ -326,7 +308,7 @@ def render_xperiment(lattice):
         else:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 color=config.COLOR_MEDIUM[1],
             )
 
@@ -334,7 +316,7 @@ def render_xperiment(lattice):
         if show_sources:
             render.scene.particles(
                 centers=ewave.sources_pos_field,
-                radius=normalized_radius * 2,
+                radius=granule.radius_screen * 2,
                 color=config.COLOR_SOURCE[1],
             )
 

--- a/openwave/xperiments/level0_granule_based/spacetime_vibration.py
+++ b/openwave/xperiments/level0_granule_based/spacetime_vibration.py
@@ -222,12 +222,8 @@ def render_xperiment(lattice):
     """
     global elapsed_t, last_time, frame, peak_amplitude
 
-    # Convert phase from degrees to radians for physics calculations
-    # Conversion: radians = degrees × π/180
-    sources_phase_rad = [deg * ti.math.pi / 180 for deg in sources_phase_deg]
-
     ewave.build_source_vectors(
-        sources_position, sources_phase_rad, NUM_SOURCES, lattice
+        sources_position, sources_phase_deg, NUM_SOURCES, lattice
     )  # compute distance & direction vectors to all sources
 
     # Print diagnostics header if enabled

--- a/openwave/xperiments/level0_granule_based/spacetime_vibration.py
+++ b/openwave/xperiments/level0_granule_based/spacetime_vibration.py
@@ -82,6 +82,22 @@ COLOR_THEME = "OCEAN"
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge, lattice.max_universe_edge)
 
+# Initialize UI control variables
+show_axis = False  # Toggle to show/hide axis lines
+block_slice = False  # Block-slicing toggle
+show_sources = False  # Show wave sources toggle
+radius_factor = 0.5  # Initialize granule size factor
+freq_boost = 10.0  # Initialize frequency boost
+amp_boost = 1.0  # Initialize amplitude boost
+paused = False  # Pause toggle
+granule_type = True  # Granule type coloring toggle
+ironbow = False  # Ironbow (displacement) coloring toggle
+
+# Initialize time tracking for harmonic oscillations
+elapsed_t = 0.0
+last_time = time.time()
+frame = 0  # Frame counter for diagnostics
+
 # DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
@@ -204,27 +220,7 @@ def render_xperiment(lattice):
     Args:
         lattice: Lattice instance with positions, directions, and universe parameters
     """
-    global show_axis, block_slice, show_sources
-    global radius_factor, freq_boost, amp_boost, paused
-    global granule_type, ironbow
-    global elapsed_t, frame
-    global peak_amplitude
-
-    # Initialize UI control variables
-    show_axis = False  # Toggle to show/hide axis lines
-    block_slice = False  # Block-slicing toggle
-    show_sources = False  # Show wave sources toggle
-    radius_factor = 0.5  # Initialize granule size factor
-    freq_boost = 10.0  # Initialize frequency boost
-    amp_boost = 1.0  # Initialize amplitude boost
-    paused = False  # Pause toggle
-    granule_type = True  # Granule type coloring toggle
-    ironbow = False  # Ironbow (displacement) coloring toggle
-
-    # Time tracking for harmonic oscillation of all granules
-    elapsed_t = 0.0
-    last_time = time.time()
-    frame = 0  # Frame counter for diagnostics
+    global elapsed_t, last_time, frame, peak_amplitude
 
     # Convert phase from degrees to radians for physics calculations
     # Conversion: radians = degrees × π/180
@@ -248,8 +244,8 @@ def render_xperiment(lattice):
             # Calculate actual elapsed time (real-time tracking)
             current_time = time.time()
             dt_real = current_time - last_time
-            last_time = current_time
             elapsed_t += dt_real  # Use real elapsed time instead of fixed DT
+            last_time = current_time
 
             # Apply radial harmonic oscillation to all granules from multiple wave sources
             # Each granule receives wave contributions from all active sources

--- a/openwave/xperiments/level0_granule_based/spherical_wave.py
+++ b/openwave/xperiments/level0_granule_based/spherical_wave.py
@@ -201,12 +201,8 @@ def render_xperiment(lattice):
     """
     global elapsed_t, last_time, frame, peak_amplitude
 
-    # Convert phase from degrees to radians for physics calculations
-    # Conversion: radians = degrees × π/180
-    sources_phase_rad = [deg * ti.math.pi / 180 for deg in sources_phase_deg]
-
     ewave.build_source_vectors(
-        sources_position, sources_phase_rad, NUM_SOURCES, lattice
+        sources_position, sources_phase_deg, NUM_SOURCES, lattice
     )  # compute distance & direction vectors to all sources
 
     # Print diagnostics header if enabled

--- a/openwave/xperiments/level0_granule_based/spherical_wave.py
+++ b/openwave/xperiments/level0_granule_based/spherical_wave.py
@@ -86,7 +86,6 @@ def xperiment_specs():
 
 def data_dashboard():
     """Display simulation data dashboard."""
-
     with render.gui.sub_window("DATA-DASHBOARD", 0.00, 0.41, 0.19, 0.59) as sub:
         sub.text("--- WAVE-MEDIUM ---", color=config.LIGHT_BLUE[1])
         sub.text(f"Universe Size: {lattice.max_universe_edge:.1e} m (max edge)")
@@ -175,19 +174,6 @@ def color_menu():
 # ================================================================
 
 
-@ti.kernel
-def normalize_lattice(enable_slice: ti.i32):  # type: ignore
-    """Normalize lattice positions to 0-1 range for GGUI rendering."""
-    for i in range(lattice.total_granules):
-        # Normalize to 0-1 range (positions are in attometers, scale them back)
-        if enable_slice == 1 and lattice.front_octant[i] == 1:
-            # Block-slicing enabled: hide front octant granules by moving to origin
-            normalized_position[i] = ti.Vector([0.0, 0.0, 0.0])
-        else:
-            # Normal rendering: normalize to 0-1 range
-            normalized_position[i] = lattice.position_am[i] / lattice.max_universe_edge_am
-
-
 def normalize_granule():
     """Normalize granule radius to 0-1 range for GGUI rendering"""
     global normalized_radius
@@ -215,7 +201,6 @@ def render_xperiment(lattice):
     global radius_factor, freq_boost, amp_boost, paused
     global granule_type, ironbow
     global elapsed_t, frame
-    global normalized_position
     global peak_amplitude
 
     # Initialize UI control variables
@@ -236,7 +221,6 @@ def render_xperiment(lattice):
 
     # Initialize normalized position (0-1 range for GGUI) & block-slicing
     # block-slicing: hide front 1/8th of the lattice for see-through effect
-    normalized_position = ti.Vector.field(3, dtype=ti.f32, shape=lattice.total_granules)
     normalize_granule()
 
     # Convert phase from degrees to radians for physics calculations
@@ -281,7 +265,7 @@ def render_xperiment(lattice):
 
             # Update normalized positions for rendering (must happen after position updates)
             # with optional block-slicing (see-through effect)
-            normalize_lattice(1 if block_slice else 0)
+            lattice.normalize_to_screen(1 if block_slice else 0)
 
             # IN-FRAME DATA SAMPLING & DIAGNOSTICS ==================================
             # Update data sampling every 30 frames to reduce overhead
@@ -302,16 +286,16 @@ def render_xperiment(lattice):
             # Update last_time during pause to prevent time jump on resume
             last_time = time.time()
 
-        # Render granules with optional type-coloring
+        # Render granules with optional coloring
         if granule_type:
             render.scene.particles(
-                normalized_position,
+                lattice.position_screen,
                 radius=normalized_radius * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
         elif ironbow:
             render.scene.particles(
-                normalized_position,
+                lattice.position_screen,
                 radius=normalized_radius * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
@@ -320,7 +304,7 @@ def render_xperiment(lattice):
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
         else:
             render.scene.particles(
-                normalized_position,
+                lattice.position_screen,
                 radius=normalized_radius * radius_factor,
                 color=config.COLOR_MEDIUM[1],
             )

--- a/openwave/xperiments/level0_granule_based/spherical_wave.py
+++ b/openwave/xperiments/level0_granule_based/spherical_wave.py
@@ -59,7 +59,7 @@ COLOR_THEME = "OCEAN"
 
 # Instantiate the lattice and granule objects (chose BCC or SC Lattice type)
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
-granule = medium.BCCGranule(lattice.unit_cell_edge)
+granule = medium.BCCGranule(lattice.unit_cell_edge, lattice.max_universe_edge)
 
 # DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
@@ -170,20 +170,6 @@ def color_menu():
 
 
 # ================================================================
-# Xperiment Normalization to Screen Coordinates
-# ================================================================
-
-
-def normalize_granule():
-    """Normalize granule radius to 0-1 range for GGUI rendering"""
-    global normalized_radius
-
-    normalized_radius = max(
-        granule.radius / lattice.max_universe_edge, 0.0001
-    )  # Ensure minimum 0.01% of screen radius for visibility
-
-
-# ================================================================
 # Xperiment Rendering
 # ================================================================
 
@@ -218,10 +204,6 @@ def render_xperiment(lattice):
     elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics
-
-    # Initialize normalized position (0-1 range for GGUI) & block-slicing
-    # block-slicing: hide front 1/8th of the lattice for see-through effect
-    normalize_granule()
 
     # Convert phase from degrees to radians for physics calculations
     # Conversion: radians = degrees × π/180
@@ -290,13 +272,13 @@ def render_xperiment(lattice):
         if granule_type:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
         elif ironbow:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
             # Display ironbow gradient palette
@@ -305,7 +287,7 @@ def render_xperiment(lattice):
         else:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 color=config.COLOR_MEDIUM[1],
             )
 
@@ -313,7 +295,7 @@ def render_xperiment(lattice):
         if show_sources:
             render.scene.particles(
                 centers=ewave.sources_pos_field,
-                radius=normalized_radius * 2,
+                radius=granule.radius_screen * 2,
                 color=config.COLOR_SOURCE[1],
             )
 

--- a/openwave/xperiments/level0_granule_based/spherical_wave.py
+++ b/openwave/xperiments/level0_granule_based/spherical_wave.py
@@ -61,6 +61,22 @@ COLOR_THEME = "OCEAN"
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge, lattice.max_universe_edge)
 
+# Initialize UI control variables
+show_axis = True  # Toggle to show/hide axis lines
+block_slice = True  # Block-slicing toggle
+show_sources = False  # Show wave sources toggle
+radius_factor = 0.4  # Initialize granule size factor
+freq_boost = 1.0  # Initialize frequency boost
+amp_boost = 5.0  # Initialize amplitude boost
+paused = False  # Pause toggle
+granule_type = False  # Granule type coloring toggle
+ironbow = False  # Ironbow (displacement) coloring toggle
+
+# Initialize time tracking for harmonic oscillations
+elapsed_t = 0.0
+last_time = time.time()
+frame = 0  # Frame counter for diagnostics
+
 # DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
@@ -183,27 +199,7 @@ def render_xperiment(lattice):
     Args:
         lattice: Lattice instance with positions, directions, and universe parameters
     """
-    global show_axis, block_slice, show_sources
-    global radius_factor, freq_boost, amp_boost, paused
-    global granule_type, ironbow
-    global elapsed_t, frame
-    global peak_amplitude
-
-    # Initialize UI control variables
-    show_axis = True  # Toggle to show/hide axis lines
-    block_slice = True  # Block-slicing toggle
-    show_sources = False  # Show wave sources toggle
-    radius_factor = 0.4  # Initialize granule size factor
-    freq_boost = 1.0  # Initialize frequency boost
-    amp_boost = 5.0  # Initialize amplitude boost
-    paused = False  # Pause toggle
-    granule_type = False  # Granule type coloring toggle
-    ironbow = False  # Ironbow (displacement) coloring toggle
-
-    # Time tracking for harmonic oscillation of all granules
-    elapsed_t = 0.0
-    last_time = time.time()
-    frame = 0  # Frame counter for diagnostics
+    global elapsed_t, last_time, frame, peak_amplitude
 
     # Convert phase from degrees to radians for physics calculations
     # Conversion: radians = degrees × π/180
@@ -227,8 +223,8 @@ def render_xperiment(lattice):
             # Calculate actual elapsed time (real-time tracking)
             current_time = time.time()
             dt_real = current_time - last_time
-            last_time = current_time
             elapsed_t += dt_real  # Use real elapsed time instead of fixed DT
+            last_time = current_time
 
             # Apply radial harmonic oscillation to all granules from multiple wave sources
             # Each granule receives wave contributions from all active sources

--- a/openwave/xperiments/level0_granule_based/standing_wave.py
+++ b/openwave/xperiments/level0_granule_based/standing_wave.py
@@ -74,6 +74,22 @@ COLOR_THEME = "OCEAN"
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge, lattice.max_universe_edge)
 
+# Initialize UI control variables
+show_axis = False  # Toggle to show/hide axis lines
+block_slice = False  # Block-slicing toggle
+show_sources = False  # Show wave sources toggle
+radius_factor = 1.0  # Initialize granule size factor
+freq_boost = 0.5  # Initialize frequency boost
+amp_boost = 0.1  # Initialize amplitude boost
+paused = False  # Pause toggle
+granule_type = False  # Granule type coloring toggle
+ironbow = True  # Ironbow (displacement) coloring toggle
+
+# Initialize time tracking for harmonic oscillations
+elapsed_t = 0.0
+last_time = time.time()
+frame = 0  # Frame counter for diagnostics
+
 # DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
@@ -196,27 +212,7 @@ def render_xperiment(lattice):
     Args:
         lattice: Lattice instance with positions, directions, and universe parameters
     """
-    global show_axis, block_slice, show_sources
-    global radius_factor, freq_boost, amp_boost, paused
-    global granule_type, ironbow
-    global elapsed_t, frame
-    global peak_amplitude
-
-    # Initialize UI control variables
-    show_axis = False  # Toggle to show/hide axis lines
-    block_slice = False  # Block-slicing toggle
-    show_sources = False  # Show wave sources toggle
-    radius_factor = 1.0  # Initialize granule size factor
-    freq_boost = 0.5  # Initialize frequency boost
-    amp_boost = 0.1  # Initialize amplitude boost
-    paused = False  # Pause toggle
-    granule_type = False  # Granule type coloring toggle
-    ironbow = True  # Ironbow (displacement) coloring toggle
-
-    # Time tracking for harmonic oscillation of all granules
-    elapsed_t = 0.0
-    last_time = time.time()
-    frame = 0  # Frame counter for diagnostics
+    global elapsed_t, last_time, frame, peak_amplitude
 
     # Convert phase from degrees to radians for physics calculations
     # Conversion: radians = degrees × π/180
@@ -240,8 +236,8 @@ def render_xperiment(lattice):
             # Calculate actual elapsed time (real-time tracking)
             current_time = time.time()
             dt_real = current_time - last_time
-            last_time = current_time
             elapsed_t += dt_real  # Use real elapsed time instead of fixed DT
+            last_time = current_time
 
             # Apply radial harmonic oscillation to all granules from multiple wave sources
             # Each granule receives wave contributions from all active sources

--- a/openwave/xperiments/level0_granule_based/standing_wave.py
+++ b/openwave/xperiments/level0_granule_based/standing_wave.py
@@ -72,7 +72,7 @@ COLOR_THEME = "OCEAN"
 
 # Instantiate the lattice and granule objects (chose BCC or SC Lattice type)
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
-granule = medium.BCCGranule(lattice.unit_cell_edge)
+granule = medium.BCCGranule(lattice.unit_cell_edge, lattice.max_universe_edge)
 
 # DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
@@ -183,20 +183,6 @@ def color_menu():
 
 
 # ================================================================
-# Xperiment Normalization to Screen Coordinates
-# ================================================================
-
-
-def normalize_granule():
-    """Normalize granule radius to 0-1 range for GGUI rendering"""
-    global normalized_radius
-
-    normalized_radius = max(
-        granule.radius / lattice.max_universe_edge, 0.0001
-    )  # Ensure minimum 0.01% of screen radius for visibility
-
-
-# ================================================================
 # Xperiment Rendering
 # ================================================================
 
@@ -231,10 +217,6 @@ def render_xperiment(lattice):
     elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics
-
-    # Initialize normalized position (0-1 range for GGUI) & block-slicing
-    # block-slicing: hide front 1/8th of the lattice for see-through effect
-    normalize_granule()
 
     # Convert phase from degrees to radians for physics calculations
     # Conversion: radians = degrees × π/180
@@ -303,19 +285,19 @@ def render_xperiment(lattice):
         if granule_type:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
         elif ironbow:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
         else:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 color=config.COLOR_MEDIUM[1],
             )
 
@@ -323,7 +305,7 @@ def render_xperiment(lattice):
         if show_sources:
             render.scene.particles(
                 centers=ewave.sources_pos_field,
-                radius=normalized_radius * 2,
+                radius=granule.radius_screen * 2,
                 color=config.COLOR_SOURCE[1],
             )
 

--- a/openwave/xperiments/level0_granule_based/standing_wave.py
+++ b/openwave/xperiments/level0_granule_based/standing_wave.py
@@ -214,12 +214,8 @@ def render_xperiment(lattice):
     """
     global elapsed_t, last_time, frame, peak_amplitude
 
-    # Convert phase from degrees to radians for physics calculations
-    # Conversion: radians = degrees × π/180
-    sources_phase_rad = [deg * ti.math.pi / 180 for deg in sources_phase_deg]
-
     ewave.build_source_vectors(
-        sources_position, sources_phase_rad, NUM_SOURCES, lattice
+        sources_position, sources_phase_deg, NUM_SOURCES, lattice
     )  # compute distance & direction vectors to all sources
 
     # Print diagnostics header if enabled

--- a/openwave/xperiments/level0_granule_based/standing_wave.py
+++ b/openwave/xperiments/level0_granule_based/standing_wave.py
@@ -99,7 +99,6 @@ def xperiment_specs():
 
 def data_dashboard():
     """Display simulation data dashboard."""
-
     with render.gui.sub_window("DATA-DASHBOARD", 0.00, 0.41, 0.19, 0.59) as sub:
         sub.text("--- WAVE-MEDIUM ---", color=config.LIGHT_BLUE[1])
         sub.text(f"Universe Size: {lattice.max_universe_edge:.1e} m (max edge)")
@@ -188,19 +187,6 @@ def color_menu():
 # ================================================================
 
 
-@ti.kernel
-def normalize_lattice(enable_slice: ti.i32):  # type: ignore
-    """Normalize lattice positions to 0-1 range for GGUI rendering."""
-    for i in range(lattice.total_granules):
-        # Normalize to 0-1 range (positions are in attometers, scale them back)
-        if enable_slice == 1 and lattice.front_octant[i] == 1:
-            # Block-slicing enabled: hide front octant granules by moving to origin
-            normalized_position[i] = ti.Vector([0.0, 0.0, 0.0])
-        else:
-            # Normal rendering: normalize to 0-1 range
-            normalized_position[i] = lattice.position_am[i] / lattice.max_universe_edge_am
-
-
 def normalize_granule():
     """Normalize granule radius to 0-1 range for GGUI rendering"""
     global normalized_radius
@@ -228,7 +214,6 @@ def render_xperiment(lattice):
     global radius_factor, freq_boost, amp_boost, paused
     global granule_type, ironbow
     global elapsed_t, frame
-    global normalized_position
     global peak_amplitude
 
     # Initialize UI control variables
@@ -249,7 +234,6 @@ def render_xperiment(lattice):
 
     # Initialize normalized position (0-1 range for GGUI) & block-slicing
     # block-slicing: hide front 1/8th of the lattice for see-through effect
-    normalized_position = ti.Vector.field(3, dtype=ti.f32, shape=lattice.total_granules)
     normalize_granule()
 
     # Convert phase from degrees to radians for physics calculations
@@ -294,7 +278,7 @@ def render_xperiment(lattice):
 
             # Update normalized positions for rendering (must happen after position updates)
             # with optional block-slicing (see-through effect)
-            normalize_lattice(1 if block_slice else 0)
+            lattice.normalize_to_screen(1 if block_slice else 0)
 
             # IN-FRAME DATA SAMPLING & DIAGNOSTICS ==================================
             # Update data sampling every 30 frames to reduce overhead
@@ -315,22 +299,22 @@ def render_xperiment(lattice):
             # Update last_time during pause to prevent time jump on resume
             last_time = time.time()
 
-        # Render granules with optional type-coloring
+        # Render granules with optional coloring
         if granule_type:
             render.scene.particles(
-                normalized_position,
+                lattice.position_screen,
                 radius=normalized_radius * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
         elif ironbow:
             render.scene.particles(
-                normalized_position,
+                lattice.position_screen,
                 radius=normalized_radius * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
         else:
             render.scene.particles(
-                normalized_position,
+                lattice.position_screen,
                 radius=normalized_radius * radius_factor,
                 color=config.COLOR_MEDIUM[1],
             )

--- a/openwave/xperiments/level0_granule_based/wave_interference.py
+++ b/openwave/xperiments/level0_granule_based/wave_interference.py
@@ -217,12 +217,8 @@ def render_xperiment(lattice):
     """
     global elapsed_t, last_time, frame, peak_amplitude
 
-    # Convert phase from degrees to radians for physics calculations
-    # Conversion: radians = degrees × π/180
-    sources_phase_rad = [deg * ti.math.pi / 180 for deg in sources_phase_deg]
-
     ewave.build_source_vectors(
-        sources_position, sources_phase_rad, NUM_SOURCES, lattice
+        sources_position, sources_phase_deg, NUM_SOURCES, lattice
     )  # compute distance & direction vectors to all sources
 
     # Print diagnostics header if enabled

--- a/openwave/xperiments/level0_granule_based/wave_interference.py
+++ b/openwave/xperiments/level0_granule_based/wave_interference.py
@@ -77,6 +77,22 @@ COLOR_THEME = "OCEAN"
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge, lattice.max_universe_edge)
 
+# Initialize UI control variables
+show_axis = False  # Toggle to show/hide axis lines
+block_slice = False  # Block-slicing toggle
+show_sources = True  # Show wave sources toggle
+radius_factor = 1.0  # Initialize granule size factor
+freq_boost = 1.0  # Initialize frequency boost
+amp_boost = 1.0  # Initialize amplitude boost
+paused = False  # Pause toggle
+granule_type = False  # Granule type coloring toggle
+ironbow = True  # Ironbow (displacement) coloring toggle
+
+# Initialize time tracking for harmonic oscillations
+elapsed_t = 0.0
+last_time = time.time()
+frame = 0  # Frame counter for diagnostics
+
 # DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
@@ -199,27 +215,7 @@ def render_xperiment(lattice):
     Args:
         lattice: Lattice instance with positions, directions, and universe parameters
     """
-    global show_axis, block_slice, show_sources
-    global radius_factor, freq_boost, amp_boost, paused
-    global granule_type, ironbow
-    global elapsed_t, frame
-    global peak_amplitude
-
-    # Initialize UI control variables
-    show_axis = False  # Toggle to show/hide axis lines
-    block_slice = False  # Block-slicing toggle
-    show_sources = True  # Show wave sources toggle
-    radius_factor = 1.0  # Initialize granule size factor
-    freq_boost = 1.0  # Initialize frequency boost
-    amp_boost = 1.0  # Initialize amplitude boost
-    paused = False  # Pause toggle
-    granule_type = False  # Granule type coloring toggle
-    ironbow = True  # Ironbow (displacement) coloring toggle
-
-    # Time tracking for harmonic oscillation of all granules
-    elapsed_t = 0.0
-    last_time = time.time()
-    frame = 0  # Frame counter for diagnostics
+    global elapsed_t, last_time, frame, peak_amplitude
 
     # Convert phase from degrees to radians for physics calculations
     # Conversion: radians = degrees × π/180
@@ -243,8 +239,8 @@ def render_xperiment(lattice):
             # Calculate actual elapsed time (real-time tracking)
             current_time = time.time()
             dt_real = current_time - last_time
-            last_time = current_time
             elapsed_t += dt_real  # Use real elapsed time instead of fixed DT
+            last_time = current_time
 
             # Apply radial harmonic oscillation to all granules from multiple wave sources
             # Each granule receives wave contributions from all active sources

--- a/openwave/xperiments/level0_granule_based/wave_interference.py
+++ b/openwave/xperiments/level0_granule_based/wave_interference.py
@@ -75,7 +75,7 @@ COLOR_THEME = "OCEAN"
 
 # Instantiate the lattice and granule objects (chose BCC or SC Lattice type)
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
-granule = medium.BCCGranule(lattice.unit_cell_edge)
+granule = medium.BCCGranule(lattice.unit_cell_edge, lattice.max_universe_edge)
 
 # DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
@@ -186,20 +186,6 @@ def color_menu():
 
 
 # ================================================================
-# Xperiment Normalization to Screen Coordinates
-# ================================================================
-
-
-def normalize_granule():
-    """Normalize granule radius to 0-1 range for GGUI rendering"""
-    global normalized_radius
-
-    normalized_radius = max(
-        granule.radius / lattice.max_universe_edge, 0.0001
-    )  # Ensure minimum 0.01% of screen radius for visibility
-
-
-# ================================================================
 # Xperiment Rendering
 # ================================================================
 
@@ -234,10 +220,6 @@ def render_xperiment(lattice):
     elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics
-
-    # Initialize normalized position (0-1 range for GGUI) & block-slicing
-    # block-slicing: hide front 1/8th of the lattice for see-through effect
-    normalize_granule()
 
     # Convert phase from degrees to radians for physics calculations
     # Conversion: radians = degrees × π/180
@@ -306,13 +288,13 @@ def render_xperiment(lattice):
         if granule_type:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
         elif ironbow:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
             # Display ironbow gradient palette
@@ -321,7 +303,7 @@ def render_xperiment(lattice):
         else:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 color=config.COLOR_MEDIUM[1],
             )
 
@@ -329,7 +311,7 @@ def render_xperiment(lattice):
         if show_sources:
             render.scene.particles(
                 centers=ewave.sources_pos_field,
-                radius=normalized_radius * 2,
+                radius=granule.radius_screen * 2,
                 color=config.COLOR_SOURCE[1],
             )
 

--- a/openwave/xperiments/level0_granule_based/wave_interference.py
+++ b/openwave/xperiments/level0_granule_based/wave_interference.py
@@ -102,7 +102,6 @@ def xperiment_specs():
 
 def data_dashboard():
     """Display simulation data dashboard."""
-
     with render.gui.sub_window("DATA-DASHBOARD", 0.00, 0.41, 0.19, 0.59) as sub:
         sub.text("--- WAVE-MEDIUM ---", color=config.LIGHT_BLUE[1])
         sub.text(f"Universe Size: {lattice.max_universe_edge:.1e} m (max edge)")
@@ -191,19 +190,6 @@ def color_menu():
 # ================================================================
 
 
-@ti.kernel
-def normalize_lattice(enable_slice: ti.i32):  # type: ignore
-    """Normalize lattice positions to 0-1 range for GGUI rendering."""
-    for i in range(lattice.total_granules):
-        # Normalize to 0-1 range (positions are in attometers, scale them back)
-        if enable_slice == 1 and lattice.front_octant[i] == 1:
-            # Block-slicing enabled: hide front octant granules by moving to origin
-            normalized_position[i] = ti.Vector([0.0, 0.0, 0.0])
-        else:
-            # Normal rendering: normalize to 0-1 range
-            normalized_position[i] = lattice.position_am[i] / lattice.max_universe_edge_am
-
-
 def normalize_granule():
     """Normalize granule radius to 0-1 range for GGUI rendering"""
     global normalized_radius
@@ -231,7 +217,6 @@ def render_xperiment(lattice):
     global radius_factor, freq_boost, amp_boost, paused
     global granule_type, ironbow
     global elapsed_t, frame
-    global normalized_position
     global peak_amplitude
 
     # Initialize UI control variables
@@ -252,7 +237,6 @@ def render_xperiment(lattice):
 
     # Initialize normalized position (0-1 range for GGUI) & block-slicing
     # block-slicing: hide front 1/8th of the lattice for see-through effect
-    normalized_position = ti.Vector.field(3, dtype=ti.f32, shape=lattice.total_granules)
     normalize_granule()
 
     # Convert phase from degrees to radians for physics calculations
@@ -297,7 +281,7 @@ def render_xperiment(lattice):
 
             # Update normalized positions for rendering (must happen after position updates)
             # with optional block-slicing (see-through effect)
-            normalize_lattice(1 if block_slice else 0)
+            lattice.normalize_to_screen(1 if block_slice else 0)
 
             # IN-FRAME DATA SAMPLING & DIAGNOSTICS ==================================
             # Update data sampling every 30 frames to reduce overhead
@@ -318,16 +302,16 @@ def render_xperiment(lattice):
             # Update last_time during pause to prevent time jump on resume
             last_time = time.time()
 
-        # Render granules with optional type-coloring
+        # Render granules with optional coloring
         if granule_type:
             render.scene.particles(
-                normalized_position,
+                lattice.position_screen,
                 radius=normalized_radius * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
         elif ironbow:
             render.scene.particles(
-                normalized_position,
+                lattice.position_screen,
                 radius=normalized_radius * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
@@ -336,7 +320,7 @@ def render_xperiment(lattice):
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
         else:
             render.scene.particles(
-                normalized_position,
+                lattice.position_screen,
                 radius=normalized_radius * radius_factor,
                 color=config.COLOR_MEDIUM[1],
             )

--- a/openwave/xperiments/level0_granule_based/wave_pulse.py
+++ b/openwave/xperiments/level0_granule_based/wave_pulse.py
@@ -201,12 +201,8 @@ def render_xperiment(lattice):
     """
     global elapsed_t, last_time, frame, peak_amplitude
 
-    # Convert phase from degrees to radians for physics calculations
-    # Conversion: radians = degrees × π/180
-    sources_phase_rad = [deg * ti.math.pi / 180 for deg in sources_phase_deg]
-
     ewave.build_source_vectors(
-        sources_position, sources_phase_rad, NUM_SOURCES, lattice
+        sources_position, sources_phase_deg, NUM_SOURCES, lattice
     )  # compute distance & direction vectors to all sources
 
     # Print diagnostics header if enabled

--- a/openwave/xperiments/level0_granule_based/wave_pulse.py
+++ b/openwave/xperiments/level0_granule_based/wave_pulse.py
@@ -61,6 +61,22 @@ COLOR_THEME = "OCEAN"
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge, lattice.max_universe_edge)
 
+# Initialize UI control variables
+show_axis = True  # Toggle to show/hide axis lines
+block_slice = False  # Block-slicing toggle
+show_sources = False  # Show wave sources toggle
+radius_factor = 0.1  # Initialize granule size factor
+freq_boost = 10.0  # Initialize frequency boost
+amp_boost = 5.0  # Initialize amplitude boost
+paused = False  # Pause toggle
+granule_type = False  # Granule type coloring toggle
+ironbow = False  # Ironbow (displacement) coloring toggle
+
+# Initialize time tracking for harmonic oscillations
+elapsed_t = 0.0
+last_time = time.time()
+frame = 0  # Frame counter for diagnostics
+
 # DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = True  # Toggle wave diagnostics (speed & wavelength measurements)
@@ -183,27 +199,7 @@ def render_xperiment(lattice):
     Args:
         lattice: Lattice instance with positions, directions, and universe parameters
     """
-    global show_axis, block_slice, show_sources
-    global radius_factor, freq_boost, amp_boost, paused
-    global granule_type, ironbow
-    global elapsed_t, frame
-    global peak_amplitude
-
-    # Initialize UI control variables
-    show_axis = True  # Toggle to show/hide axis lines
-    block_slice = False  # Block-slicing toggle
-    show_sources = False  # Show wave sources toggle
-    radius_factor = 0.1  # Initialize granule size factor
-    freq_boost = 10.0  # Initialize frequency boost
-    amp_boost = 5.0  # Initialize amplitude boost
-    paused = False  # Pause toggle
-    granule_type = False  # Granule type coloring toggle
-    ironbow = False  # Ironbow (displacement) coloring toggle
-
-    # Time tracking for harmonic oscillation of all granules
-    elapsed_t = 0.0
-    last_time = time.time()
-    frame = 0  # Frame counter for diagnostics
+    global elapsed_t, last_time, frame, peak_amplitude
 
     # Convert phase from degrees to radians for physics calculations
     # Conversion: radians = degrees × π/180
@@ -227,8 +223,8 @@ def render_xperiment(lattice):
             # Calculate actual elapsed time (real-time tracking)
             current_time = time.time()
             dt_real = current_time - last_time
-            last_time = current_time
             elapsed_t += dt_real  # Use real elapsed time instead of fixed DT
+            last_time = current_time
 
             # Apply radial harmonic oscillation to all granules from multiple wave sources
             # Each granule receives wave contributions from all active sources

--- a/openwave/xperiments/level0_granule_based/wave_pulse.py
+++ b/openwave/xperiments/level0_granule_based/wave_pulse.py
@@ -86,7 +86,6 @@ def xperiment_specs():
 
 def data_dashboard():
     """Display simulation data dashboard."""
-
     with render.gui.sub_window("DATA-DASHBOARD", 0.00, 0.41, 0.19, 0.59) as sub:
         sub.text("--- WAVE-MEDIUM ---", color=config.LIGHT_BLUE[1])
         sub.text(f"Universe Size: {lattice.max_universe_edge:.1e} m (max edge)")
@@ -175,19 +174,6 @@ def color_menu():
 # ================================================================
 
 
-@ti.kernel
-def normalize_lattice(enable_slice: ti.i32):  # type: ignore
-    """Normalize lattice positions to 0-1 range for GGUI rendering."""
-    for i in range(lattice.total_granules):
-        # Normalize to 0-1 range (positions are in attometers, scale them back)
-        if enable_slice == 1 and lattice.front_octant[i] == 1:
-            # Block-slicing enabled: hide front octant granules by moving to origin
-            normalized_position[i] = ti.Vector([0.0, 0.0, 0.0])
-        else:
-            # Normal rendering: normalize to 0-1 range
-            normalized_position[i] = lattice.position_am[i] / lattice.max_universe_edge_am
-
-
 def normalize_granule():
     """Normalize granule radius to 0-1 range for GGUI rendering"""
     global normalized_radius
@@ -215,7 +201,6 @@ def render_xperiment(lattice):
     global radius_factor, freq_boost, amp_boost, paused
     global granule_type, ironbow
     global elapsed_t, frame
-    global normalized_position
     global peak_amplitude
 
     # Initialize UI control variables
@@ -236,7 +221,6 @@ def render_xperiment(lattice):
 
     # Initialize normalized position (0-1 range for GGUI) & block-slicing
     # block-slicing: hide front 1/8th of the lattice for see-through effect
-    normalized_position = ti.Vector.field(3, dtype=ti.f32, shape=lattice.total_granules)
     normalize_granule()
 
     # Convert phase from degrees to radians for physics calculations
@@ -281,7 +265,7 @@ def render_xperiment(lattice):
 
             # Update normalized positions for rendering (must happen after position updates)
             # with optional block-slicing (see-through effect)
-            normalize_lattice(1 if block_slice else 0)
+            lattice.normalize_to_screen(1 if block_slice else 0)
 
             # IN-FRAME DATA SAMPLING & DIAGNOSTICS ==================================
             # Update data sampling every 30 frames to reduce overhead
@@ -302,16 +286,16 @@ def render_xperiment(lattice):
             # Update last_time during pause to prevent time jump on resume
             last_time = time.time()
 
-        # Render granules with optional type-coloring
+        # Render granules with optional coloring
         if granule_type:
             render.scene.particles(
-                normalized_position,
+                lattice.position_screen,
                 radius=normalized_radius * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
         elif ironbow:
             render.scene.particles(
-                normalized_position,
+                lattice.position_screen,
                 radius=normalized_radius * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
@@ -320,7 +304,7 @@ def render_xperiment(lattice):
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
         else:
             render.scene.particles(
-                normalized_position,
+                lattice.position_screen,
                 radius=normalized_radius * radius_factor,
                 color=config.COLOR_MEDIUM[1],
             )

--- a/openwave/xperiments/level0_granule_based/wave_pulse.py
+++ b/openwave/xperiments/level0_granule_based/wave_pulse.py
@@ -59,7 +59,7 @@ COLOR_THEME = "OCEAN"
 
 # Instantiate the lattice and granule objects (chose BCC or SC Lattice type)
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
-granule = medium.BCCGranule(lattice.unit_cell_edge)
+granule = medium.BCCGranule(lattice.unit_cell_edge, lattice.max_universe_edge)
 
 # DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
@@ -170,20 +170,6 @@ def color_menu():
 
 
 # ================================================================
-# Xperiment Normalization to Screen Coordinates
-# ================================================================
-
-
-def normalize_granule():
-    """Normalize granule radius to 0-1 range for GGUI rendering"""
-    global normalized_radius
-
-    normalized_radius = max(
-        granule.radius / lattice.max_universe_edge, 0.0001
-    )  # Ensure minimum 0.01% of screen radius for visibility
-
-
-# ================================================================
 # Xperiment Rendering
 # ================================================================
 
@@ -218,10 +204,6 @@ def render_xperiment(lattice):
     elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics
-
-    # Initialize normalized position (0-1 range for GGUI) & block-slicing
-    # block-slicing: hide front 1/8th of the lattice for see-through effect
-    normalize_granule()
 
     # Convert phase from degrees to radians for physics calculations
     # Conversion: radians = degrees × π/180
@@ -290,13 +272,13 @@ def render_xperiment(lattice):
         if granule_type:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
         elif ironbow:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
             # Display ironbow gradient palette
@@ -305,7 +287,7 @@ def render_xperiment(lattice):
         else:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 color=config.COLOR_MEDIUM[1],
             )
 
@@ -313,7 +295,7 @@ def render_xperiment(lattice):
         if show_sources:
             render.scene.particles(
                 centers=ewave.sources_pos_field,
-                radius=normalized_radius * 2,
+                radius=granule.radius_screen * 2,
                 color=config.COLOR_SOURCE[1],
             )
 

--- a/openwave/xperiments/level0_granule_based/xwaves.py
+++ b/openwave/xperiments/level0_granule_based/xwaves.py
@@ -82,6 +82,22 @@ COLOR_THEME = "DESERT"
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge, lattice.max_universe_edge)
 
+# Initialize UI control variables
+show_axis = False  # Toggle to show/hide axis lines
+block_slice = False  # Block-slicing toggle
+show_sources = True  # Show wave sources toggle
+radius_factor = 1.0  # Initialize granule size factor
+freq_boost = 1.0  # Initialize frequency boost
+amp_boost = 5.0  # Initialize amplitude boost
+paused = False  # Pause toggle
+granule_type = True  # Granule type coloring toggle
+ironbow = False  # Ironbow (displacement) coloring toggle
+
+# Initialize time tracking for harmonic oscillations
+elapsed_t = 0.0
+last_time = time.time()
+frame = 0  # Frame counter for diagnostics
+
 # DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
@@ -204,27 +220,7 @@ def render_xperiment(lattice):
     Args:
         lattice: Lattice instance with positions, directions, and universe parameters
     """
-    global show_axis, block_slice, show_sources
-    global radius_factor, freq_boost, amp_boost, paused
-    global granule_type, ironbow
-    global elapsed_t, frame
-    global peak_amplitude
-
-    # Initialize UI control variables
-    show_axis = False  # Toggle to show/hide axis lines
-    block_slice = False  # Block-slicing toggle
-    show_sources = True  # Show wave sources toggle
-    radius_factor = 1.0  # Initialize granule size factor
-    freq_boost = 1.0  # Initialize frequency boost
-    amp_boost = 5.0  # Initialize amplitude boost
-    paused = False  # Pause toggle
-    granule_type = True  # Granule type coloring toggle
-    ironbow = False  # Ironbow (displacement) coloring toggle
-
-    # Time tracking for harmonic oscillation of all granules
-    elapsed_t = 0.0
-    last_time = time.time()
-    frame = 0  # Frame counter for diagnostics
+    global elapsed_t, last_time, frame, peak_amplitude
 
     # Convert phase from degrees to radians for physics calculations
     # Conversion: radians = degrees × π/180
@@ -248,8 +244,8 @@ def render_xperiment(lattice):
             # Calculate actual elapsed time (real-time tracking)
             current_time = time.time()
             dt_real = current_time - last_time
-            last_time = current_time
             elapsed_t += dt_real  # Use real elapsed time instead of fixed DT
+            last_time = current_time
 
             # Apply radial harmonic oscillation to all granules from multiple wave sources
             # Each granule receives wave contributions from all active sources

--- a/openwave/xperiments/level0_granule_based/xwaves.py
+++ b/openwave/xperiments/level0_granule_based/xwaves.py
@@ -222,12 +222,8 @@ def render_xperiment(lattice):
     """
     global elapsed_t, last_time, frame, peak_amplitude
 
-    # Convert phase from degrees to radians for physics calculations
-    # Conversion: radians = degrees × π/180
-    sources_phase_rad = [deg * ti.math.pi / 180 for deg in sources_phase_deg]
-
     ewave.build_source_vectors(
-        sources_position, sources_phase_rad, NUM_SOURCES, lattice
+        sources_position, sources_phase_deg, NUM_SOURCES, lattice
     )  # compute distance & direction vectors to all sources
 
     # Print diagnostics header if enabled

--- a/openwave/xperiments/level0_granule_based/xwaves.py
+++ b/openwave/xperiments/level0_granule_based/xwaves.py
@@ -80,7 +80,7 @@ COLOR_THEME = "DESERT"
 
 # Instantiate the lattice and granule objects (chose BCC or SC Lattice type)
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
-granule = medium.BCCGranule(lattice.unit_cell_edge)
+granule = medium.BCCGranule(lattice.unit_cell_edge, lattice.max_universe_edge)
 
 # DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
@@ -191,20 +191,6 @@ def color_menu():
 
 
 # ================================================================
-# Xperiment Normalization to Screen Coordinates
-# ================================================================
-
-
-def normalize_granule():
-    """Normalize granule radius to 0-1 range for GGUI rendering"""
-    global normalized_radius
-
-    normalized_radius = max(
-        granule.radius / lattice.max_universe_edge, 0.0001
-    )  # Ensure minimum 0.01% of screen radius for visibility
-
-
-# ================================================================
 # Xperiment Rendering
 # ================================================================
 
@@ -239,10 +225,6 @@ def render_xperiment(lattice):
     elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics
-
-    # Initialize normalized position (0-1 range for GGUI) & block-slicing
-    # block-slicing: hide front 1/8th of the lattice for see-through effect
-    normalize_granule()
 
     # Convert phase from degrees to radians for physics calculations
     # Conversion: radians = degrees × π/180
@@ -311,13 +293,13 @@ def render_xperiment(lattice):
         if granule_type:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
         elif ironbow:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
             # Display ironbow gradient palette
@@ -326,7 +308,7 @@ def render_xperiment(lattice):
         else:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 color=config.COLOR_MEDIUM[1],
             )
 
@@ -334,7 +316,7 @@ def render_xperiment(lattice):
         if show_sources:
             render.scene.particles(
                 centers=ewave.sources_pos_field,
-                radius=normalized_radius * 2,
+                radius=granule.radius_screen * 2,
                 color=config.COLOR_SOURCE[1],
             )
 

--- a/openwave/xperiments/level0_granule_based/yin_yang.py
+++ b/openwave/xperiments/level0_granule_based/yin_yang.py
@@ -76,6 +76,22 @@ COLOR_THEME = "OCEAN"
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
 granule = medium.BCCGranule(lattice.unit_cell_edge, lattice.max_universe_edge)
 
+# Initialize UI control variables
+show_axis = False  # Toggle to show/hide axis lines
+block_slice = False  # Block-slicing toggle
+show_sources = True  # Show wave sources toggle
+radius_factor = 2.0  # Initialize granule size factor
+freq_boost = 0.1  # Initialize frequency boost
+amp_boost = 5.0  # Initialize amplitude boost
+paused = False  # Pause toggle
+granule_type = True  # Granule type coloring toggle
+ironbow = False  # Ironbow (displacement) coloring toggle
+
+# Initialize time tracking for harmonic oscillations
+elapsed_t = 0.0
+last_time = time.time()
+frame = 0  # Frame counter for diagnostics
+
 # DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
@@ -198,27 +214,7 @@ def render_xperiment(lattice):
     Args:
         lattice: Lattice instance with positions, directions, and universe parameters
     """
-    global show_axis, block_slice, show_sources
-    global radius_factor, freq_boost, amp_boost, paused
-    global granule_type, ironbow
-    global elapsed_t, frame
-    global peak_amplitude
-
-    # Initialize UI control variables
-    show_axis = False  # Toggle to show/hide axis lines
-    block_slice = False  # Block-slicing toggle
-    show_sources = True  # Show wave sources toggle
-    radius_factor = 2.0  # Initialize granule size factor
-    freq_boost = 0.1  # Initialize frequency boost
-    amp_boost = 5.0  # Initialize amplitude boost
-    paused = False  # Pause toggle
-    granule_type = True  # Granule type coloring toggle
-    ironbow = False  # Ironbow (displacement) coloring toggle
-
-    # Time tracking for harmonic oscillation of all granules
-    elapsed_t = 0.0
-    last_time = time.time()
-    frame = 0  # Frame counter for diagnostics
+    global elapsed_t, last_time, frame, peak_amplitude
 
     # Convert phase from degrees to radians for physics calculations
     # Conversion: radians = degrees × π/180
@@ -242,8 +238,8 @@ def render_xperiment(lattice):
             # Calculate actual elapsed time (real-time tracking)
             current_time = time.time()
             dt_real = current_time - last_time
-            last_time = current_time
             elapsed_t += dt_real  # Use real elapsed time instead of fixed DT
+            last_time = current_time
 
             # Apply radial harmonic oscillation to all granules from multiple wave sources
             # Each granule receives wave contributions from all active sources

--- a/openwave/xperiments/level0_granule_based/yin_yang.py
+++ b/openwave/xperiments/level0_granule_based/yin_yang.py
@@ -216,12 +216,8 @@ def render_xperiment(lattice):
     """
     global elapsed_t, last_time, frame, peak_amplitude
 
-    # Convert phase from degrees to radians for physics calculations
-    # Conversion: radians = degrees × π/180
-    sources_phase_rad = [deg * ti.math.pi / 180 for deg in sources_phase_deg]
-
     ewave.build_source_vectors(
-        sources_position, sources_phase_rad, NUM_SOURCES, lattice
+        sources_position, sources_phase_deg, NUM_SOURCES, lattice
     )  # compute distance & direction vectors to all sources
 
     # Print diagnostics header if enabled

--- a/openwave/xperiments/level0_granule_based/yin_yang.py
+++ b/openwave/xperiments/level0_granule_based/yin_yang.py
@@ -74,7 +74,7 @@ COLOR_THEME = "OCEAN"
 
 # Instantiate the lattice and granule objects (chose BCC or SC Lattice type)
 lattice = medium.BCCLattice(UNIVERSE_SIZE, theme=COLOR_THEME)
-granule = medium.BCCGranule(lattice.unit_cell_edge)
+granule = medium.BCCGranule(lattice.unit_cell_edge, lattice.max_universe_edge)
 
 # DATA SAMPLING & DIAGNOSTICS --------------------------------------------
 peak_amplitude = 0.0  # Initialize granule max displacement (data sampling variable)
@@ -185,20 +185,6 @@ def color_menu():
 
 
 # ================================================================
-# Xperiment Normalization to Screen Coordinates
-# ================================================================
-
-
-def normalize_granule():
-    """Normalize granule radius to 0-1 range for GGUI rendering"""
-    global normalized_radius
-
-    normalized_radius = max(
-        granule.radius / lattice.max_universe_edge, 0.0001
-    )  # Ensure minimum 0.01% of screen radius for visibility
-
-
-# ================================================================
 # Xperiment Rendering
 # ================================================================
 
@@ -233,10 +219,6 @@ def render_xperiment(lattice):
     elapsed_t = 0.0
     last_time = time.time()
     frame = 0  # Frame counter for diagnostics
-
-    # Initialize normalized position (0-1 range for GGUI) & block-slicing
-    # block-slicing: hide front 1/8th of the lattice for see-through effect
-    normalize_granule()
 
     # Convert phase from degrees to radians for physics calculations
     # Conversion: radians = degrees × π/180
@@ -305,13 +287,13 @@ def render_xperiment(lattice):
         if granule_type:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
         elif ironbow:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
             # Display ironbow gradient palette
@@ -320,7 +302,7 @@ def render_xperiment(lattice):
         else:
             render.scene.particles(
                 lattice.position_screen,
-                radius=normalized_radius * radius_factor,
+                radius=granule.radius_screen * radius_factor,
                 color=config.COLOR_MEDIUM[1],
             )
 
@@ -328,7 +310,7 @@ def render_xperiment(lattice):
         if show_sources:
             render.scene.particles(
                 centers=ewave.sources_pos_field,
-                radius=normalized_radius * 2,
+                radius=granule.radius_screen * 2,
                 color=config.COLOR_SOURCE[1],
             )
 

--- a/openwave/xperiments/level0_granule_based/yin_yang.py
+++ b/openwave/xperiments/level0_granule_based/yin_yang.py
@@ -101,7 +101,6 @@ def xperiment_specs():
 
 def data_dashboard():
     """Display simulation data dashboard."""
-
     with render.gui.sub_window("DATA-DASHBOARD", 0.00, 0.41, 0.19, 0.59) as sub:
         sub.text("--- WAVE-MEDIUM ---", color=config.LIGHT_BLUE[1])
         sub.text(f"Universe Size: {lattice.max_universe_edge:.1e} m (max edge)")
@@ -190,19 +189,6 @@ def color_menu():
 # ================================================================
 
 
-@ti.kernel
-def normalize_lattice(enable_slice: ti.i32):  # type: ignore
-    """Normalize lattice positions to 0-1 range for GGUI rendering."""
-    for i in range(lattice.total_granules):
-        # Normalize to 0-1 range (positions are in attometers, scale them back)
-        if enable_slice == 1 and lattice.front_octant[i] == 1:
-            # Block-slicing enabled: hide front octant granules by moving to origin
-            normalized_position[i] = ti.Vector([0.0, 0.0, 0.0])
-        else:
-            # Normal rendering: normalize to 0-1 range
-            normalized_position[i] = lattice.position_am[i] / lattice.max_universe_edge_am
-
-
 def normalize_granule():
     """Normalize granule radius to 0-1 range for GGUI rendering"""
     global normalized_radius
@@ -230,7 +216,6 @@ def render_xperiment(lattice):
     global radius_factor, freq_boost, amp_boost, paused
     global granule_type, ironbow
     global elapsed_t, frame
-    global normalized_position
     global peak_amplitude
 
     # Initialize UI control variables
@@ -251,7 +236,6 @@ def render_xperiment(lattice):
 
     # Initialize normalized position (0-1 range for GGUI) & block-slicing
     # block-slicing: hide front 1/8th of the lattice for see-through effect
-    normalized_position = ti.Vector.field(3, dtype=ti.f32, shape=lattice.total_granules)
     normalize_granule()
 
     # Convert phase from degrees to radians for physics calculations
@@ -296,7 +280,7 @@ def render_xperiment(lattice):
 
             # Update normalized positions for rendering (must happen after position updates)
             # with optional block-slicing (see-through effect)
-            normalize_lattice(1 if block_slice else 0)
+            lattice.normalize_to_screen(1 if block_slice else 0)
 
             # IN-FRAME DATA SAMPLING & DIAGNOSTICS ==================================
             # Update data sampling every 30 frames to reduce overhead
@@ -317,16 +301,16 @@ def render_xperiment(lattice):
             # Update last_time during pause to prevent time jump on resume
             last_time = time.time()
 
-        # Render granules with optional type-coloring
+        # Render granules with optional coloring
         if granule_type:
             render.scene.particles(
-                normalized_position,
+                lattice.position_screen,
                 radius=normalized_radius * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
         elif ironbow:
             render.scene.particles(
-                normalized_position,
+                lattice.position_screen,
                 radius=normalized_radius * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
@@ -335,7 +319,7 @@ def render_xperiment(lattice):
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
         else:
             render.scene.particles(
-                normalized_position,
+                lattice.position_screen,
                 radius=normalized_radius * radius_factor,
                 color=config.COLOR_MEDIUM[1],
             )


### PR DESCRIPTION
This pull request refactors the granule rendering and wave source initialization logic across the medium-level simulation and two xperiment scripts. The main goal is to standardize how granule positions and radii are normalized for rendering, streamline the initialization of simulation variables, and improve clarity and maintainability by removing redundant code. The changes also ensure that wave source phases are consistently handled in degrees and converted to radians internally.

**Granule normalization and rendering improvements:**

* Added `position_screen` and `radius_screen` fields to both `BCCGranule` and `SCGranule` classes, allowing granule positions and radii to be normalized to the 0-1 screen space directly within the lattice classes for GGUI rendering. [[1]](diffhunk://#diff-a1d03c4ac0417a2333f0626af21ef55105994e9f2aead28872ed00e0758ea54dL29-R40) [[2]](diffhunk://#diff-a1d03c4ac0417a2333f0626af21ef55105994e9f2aead28872ed00e0758ea54dL508-R538) [[3]](diffhunk://#diff-a1d03c4ac0417a2333f0626af21ef55105994e9f2aead28872ed00e0758ea54dR159) [[4]](diffhunk://#diff-a1d03c4ac0417a2333f0626af21ef55105994e9f2aead28872ed00e0758ea54dR654)
* Implemented a new `normalize_to_screen` kernel method in both lattice classes, replacing the previous global normalization functions and handling block-slicing for see-through effects. [[1]](diffhunk://#diff-a1d03c4ac0417a2333f0626af21ef55105994e9f2aead28872ed00e0758ea54dR302-R314) [[2]](diffhunk://#diff-a1d03c4ac0417a2333f0626af21ef55105994e9f2aead28872ed00e0758ea54dR769-R781)
* Updated rendering logic in both `spacetime_vibration.py` and `spherical_wave.py` to use the new `position_screen` and `radius_screen` fields, removing the need for global normalization variables and functions. [[1]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL194-L220) [[2]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL305-R263) [[3]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL326-R311) [[4]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L173-L199) [[5]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L214-R205)

**Wave source phase handling:**

* Changed the `build_source_vectors` function to accept phase offsets in degrees (`sources_phase_deg`) and internally convert them to radians for physics calculations, ensuring consistency across the codebase. [[1]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL45-R45) [[2]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL59-R69) [[3]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL88-R92)
* Updated calls to `build_source_vectors` in both xperiment scripts to pass phase values in degrees. [[1]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL235-R226) [[2]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L214-R205)

**Initialization and code simplification:**

* Moved UI control variable initialization and time tracking directly to the top-level scope in both xperiment scripts, removing redundant re-initialization inside the rendering functions. [[1]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL83-R99) [[2]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L62-R78)
* Removed obsolete global normalization functions and variables from the xperiment scripts, consolidating normalization logic within the lattice classes. [[1]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL194-L220) [[2]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L173-L199)

**Minor fixes:**

* Corrected the update order for time tracking variables to prevent time jumps after pausing.

These changes collectively improve the maintainability, readability, and correctness of the granule-based spacetime simulation code.