### PR TITLE
Add Video Export Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,10 +212,5 @@ __marimo__/
 # Taichi artifacts
 imgui.ini
 
-# Development Sandbox - Experimental Code
-# Uncomment the lines below to ignore sandbox experiments
-# /dev_sandbox/wip_*
-# /dev_sandbox/*/wip_*
-# Or ignore everything except README:
-# /dev_sandbox/*
-# !/dev_sandbox/README.md
+# Video export directory
+/openwave/video_export

--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ OpenWave provides computational and visualization tools to explore, demonstrate,
 
 - Illustrates complex, often invisible phenomena for better comprehension
 - Represents graphically wave equations and analyses
-- [PLANNED] Automates animation export for online video publishing
+- Automates animation export for online video publishing
 
 ### Exploratory Simulations
 
 - Models experimental wave field configurations for parametric studies
-- [PLANNED] Supports hypothesis testing and comparative analysis against theoretical predictions
+- Supports hypothesis testing and comparative analysis against theoretical predictions
 
 ## Explore Wave Field Dynamics with 3D Visualization
 
@@ -339,8 +339,7 @@ class `I/O
   MODULE`{
     cli.py ✓
     render.py ✓
-    *WIP*: file_export.py
-    *WIP*: video_manager.py
+    video.py ✓
   }
 ```
 
@@ -403,7 +402,8 @@ kanban
       - equations.py]
     [**I/O MODULE**
       - cli.py
-      - render.py]
+      - render.py
+      - video.py]
 ```
 
 ### Scalability & Performance

--- a/openwave/_io/cli.py
+++ b/openwave/_io/cli.py
@@ -9,12 +9,12 @@ import argparse
 import os
 import sys
 import subprocess
-import platform
 from pathlib import Path
 
 # Conditional import for simple_term_menu (not available on Windows)
 try:
     from simple_term_menu import TerminalMenu
+
     HAS_INTERACTIVE_MENU = True
 except (ImportError, NotImplementedError):
     HAS_INTERACTIVE_MENU = False
@@ -163,10 +163,12 @@ def show_menu_simple(experiments):
     # Get version from source (works with editable installs)
     try:
         from openwave import __version__
+
         pkg_version = __version__
     except ImportError:
         # Fallback to metadata if __version__ not available
         from importlib.metadata import version
+
         pkg_version = version("OPENWAVE")
 
     print("\n" + "=" * 64)
@@ -233,10 +235,12 @@ def show_menu_interactive(experiments):
     # Get version from source (works with editable installs)
     try:
         from openwave import __version__
+
         pkg_version = __version__
     except ImportError:
         # Fallback to metadata if __version__ not available
         from importlib.metadata import version
+
         pkg_version = version("OPENWAVE")
 
     for display_name, file_path in experiments:

--- a/openwave/_io/video.py
+++ b/openwave/_io/video.py
@@ -1,0 +1,68 @@
+"""
+Video generation engine for OPENWAVE using Taichi GGUI.
+"""
+
+from pathlib import Path
+
+import taichi as ti
+
+from openwave._io import render
+
+# Get the video_export directory path
+# Navigate from _io module to parent package, then to video_export
+package_dir = Path(__file__).parent.parent
+export_dir = package_dir / "video_export"
+
+# Initialize VideoManager
+manager = ti.tools.VideoManager(output_dir=export_dir, framerate=24, automatic_build=False)
+
+
+def write_frame(image, current_frame, final_frame):
+    """Write a frame to the video manager.
+    To be called inside the main simulation loop.
+
+    Args:
+        image (numpy.ndarray): The image array to write as a frame.
+        current_frame (int): The current frame number for logging.
+        final_frame (int): The target frame number to stop recording and
+            finalize the video export.
+    """
+    manager.write_frame(image)
+    print(f"\nFrame {current_frame}/{final_frame} is recorded", end="")
+
+
+def finalize_video():
+    """Finalize and export the video files.
+    To be called after the main simulation loop.
+    """
+    print("")
+    print("\nExporting .mp4 and .gif videos...")
+    manager.make_video(gif=False, mp4=True)
+    print("\n================================================================")
+    print("VIDEO MANAGER")
+    print(f'MP4 video is saved to {manager.get_output_filename(".mp4")}')
+    print("================================================================")
+    print("")
+
+
+def export(current_frame, final_frame):
+    """Capture current frame and finalize video when reaching the final frame.
+
+    Called during the simulation loop to record each frame. When the current
+    frame reaches the final frame, automatically finalizes the video export
+    (MP4 and GIF) and stops the simulation window.
+
+    Args:
+        current_frame (int): The current frame number being rendered.
+        final_frame (int): The target frame number to stop recording and
+            finalize the video export.
+    """
+
+    # Capture frame for video export
+    image = render.window.get_image_buffer_as_numpy()
+    write_frame(image, current_frame, final_frame)
+
+    # Set desired frame to stop the simulation
+    if current_frame >= final_frame:
+        finalize_video()
+        render.window.running = False

--- a/openwave/spacetime/medium_level0.py
+++ b/openwave/spacetime/medium_level0.py
@@ -13,9 +13,7 @@ import random
 
 import taichi as ti
 
-from openwave.common import config
-from openwave.common import constants
-from openwave.common import equations
+from openwave.common import config, constants, equations
 
 
 class BCCGranule:

--- a/openwave/spacetime/wave_engine_level0.py
+++ b/openwave/spacetime/wave_engine_level0.py
@@ -35,6 +35,7 @@ sources_phase_shift = None  # Phase offset for each wave source (radians)
 max_displacement_am = None  # Maximum displacement from all granules
 peak_amplitude_am = None  # Peak amplitude
 avg_amplitude_am = None  # RMS amplitude for energy calculation (peak * 0.707)
+last_amp_boost = None  # Track last amp_boost value for reset
 
 
 # ================================================================
@@ -83,7 +84,6 @@ def build_source_vectors(sources_position, sources_phase_deg, num_sources, latti
     peak_amplitude_am = ti.field(dtype=ti.f32, shape=())
     avg_amplitude_am = ti.field(dtype=ti.f32, shape=())
     last_amp_boost = ti.field(dtype=ti.f32, shape=())  # Track last amp_boost value
-    last_amp_boost[None] = 1.0
 
     # Copy source data to Taichi fields
     for i in range(num_sources):

--- a/openwave/spacetime/wave_engine_level0.py
+++ b/openwave/spacetime/wave_engine_level0.py
@@ -126,11 +126,11 @@ def oscillate_granules(
     amplitude_am: ti.template(),  # type: ignore
     velocity_am: ti.template(),  # type: ignore
     granule_var_color: ti.template(),  # type: ignore
+    freq_boost: ti.f32,  # type: ignore
+    amp_boost: ti.f32,  # type: ignore
     ib_displacement: ti.i32,  # type: ignore
     num_sources: ti.i32,  # type: ignore
     elapsed_t: ti.f32,  # type: ignore
-    freq_boost: ti.f32,  # type: ignore
-    amp_boost: ti.f32,  # type: ignore
 ):
     """Charges energy into all granules from multiple wave sources using wave superposition.
 

--- a/openwave/spacetime/wave_engine_level0.py
+++ b/openwave/spacetime/wave_engine_level0.py
@@ -11,9 +11,7 @@ Each source generates spherical longitudinal waves that superpose at each granul
 
 import taichi as ti
 
-from openwave.common import config
-from openwave.common import constants
-from openwave.common import equations
+from openwave.common import config, constants, equations
 
 # ================================================================
 # Energy-Wave Oscillation Parameters

--- a/openwave/validations/stability_analysis.py
+++ b/openwave/validations/stability_analysis.py
@@ -1,8 +1,6 @@
 import math
 
-from openwave.common import config
-from openwave.common import constants
-from openwave.common import equations
+from openwave.common import config, constants, equations
 
 import openwave.spacetime.medium_level0 as medium
 

--- a/openwave/validations/wave_diagnostics.py
+++ b/openwave/validations/wave_diagnostics.py
@@ -10,8 +10,7 @@ This module simply confirms the simulation is running with correct parameters.
 This provides zero-overhead diagnostics that can be toggled on/off per experiment.
 """
 
-from openwave.common import config
-from openwave.common import constants
+from openwave.common import config, constants
 
 
 # ================================================================

--- a/openwave/xperiments/_archives/radial_wave/medium_bccgranule.py
+++ b/openwave/xperiments/_archives/radial_wave/medium_bccgranule.py
@@ -13,9 +13,7 @@ import random
 
 import taichi as ti
 
-from openwave.common import config
-from openwave.common import constants
-from openwave.common import equations
+from openwave.common import config, constants, equations
 
 
 class BCCGranule:

--- a/openwave/xperiments/_archives/radial_wave/radial_pulse.py
+++ b/openwave/xperiments/_archives/radial_wave/radial_pulse.py
@@ -18,8 +18,7 @@ This XPERIMENT showcases:
 import taichi as ti
 import time
 
-from openwave.common import config
-from openwave.common import constants
+from openwave.common import config, constants
 from openwave._io import render
 
 import openwave.xperiments._archives.radial_wave.medium_bccgranule as medium

--- a/openwave/xperiments/_archives/radial_wave/radial_spherical.py
+++ b/openwave/xperiments/_archives/radial_wave/radial_spherical.py
@@ -18,8 +18,7 @@ This XPERIMENT showcases:
 import taichi as ti
 import time
 
-from openwave.common import config
-from openwave.common import constants
+from openwave.common import config, constants
 from openwave._io import render
 
 import openwave.xperiments._archives.radial_wave.medium_bccgranule as medium

--- a/openwave/xperiments/_archives/radial_wave/radial_wave.py
+++ b/openwave/xperiments/_archives/radial_wave/radial_wave.py
@@ -18,8 +18,7 @@ This XPERIMENT showcases:
 import taichi as ti
 import time
 
-from openwave.common import config
-from openwave.common import constants
+from openwave.common import config, constants
 from openwave._io import render
 
 import openwave.xperiments._archives.radial_wave.medium_bccgranule as medium

--- a/openwave/xperiments/_archives/spring_mass/medium_bccgranule.py
+++ b/openwave/xperiments/_archives/spring_mass/medium_bccgranule.py
@@ -13,9 +13,7 @@ import random
 
 import taichi as ti
 
-from openwave.common import config
-from openwave.common import constants
-from openwave.common import equations
+from openwave.common import config, constants, equations
 
 
 class BCCGranule:

--- a/openwave/xperiments/_archives/spring_mass/spring_euler.py
+++ b/openwave/xperiments/_archives/spring_mass/spring_euler.py
@@ -17,8 +17,7 @@ print("")
 import taichi as ti
 import time
 
-from openwave.common import config
-from openwave.common import constants
+from openwave.common import config, constants
 from openwave._io import render
 
 import openwave.xperiments._archives.spring_mass.medium_bccgranule as medium

--- a/openwave/xperiments/_archives/spring_mass/spring_leap.py
+++ b/openwave/xperiments/_archives/spring_mass/spring_leap.py
@@ -17,8 +17,7 @@ print("")
 import taichi as ti
 import time
 
-from openwave.common import config
-from openwave.common import constants
+from openwave.common import config, constants
 from openwave._io import render
 
 import openwave.xperiments._archives.spring_mass.medium_bccgranule as medium

--- a/openwave/xperiments/_archives/spring_mass/xpbd.py
+++ b/openwave/xperiments/_archives/spring_mass/xpbd.py
@@ -8,9 +8,7 @@ Tweak universe size and other parameters to explore different scales.
 import taichi as ti
 import time
 
-from openwave.common import config
-from openwave.common import constants
-from openwave.common import equations
+from openwave.common import config, constants, equations
 from openwave._io import render
 
 import openwave.xperiments._archives.spring_mass.medium_bccgranule as medium

--- a/openwave/xperiments/level0_granule_based/spacetime_vibration.py
+++ b/openwave/xperiments/level0_granule_based/spacetime_vibration.py
@@ -18,16 +18,15 @@ This XPERIMENT showcases:
 import taichi as ti
 import time
 
-from openwave.common import config
-from openwave.common import constants
-from openwave._io import render
+from openwave.common import config, constants
+from openwave._io import render, video
 
 import openwave.spacetime.medium_level0 as medium
 import openwave.spacetime.wave_engine_level0 as ewave
 import openwave.validations.wave_diagnostics as diagnostics
 
 # Define the architecture to be used by Taichi (GPU vs CPU)
-ti.init(arch=ti.gpu)  # Use GPU if available, else fallback to CPU
+ti.init(arch=ti.gpu, log_level=ti.WARN)  # Use GPU if available, suppress info logs
 
 # ================================================================
 # Xperiment Parameters & Subatomic Objects Instantiation
@@ -103,6 +102,8 @@ frame = 0  # Frame counter for diagnostics
 max_displacement = 0.0  # Initialize granule max displacement (data sampling variable)
 peak_amplitude = 0.0  # Initialize granule peak amplitude (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
+EXPORT_VIDEO = False  # Toggle frame image export to video directory
+VIDEO_FRAMES = 24  # The target frame number to stop recording and finalize video export
 
 # ================================================================
 # Xperiment UI and overlay windows
@@ -327,6 +328,10 @@ def render_xperiment(lattice):
         color_menu()
         xperiment_specs()
         render.show_scene()
+
+        # Capture frame for video export (finalizes and stops at set VIDEO_FRAMES)
+        if EXPORT_VIDEO:
+            video.export(frame, VIDEO_FRAMES)
 
 
 # ================================================================

--- a/openwave/xperiments/level0_granule_based/spacetime_vibration.py
+++ b/openwave/xperiments/level0_granule_based/spacetime_vibration.py
@@ -261,11 +261,11 @@ def render_xperiment(lattice):
                 lattice.amplitude_am,  # Granule amplitude in am
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
+                freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
+                amp_boost,  # Amplitude visibility boost for scaled lattices
                 ib_displacement,  # Ironbow displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
-                freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
-                amp_boost,  # Amplitude visibility boost for scaled lattices
             )
 
             # Update normalized positions for rendering (must happen after position updates)

--- a/openwave/xperiments/level0_granule_based/spherical_wave.py
+++ b/openwave/xperiments/level0_granule_based/spherical_wave.py
@@ -18,16 +18,15 @@ This XPERIMENT showcases:
 import taichi as ti
 import time
 
-from openwave.common import config
-from openwave.common import constants
-from openwave._io import render
+from openwave.common import config, constants
+from openwave._io import render, video
 
 import openwave.spacetime.medium_level0 as medium
 import openwave.spacetime.wave_engine_level0 as ewave
 import openwave.validations.wave_diagnostics as diagnostics
 
 # Define the architecture to be used by Taichi (GPU vs CPU)
-ti.init(arch=ti.gpu)  # Use GPU if available, else fallback to CPU
+ti.init(arch=ti.gpu, log_level=ti.WARN)  # Use GPU if available, suppress info logs
 
 # ================================================================
 # Xperiment Parameters & Subatomic Objects Instantiation
@@ -82,6 +81,8 @@ frame = 0  # Frame counter for diagnostics
 max_displacement = 0.0  # Initialize granule max displacement (data sampling variable)
 peak_amplitude = 0.0  # Initialize granule peak amplitude (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
+EXPORT_VIDEO = False  # Toggle frame image export to video directory
+VIDEO_FRAMES = 24  # The target frame number to stop recording and finalize video export
 
 # ================================================================
 # Xperiment UI and overlay windows
@@ -306,6 +307,10 @@ def render_xperiment(lattice):
         color_menu()
         xperiment_specs()
         render.show_scene()
+
+        # Capture frame for video export (finalizes and stops at set VIDEO_FRAMES)
+        if EXPORT_VIDEO:
+            video.export(frame, VIDEO_FRAMES)
 
 
 # ================================================================

--- a/openwave/xperiments/level0_granule_based/spherical_wave.py
+++ b/openwave/xperiments/level0_granule_based/spherical_wave.py
@@ -240,11 +240,11 @@ def render_xperiment(lattice):
                 lattice.amplitude_am,  # Granule amplitude in am
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
+                freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
+                amp_boost,  # Amplitude visibility boost for scaled lattices
                 ib_displacement,  # Ironbow displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
-                freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
-                amp_boost,  # Amplitude visibility boost for scaled lattices
             )
 
             # Update normalized positions for rendering (must happen after position updates)

--- a/openwave/xperiments/level0_granule_based/standing_wave.py
+++ b/openwave/xperiments/level0_granule_based/standing_wave.py
@@ -18,16 +18,15 @@ This XPERIMENT showcases:
 import taichi as ti
 import time
 
-from openwave.common import config
-from openwave.common import constants
-from openwave._io import render
+from openwave.common import config, constants
+from openwave._io import render, video
 
 import openwave.spacetime.medium_level0 as medium
 import openwave.spacetime.wave_engine_level0 as ewave
 import openwave.validations.wave_diagnostics as diagnostics
 
 # Define the architecture to be used by Taichi (GPU vs CPU)
-ti.init(arch=ti.gpu)  # Use GPU if available, else fallback to CPU
+ti.init(arch=ti.gpu, log_level=ti.WARN)  # Use GPU if available, suppress info logs
 
 # ================================================================
 # Xperiment Parameters & Subatomic Objects Instantiation
@@ -95,6 +94,8 @@ frame = 0  # Frame counter for diagnostics
 max_displacement = 0.0  # Initialize granule max displacement (data sampling variable)
 peak_amplitude = 0.0  # Initialize granule peak amplitude (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
+EXPORT_VIDEO = False  # Toggle frame image export to video directory
+VIDEO_FRAMES = 24  # The target frame number to stop recording and finalize video export
 
 # ================================================================
 # Xperiment UI and overlay windows
@@ -316,6 +317,10 @@ def render_xperiment(lattice):
         color_menu()
         xperiment_specs()
         render.show_scene()
+
+        # Capture frame for video export (finalizes and stops at set VIDEO_FRAMES)
+        if EXPORT_VIDEO:
+            video.export(frame, VIDEO_FRAMES)
 
 
 # ================================================================

--- a/openwave/xperiments/level0_granule_based/standing_wave.py
+++ b/openwave/xperiments/level0_granule_based/standing_wave.py
@@ -253,11 +253,11 @@ def render_xperiment(lattice):
                 lattice.amplitude_am,  # Granule amplitude in am
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
+                freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
+                amp_boost,  # Amplitude visibility boost for scaled lattices
                 ib_displacement,  # Ironbow displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
-                freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
-                amp_boost,  # Amplitude visibility boost for scaled lattices
             )
 
             # Update normalized positions for rendering (must happen after position updates)

--- a/openwave/xperiments/level0_granule_based/wave_interference.py
+++ b/openwave/xperiments/level0_granule_based/wave_interference.py
@@ -18,16 +18,15 @@ This XPERIMENT showcases:
 import taichi as ti
 import time
 
-from openwave.common import config
-from openwave.common import constants
-from openwave._io import render
+from openwave.common import config, constants
+from openwave._io import render, video
 
 import openwave.spacetime.medium_level0 as medium
 import openwave.spacetime.wave_engine_level0 as ewave
 import openwave.validations.wave_diagnostics as diagnostics
 
 # Define the architecture to be used by Taichi (GPU vs CPU)
-ti.init(arch=ti.gpu)  # Use GPU if available, else fallback to CPU
+ti.init(arch=ti.gpu, log_level=ti.WARN)  # Use GPU if available, suppress info logs
 
 # ================================================================
 # Xperiment Parameters & Subatomic Objects Instantiation
@@ -98,6 +97,8 @@ frame = 0  # Frame counter for diagnostics
 max_displacement = 0.0  # Initialize granule max displacement (data sampling variable)
 peak_amplitude = 0.0  # Initialize granule peak amplitude (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
+EXPORT_VIDEO = False  # Toggle frame image export to video directory
+VIDEO_FRAMES = 24  # The target frame number to stop recording and finalize video export
 
 # ================================================================
 # Xperiment UI and overlay windows
@@ -322,6 +323,10 @@ def render_xperiment(lattice):
         color_menu()
         xperiment_specs()
         render.show_scene()
+
+        # Capture frame for video export (finalizes and stops at set VIDEO_FRAMES)
+        if EXPORT_VIDEO:
+            video.export(frame, VIDEO_FRAMES)
 
 
 # ================================================================

--- a/openwave/xperiments/level0_granule_based/wave_interference.py
+++ b/openwave/xperiments/level0_granule_based/wave_interference.py
@@ -256,11 +256,11 @@ def render_xperiment(lattice):
                 lattice.amplitude_am,  # Granule amplitude in am
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
+                freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
+                amp_boost,  # Amplitude visibility boost for scaled lattices
                 ib_displacement,  # Ironbow displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
-                freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
-                amp_boost,  # Amplitude visibility boost for scaled lattices
             )
 
             # Update normalized positions for rendering (must happen after position updates)

--- a/openwave/xperiments/level0_granule_based/wave_pulse.py
+++ b/openwave/xperiments/level0_granule_based/wave_pulse.py
@@ -18,16 +18,15 @@ This XPERIMENT showcases:
 import taichi as ti
 import time
 
-from openwave.common import config
-from openwave.common import constants
-from openwave._io import render
+from openwave.common import config, constants
+from openwave._io import render, video
 
 import openwave.spacetime.medium_level0 as medium
 import openwave.spacetime.wave_engine_level0 as ewave
 import openwave.validations.wave_diagnostics as diagnostics
 
 # Define the architecture to be used by Taichi (GPU vs CPU)
-ti.init(arch=ti.gpu)  # Use GPU if available, else fallback to CPU
+ti.init(arch=ti.gpu, log_level=ti.WARN)  # Use GPU if available, suppress info logs
 
 # ================================================================
 # Xperiment Parameters & Subatomic Objects Instantiation
@@ -82,6 +81,8 @@ frame = 0  # Frame counter for diagnostics
 max_displacement = 0.0  # Initialize granule max displacement (data sampling variable)
 peak_amplitude = 0.0  # Initialize granule peak amplitude (data sampling variable)
 WAVE_DIAGNOSTICS = True  # Toggle wave diagnostics (speed & wavelength measurements)
+EXPORT_VIDEO = False  # Toggle frame image export to video directory
+VIDEO_FRAMES = 24  # The target frame number to stop recording and finalize video export
 
 # ================================================================
 # Xperiment UI and overlay windows
@@ -306,6 +307,10 @@ def render_xperiment(lattice):
         color_menu()
         xperiment_specs()
         render.show_scene()
+
+        # Capture frame for video export (finalizes and stops at set VIDEO_FRAMES)
+        if EXPORT_VIDEO:
+            video.export(frame, VIDEO_FRAMES)
 
 
 # ================================================================

--- a/openwave/xperiments/level0_granule_based/wave_pulse.py
+++ b/openwave/xperiments/level0_granule_based/wave_pulse.py
@@ -240,11 +240,11 @@ def render_xperiment(lattice):
                 lattice.amplitude_am,  # Granule amplitude in am
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
+                freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
+                amp_boost,  # Amplitude visibility boost for scaled lattices
                 ib_displacement,  # Ironbow displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
-                freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
-                amp_boost,  # Amplitude visibility boost for scaled lattices
             )
 
             # Update normalized positions for rendering (must happen after position updates)

--- a/openwave/xperiments/level0_granule_based/xwaves.py
+++ b/openwave/xperiments/level0_granule_based/xwaves.py
@@ -18,16 +18,15 @@ This XPERIMENT showcases:
 import taichi as ti
 import time
 
-from openwave.common import config
-from openwave.common import constants
-from openwave._io import render
+from openwave.common import config, constants
+from openwave._io import render, video
 
 import openwave.spacetime.medium_level0 as medium
 import openwave.spacetime.wave_engine_level0 as ewave
 import openwave.validations.wave_diagnostics as diagnostics
 
 # Define the architecture to be used by Taichi (GPU vs CPU)
-ti.init(arch=ti.gpu)  # Use GPU if available, else fallback to CPU
+ti.init(arch=ti.gpu, log_level=ti.WARN)  # Use GPU if available, suppress info logs
 
 # ================================================================
 # Xperiment Parameters & Subatomic Objects Instantiation
@@ -103,6 +102,8 @@ frame = 0  # Frame counter for diagnostics
 max_displacement = 0.0  # Initialize granule max displacement (data sampling variable)
 peak_amplitude = 0.0  # Initialize granule peak amplitude (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
+EXPORT_VIDEO = False  # Toggle frame image export to video directory
+VIDEO_FRAMES = 24  # The target frame number to stop recording and finalize video export
 
 # ================================================================
 # Xperiment UI and overlay windows
@@ -327,6 +328,10 @@ def render_xperiment(lattice):
         color_menu()
         xperiment_specs()
         render.show_scene()
+
+        # Capture frame for video export (finalizes and stops at set VIDEO_FRAMES)
+        if EXPORT_VIDEO:
+            video.export(frame, VIDEO_FRAMES)
 
 
 # ================================================================

--- a/openwave/xperiments/level0_granule_based/xwaves.py
+++ b/openwave/xperiments/level0_granule_based/xwaves.py
@@ -261,11 +261,11 @@ def render_xperiment(lattice):
                 lattice.amplitude_am,  # Granule amplitude in am
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
+                freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
+                amp_boost,  # Amplitude visibility boost for scaled lattices
                 ib_displacement,  # Ironbow displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
-                freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
-                amp_boost,  # Amplitude visibility boost for scaled lattices
             )
 
             # Update normalized positions for rendering (must happen after position updates)

--- a/openwave/xperiments/level0_granule_based/yin_yang.py
+++ b/openwave/xperiments/level0_granule_based/yin_yang.py
@@ -255,11 +255,11 @@ def render_xperiment(lattice):
                 lattice.amplitude_am,  # Granule amplitude in am
                 lattice.velocity_am,  # Granule velocity in am/s
                 lattice.granule_var_color,  # Granule color variations
+                freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
+                amp_boost,  # Amplitude visibility boost for scaled lattices
                 ib_displacement,  # Ironbow displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
-                freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
-                amp_boost,  # Amplitude visibility boost for scaled lattices
             )
 
             # Update normalized positions for rendering (must happen after position updates)

--- a/openwave/xperiments/level0_granule_based/yin_yang.py
+++ b/openwave/xperiments/level0_granule_based/yin_yang.py
@@ -18,16 +18,15 @@ This XPERIMENT showcases:
 import taichi as ti
 import time
 
-from openwave.common import config
-from openwave.common import constants
-from openwave._io import render
+from openwave.common import config, constants
+from openwave._io import render, video
 
 import openwave.spacetime.medium_level0 as medium
 import openwave.spacetime.wave_engine_level0 as ewave
 import openwave.validations.wave_diagnostics as diagnostics
 
 # Define the architecture to be used by Taichi (GPU vs CPU)
-ti.init(arch=ti.gpu)  # Use GPU if available, else fallback to CPU
+ti.init(arch=ti.gpu, log_level=ti.WARN)  # Use GPU if available, suppress info logs
 
 # ================================================================
 # Xperiment Parameters & Subatomic Objects Instantiation
@@ -97,6 +96,8 @@ frame = 0  # Frame counter for diagnostics
 max_displacement = 0.0  # Initialize granule max displacement (data sampling variable)
 peak_amplitude = 0.0  # Initialize granule peak amplitude (data sampling variable)
 WAVE_DIAGNOSTICS = False  # Toggle wave diagnostics (speed & wavelength measurements)
+EXPORT_VIDEO = False  # Toggle frame image export to video directory
+VIDEO_FRAMES = 24  # The target frame number to stop recording and finalize video export
 
 # ================================================================
 # Xperiment UI and overlay windows
@@ -321,6 +322,10 @@ def render_xperiment(lattice):
         color_menu()
         xperiment_specs()
         render.show_scene()
+
+        # Capture frame for video export (finalizes and stops at set VIDEO_FRAMES)
+        if EXPORT_VIDEO:
+            video.export(frame, VIDEO_FRAMES)
 
 
 # ================================================================


### PR DESCRIPTION
This pull request introduces video export functionality to the OpenWave simulation framework and refines various aspects of the codebase for clarity and maintainability. The most significant changes include the addition of a new video export engine, integration of video export into key simulation scripts, and improvements to code organization and documentation.

### Video Export Functionality

* Added a new `openwave/_io/video.py` module that implements a video generation engine using Taichi's `VideoManager`, enabling automated export of simulation frames to MP4 format. This module provides functions for writing frames, finalizing video export, and integrating seamlessly with the simulation loop.

* Integrated video export into the main simulation scripts `spacetime_vibration.py` and `spherical_wave.py` by importing the new `video` module, adding configuration flags (`EXPORT_VIDEO`, `VIDEO_FRAMES`), and calling `video.export()` during the rendering loop to record and finalize videos automatically. [[1]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL21-R29) [[2]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dR105-R106) [[3]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dR332-R335) [[4]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L21-R29) [[5]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230R84-R85) [[6]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230R311-R314)

### Code Organization and Consistency

* Refactored import statements throughout the codebase to use grouped imports, improving readability and reducing redundancy in files such as `medium_level0.py`, `wave_engine_level0.py`, and multiple experiment scripts. [[1]](diffhunk://#diff-a1d03c4ac0417a2333f0626af21ef55105994e9f2aead28872ed00e0758ea54dL16-R16) [[2]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL14-R14) [[3]](diffhunk://#diff-d37fae9360a2e6d99d3b9f75ecf176712e603e63247cbb3368fe16a3661c20dbL3-R3) [[4]](diffhunk://#diff-a60efefb4f2e4329e016638178c4f8ff72170e7c20fe6d6631432aa64eda20f3L13-R13) [[5]](diffhunk://#diff-c841e80a90f35d92cf1ea03b42993672c075e0b094232265172f689cd2eaf501L16-R16) [[6]](diffhunk://#diff-b12b5622fee6ef2820126ea73559264345cfdbdd396cc7d3ee298a50aa67a261L21-R21) [[7]](diffhunk://#diff-545b1e30751eb7bb4d333f3121a650ce0cb74edcc7f02de3261b1bf15b5885bcL21-R21) [[8]](diffhunk://#diff-382fb53fae8fc7eceac652e4aaeab2e87f2c55b9b0872b14f1905a62ff203654L21-R21) [[9]](diffhunk://#diff-6e548e2bc38bacf86b9b596a0968503c334603245b244013e3cc666ded3150fcL16-R16) [[10]](diffhunk://#diff-a4a276e7b9351f5217d138d7e29794b26dd0feb55366d4af8782146e6c14352cL20-R20) [[11]](diffhunk://#diff-c61b4d6f1f1350b2d32722db1b8c42edfb5cb431c55c5f01083300e85e1f86f5L20-R20) [[12]](diffhunk://#diff-e6a5f9f6aa37839589bd1d97866249230849adeef89437581cc3125d201ed9a0L11-R11)

### Documentation Updates

* Updated the `README.md` to reflect the new video export capabilities, moving the feature from "PLANNED" to implemented, and listing `video.py` as a completed module in the I/O section and kanban board. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R65) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L342-R342) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L406-R406)

### Minor Improvements

* Made minor code cleanups in CLI scripts, such as removing unused imports and improving version retrieval logic for better reliability. [[1]](diffhunk://#diff-20fb4f72b8d94ec6e30966b1466968fb9930114ab98caec63d782457b5e622feL12-R17) [[2]](diffhunk://#diff-20fb4f72b8d94ec6e30966b1466968fb9930114ab98caec63d782457b5e622feR166-R171) [[3]](diffhunk://#diff-20fb4f72b8d94ec6e30966b1466968fb9930114ab98caec63d782457b5e622feR238-R243)

* Adjusted parameter ordering and initialization in wave engine functions for improved clarity and correctness. [[1]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aR36) [[2]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL86) [[3]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aR127-L133) [[4]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dR265-L268) [[5]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230R244-L247)

---

**References:**  
[[1]](diffhunk://#diff-18e7d1d46dc9e3cee286bc249bf4cd3034ef2841fc0ae9b3056a3cf6ed210a45R1-R68) [[2]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL21-R29) [[3]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dR105-R106) [[4]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dR332-R335) [[5]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L21-R29) [[6]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230R84-R85) [[7]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230R311-R314) [[8]](diffhunk://#diff-a1d03c4ac0417a2333f0626af21ef55105994e9f2aead28872ed00e0758ea54dL16-R16) [[9]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL14-R14) [[10]](diffhunk://#diff-d37fae9360a2e6d99d3b9f75ecf176712e603e63247cbb3368fe16a3661c20dbL3-R3) [[11]](diffhunk://#diff-a60efefb4f2e4329e016638178c4f8ff72170e7c20fe6d6631432aa64eda20f3L13-R13) [[12]](diffhunk://#diff-c841e80a90f35d92cf1ea03b42993672c075e0b094232265172f689cd2eaf501L16-R16) [[13]](diffhunk://#diff-b12b5622fee6ef2820126ea73559264345cfdbdd396cc7d3ee298a50aa67a261L21-R21) [[14]](diffhunk://#diff-545b1e30751eb7bb4d333f3121a650ce0cb74edcc7f02de3261b1bf15b5885bcL21-R21) [[15]](diffhunk://#diff-382fb53fae8fc7eceac652e4aaeab2e87f2c55b9b0872b14f1905a62ff203654L21-R21) [[16]](diffhunk://#diff-6e548e2bc38bacf86b9b596a0968503c334603245b244013e3cc666ded3150fcL16-R16) [[17]](diffhunk://#diff-a4a276e7b9351f5217d138d7e29794b26dd0feb55366d4af8782146e6c14352cL20-R20) [[18]](diffhunk://#diff-c61b4d6f1f1350b2d32722db1b8c42edfb5cb431c55c5f01083300e85e1f86f5L20-R20) [[19]](diffhunk://#diff-e6a5f9f6aa37839589bd1d97866249230849adeef89437581cc3125d201ed9a0L11-R11) [[20]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R65) [[21]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L342-R342) [[22]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L406-R406) [[23]](diffhunk://#diff-20fb4f72b8d94ec6e30966b1466968fb9930114ab98caec63d782457b5e622feL12-R17) [[24]](diffhunk://#diff-20fb4f72b8d94ec6e30966b1466968fb9930114ab98caec63d782457b5e622feR166-R171) [[25]](diffhunk://#diff-20fb4f72b8d94ec6e30966b1466968fb9930114ab98caec63d782457b5e622feR238-R243) [[26]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aR36) [[27]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL86) [[28]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aR127-L133) [[29]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dR265-L268) [[30]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230R244-L247)