### PR TITLE
Add BLUEPRINT color palette

### DIFF
--- a/openwave/_io/render.py
+++ b/openwave/_io/render.py
@@ -30,7 +30,7 @@ def init_UI(universe_size=[1.0, 1.0, 1.0], tick_spacing=0.25, cam_init_pos=[2.0,
     pkg_name = "OPENWAVE"
     title = pkg_name + " (v" + pkg_version + ")"
     width, height = pyautogui.size()
-    # width, height = 1470, 884  # uncomment to test on min supported resolution
+    # width, height = 1470, 916  # uncomment to test on min supported resolution
 
     window = ti.ui.Window(title, (width, height), vsync=True)
     camera = ti.ui.Camera()  # Camera object for 3D view control

--- a/openwave/spacetime/wave_engine_level0.py
+++ b/openwave/spacetime/wave_engine_level0.py
@@ -127,7 +127,7 @@ def oscillate_granules(
     freq_boost: ti.f32,  # type: ignore
     amp_boost: ti.f32,  # type: ignore
     ironbow: ti.i32,  # type: ignore
-    color_disp: ti.i32,  # type: ignore
+    var_displacement: ti.i32,  # type: ignore
     num_sources: ti.i32,  # type: ignore
     elapsed_t: ti.f32,  # type: ignore
 ):
@@ -191,7 +191,7 @@ def oscillate_granules(
         velocity_am: Velocity field for all granules (modified in-place, in attometers/second)
         granule_var_color: Color field for displacement/amplitude visualization
         ironbow: Ironbow coloring toggle
-        color_disp: Displacement vs amplitude toggle
+        var_displacement: Displacement vs amplitude toggle
         num_sources: Number of wave sources
         elapsed_t: Current simulation time (accumulated, seconds)
         freq_boost: Frequency multiplier (applied after slow_mo)
@@ -288,15 +288,15 @@ def oscillate_granules(
         # Map displacement/amplitude to gradient color
         if ironbow:
             granule_var_color[granule_idx] = config.get_ironbow_color(
-                displacement_am if color_disp else amplitude_am[granule_idx],
+                displacement_am if var_displacement else amplitude_am[granule_idx],
                 0.0,
-                max_displacement_am[None] if color_disp else peak_amplitude_am[None],
+                max_displacement_am[None] if var_displacement else peak_amplitude_am[None],
             )
         else:
             granule_var_color[granule_idx] = config.get_blueprint_color(
-                displacement_am if color_disp else amplitude_am[granule_idx],
+                displacement_am if var_displacement else amplitude_am[granule_idx],
                 0.0,
-                max_displacement_am[None] if color_disp else peak_amplitude_am[None],
+                max_displacement_am[None] if var_displacement else peak_amplitude_am[None],
             )
 
     # Reset amplitude trackers if amplitude boost changed

--- a/openwave/spacetime/wave_engine_level0.py
+++ b/openwave/spacetime/wave_engine_level0.py
@@ -126,6 +126,7 @@ def oscillate_granules(
     granule_var_color: ti.template(),  # type: ignore
     freq_boost: ti.f32,  # type: ignore
     amp_boost: ti.f32,  # type: ignore
+    ironbow: ti.i32,  # type: ignore
     color_disp: ti.i32,  # type: ignore
     num_sources: ti.i32,  # type: ignore
     elapsed_t: ti.f32,  # type: ignore
@@ -188,8 +189,9 @@ def oscillate_granules(
         equilibrium_am: Equilibrium (rest) positions for all granules (in attometers)
         amplitude_am: Amplitude field for all granules (modified in-place, in attometers)
         velocity_am: Velocity field for all granules (modified in-place, in attometers/second)
-        granule_var_color: Color field for IRONBOW displacement visualization
-        color_disp: Ironbow displacement vs amplitude toggle
+        granule_var_color: Color field for displacement/amplitude visualization
+        ironbow: Ironbow coloring toggle
+        color_disp: Displacement vs amplitude toggle
         num_sources: Number of wave sources
         elapsed_t: Current simulation time (accumulated, seconds)
         freq_boost: Frequency multiplier (applied after slow_mo)
@@ -284,11 +286,18 @@ def oscillate_granules(
 
         # COLOR CONVERSION OF DISPLACEMENT/AMPLITUDE VALUES
         # Map displacement/amplitude to gradient color
-        granule_var_color[granule_idx] = config.get_ironbow_color(
-            displacement_am if color_disp else amplitude_am[granule_idx],
-            0.0,
-            max_displacement_am[None] if color_disp else peak_amplitude_am[None],
-        )
+        if ironbow:
+            granule_var_color[granule_idx] = config.get_ironbow_color(
+                displacement_am if color_disp else amplitude_am[granule_idx],
+                0.0,
+                max_displacement_am[None] if color_disp else peak_amplitude_am[None],
+            )
+        else:
+            granule_var_color[granule_idx] = config.get_blueprint_color(
+                displacement_am if color_disp else amplitude_am[granule_idx],
+                0.0,
+                max_displacement_am[None] if color_disp else peak_amplitude_am[None],
+            )
 
     # Reset amplitude trackers if amplitude boost changed
     # Prevents stale high values when amp_boost is reduced

--- a/openwave/spacetime/wave_engine_level0.py
+++ b/openwave/spacetime/wave_engine_level0.py
@@ -126,7 +126,7 @@ def oscillate_granules(
     granule_var_color: ti.template(),  # type: ignore
     freq_boost: ti.f32,  # type: ignore
     amp_boost: ti.f32,  # type: ignore
-    ib_displacement: ti.i32,  # type: ignore
+    color_disp: ti.i32,  # type: ignore
     num_sources: ti.i32,  # type: ignore
     elapsed_t: ti.f32,  # type: ignore
 ):
@@ -189,7 +189,7 @@ def oscillate_granules(
         amplitude_am: Amplitude field for all granules (modified in-place, in attometers)
         velocity_am: Velocity field for all granules (modified in-place, in attometers/second)
         granule_var_color: Color field for IRONBOW displacement visualization
-        ib_displacement: Ironbow displacement vs amplitude toggle
+        color_disp: Ironbow displacement vs amplitude toggle
         num_sources: Number of wave sources
         elapsed_t: Current simulation time (accumulated, seconds)
         freq_boost: Frequency multiplier (applied after slow_mo)
@@ -282,12 +282,12 @@ def oscillate_granules(
         # Used for numerical analysis
         ti.atomic_max(max_displacement_am[None], displacement_am)
 
-        # IRONBOW COLOR CONVERSION OF DISPLACEMENT/AMPLITUDE VALUE
-        # Map displacement/amplitude to IRONBOW thermal gradient color
+        # COLOR CONVERSION OF DISPLACEMENT/AMPLITUDE VALUES
+        # Map displacement/amplitude to gradient color
         granule_var_color[granule_idx] = config.get_ironbow_color(
-            displacement_am if ib_displacement else amplitude_am[granule_idx],
+            displacement_am if color_disp else amplitude_am[granule_idx],
             0.0,
-            max_displacement_am[None] if ib_displacement else peak_amplitude_am[None],
+            max_displacement_am[None] if color_disp else peak_amplitude_am[None],
         )
 
     # Reset amplitude trackers if amplitude boost changed

--- a/openwave/xperiments/level0_granule_based/spacetime_vibration.py
+++ b/openwave/xperiments/level0_granule_based/spacetime_vibration.py
@@ -91,7 +91,8 @@ amp_boost = 1.0  # Initialize amplitude boost
 paused = False  # Pause toggle
 granule_type = True  # Granule type coloring toggle
 ironbow = False  # Ironbow coloring toggle
-color_disp = True  # Ironbow displacement vs amplitude toggle
+blueprint = False  # Blueprint coloring toggle
+color_disp = True  # Displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -184,34 +185,53 @@ def controls():
                 paused = True
 
 
-# Initialize ironbow palette vertices & colors for gradient rendering
-palette_vertices, palette_colors = config.ironbow_palette(0.92, 0.67, 0.079, 0.01)
+# Initialize palette vertices & colors for gradient rendering
+ib_palette_vertices, ib_palette_colors = config.ironbow_palette(0.92, 0.65, 0.079, 0.01)
+bp_palette_vertices, bp_palette_colors = config.blueprint_palette(0.92, 0.65, 0.079, 0.01)
 
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, color_disp
+    global granule_type, ironbow, blueprint, color_disp
 
-    with render.gui.sub_window("COLOR MENU", 0.87, 0.74, 0.13, 0.14) as sub:
+    with render.gui.sub_window("COLOR MENU", 0.87, 0.72, 0.13, 0.16) as sub:
         if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
+            granule_type = False
             ironbow = True
+            blueprint = False
             color_disp = True
-            granule_type = False
         if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
-            ironbow = True
-            color_disp = False
             granule_type = False
-        if sub.checkbox("Granule Type (color)", granule_type):
+            ironbow = True
+            blueprint = False
+            color_disp = False
+        if sub.checkbox("Amplitude (blueprint)", blueprint and not color_disp):
+            granule_type = False
+            ironbow = False
+            blueprint = True
+            color_disp = False
+        if sub.checkbox("Granule Type Color", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default (color)", not (granule_type or ironbow)):
+            blueprint = False
+            color_disp = False
+        if sub.checkbox("Medium Default Color", not (granule_type or ironbow or blueprint)):
             granule_type = False
             ironbow = False
+            blueprint = False
+            color_disp = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
-            render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
+            render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.68, 0.08, 0.06
+                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+            ) as sub:
+                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+        if blueprint:  # Display blueprint gradient palette
+            # blueprint4: dark blue -> medium blue -> light blue -> extra-light blue
+            render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
+            with render.gui.sub_window(
+                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
                 sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
 
@@ -264,7 +284,8 @@ def render_xperiment(lattice):
                 lattice.granule_var_color,  # Granule color variations
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
-                color_disp,  # Ironbow displacement vs amplitude toggle
+                ironbow,  # Ironbow coloring toggle
+                color_disp,  # Displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )
@@ -300,15 +321,12 @@ def render_xperiment(lattice):
                 radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
-        elif ironbow:
+        elif ironbow or blueprint:
             render.scene.particles(
                 lattice.position_screen,
                 radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
-            # Display ironbow gradient palette
-            # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
-            render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
         else:
             render.scene.particles(
                 lattice.position_screen,

--- a/openwave/xperiments/level0_granule_based/spacetime_vibration.py
+++ b/openwave/xperiments/level0_granule_based/spacetime_vibration.py
@@ -91,7 +91,7 @@ amp_boost = 1.0  # Initialize amplitude boost
 paused = False  # Pause toggle
 granule_type = True  # Granule type coloring toggle
 ironbow = False  # Ironbow coloring toggle
-ib_displacement = True  # Ironbow displacement vs amplitude toggle
+color_disp = True  # Ironbow displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -190,30 +190,30 @@ palette_vertices, palette_colors = config.ironbow_palette(0.92, 0.67, 0.079, 0.0
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, ib_displacement
+    global granule_type, ironbow, color_disp
 
     with render.gui.sub_window("COLOR MENU", 0.87, 0.74, 0.13, 0.14) as sub:
-        if sub.checkbox("Displacement (Ironbow)", ironbow and ib_displacement):
+        if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
             ironbow = True
-            ib_displacement = True
+            color_disp = True
             granule_type = False
-        if sub.checkbox("Amplitude (Ironbow)", ironbow and not ib_displacement):
+        if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
             ironbow = True
-            ib_displacement = False
+            color_disp = False
             granule_type = False
-        if sub.checkbox("Granule Type (Color)", granule_type):
+        if sub.checkbox("Granule Type (color)", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default (Color)", not (granule_type or ironbow)):
+        if sub.checkbox("Medium Default (color)", not (granule_type or ironbow)):
             granule_type = False
             ironbow = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
             with render.gui.sub_window(
-                "displacement" if ib_displacement else "amplitude", 0.92, 0.68, 0.08, 0.06
+                "displacement" if color_disp else "amplitude", 0.92, 0.68, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if ib_displacement else peak_amplitude:.0e}m")
+                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
 
 
 # ================================================================
@@ -264,7 +264,7 @@ def render_xperiment(lattice):
                 lattice.granule_var_color,  # Granule color variations
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
-                ib_displacement,  # Ironbow displacement vs amplitude toggle
+                color_disp,  # Ironbow displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )

--- a/openwave/xperiments/level0_granule_based/spacetime_vibration.py
+++ b/openwave/xperiments/level0_granule_based/spacetime_vibration.py
@@ -92,7 +92,7 @@ paused = False  # Pause toggle
 granule_type = True  # Granule type coloring toggle
 ironbow = False  # Ironbow coloring toggle
 blueprint = False  # Blueprint coloring toggle
-color_disp = True  # Displacement vs amplitude toggle
+var_displacement = True  # Displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -192,48 +192,52 @@ bp_palette_vertices, bp_palette_colors = config.blueprint_palette(0.92, 0.65, 0.
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, blueprint, color_disp
+    global granule_type, ironbow, blueprint, var_displacement
 
     with render.gui.sub_window("COLOR MENU", 0.87, 0.72, 0.13, 0.16) as sub:
-        if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
+        if sub.checkbox("Displacement (ironbow)", ironbow and var_displacement):
             granule_type = False
             ironbow = True
             blueprint = False
-            color_disp = True
-        if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
+            var_displacement = True
+        if sub.checkbox("Amplitude (ironbow)", ironbow and not var_displacement):
             granule_type = False
             ironbow = True
             blueprint = False
-            color_disp = False
-        if sub.checkbox("Amplitude (blueprint)", blueprint and not color_disp):
+            var_displacement = False
+        if sub.checkbox("Amplitude (blueprint)", blueprint and not var_displacement):
             granule_type = False
             ironbow = False
             blueprint = True
-            color_disp = False
+            var_displacement = False
         if sub.checkbox("Granule Type Color", granule_type):
             granule_type = True
             ironbow = False
             blueprint = False
-            color_disp = False
+            var_displacement = False
         if sub.checkbox("Medium Default Color", not (granule_type or ironbow or blueprint)):
             granule_type = False
             ironbow = False
             blueprint = False
-            color_disp = False
+            var_displacement = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+                "displacement" if var_displacement else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+                sub.text(
+                    f"0       {max_displacement if var_displacement else peak_amplitude:.0e}m"
+                )
         if blueprint:  # Display blueprint gradient palette
             # blueprint4: dark blue -> medium blue -> light blue -> extra-light blue
             render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+                "displacement" if var_displacement else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+                sub.text(
+                    f"0       {max_displacement if var_displacement else peak_amplitude:.0e}m"
+                )
 
 
 # ================================================================
@@ -285,7 +289,7 @@ def render_xperiment(lattice):
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
                 ironbow,  # Ironbow coloring toggle
-                color_disp,  # Displacement vs amplitude toggle
+                var_displacement,  # Displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )

--- a/openwave/xperiments/level0_granule_based/spherical_wave.py
+++ b/openwave/xperiments/level0_granule_based/spherical_wave.py
@@ -70,7 +70,8 @@ amp_boost = 5.0  # Initialize amplitude boost
 paused = False  # Pause toggle
 granule_type = False  # Granule type coloring toggle
 ironbow = False  # Ironbow coloring toggle
-color_disp = True  # Ironbow displacement vs amplitude toggle
+blueprint = False  # Blueprint coloring toggle
+color_disp = True  # Displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -163,34 +164,53 @@ def controls():
                 paused = True
 
 
-# Initialize ironbow palette vertices & colors for gradient rendering
-palette_vertices, palette_colors = config.ironbow_palette(0.92, 0.67, 0.079, 0.01)
+# Initialize palette vertices & colors for gradient rendering
+ib_palette_vertices, ib_palette_colors = config.ironbow_palette(0.92, 0.65, 0.079, 0.01)
+bp_palette_vertices, bp_palette_colors = config.blueprint_palette(0.92, 0.65, 0.079, 0.01)
 
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, color_disp
+    global granule_type, ironbow, blueprint, color_disp
 
-    with render.gui.sub_window("COLOR MENU", 0.87, 0.74, 0.13, 0.14) as sub:
+    with render.gui.sub_window("COLOR MENU", 0.87, 0.72, 0.13, 0.16) as sub:
         if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
+            granule_type = False
             ironbow = True
+            blueprint = False
             color_disp = True
-            granule_type = False
         if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
-            ironbow = True
-            color_disp = False
             granule_type = False
-        if sub.checkbox("Granule Type (color)", granule_type):
+            ironbow = True
+            blueprint = False
+            color_disp = False
+        if sub.checkbox("Amplitude (blueprint)", blueprint and not color_disp):
+            granule_type = False
+            ironbow = False
+            blueprint = True
+            color_disp = False
+        if sub.checkbox("Granule Type Color", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default (color)", not (granule_type or ironbow)):
+            blueprint = False
+            color_disp = False
+        if sub.checkbox("Medium Default Color", not (granule_type or ironbow or blueprint)):
             granule_type = False
             ironbow = False
+            blueprint = False
+            color_disp = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
-            render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
+            render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.68, 0.08, 0.06
+                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+            ) as sub:
+                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+        if blueprint:  # Display blueprint gradient palette
+            # blueprint4: dark blue -> medium blue -> light blue -> extra-light blue
+            render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
+            with render.gui.sub_window(
+                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
                 sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
 
@@ -243,7 +263,8 @@ def render_xperiment(lattice):
                 lattice.granule_var_color,  # Granule color variations
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
-                color_disp,  # Ironbow displacement vs amplitude toggle
+                ironbow,  # Ironbow coloring toggle
+                color_disp,  # Displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )
@@ -279,15 +300,12 @@ def render_xperiment(lattice):
                 radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
-        elif ironbow:
+        elif ironbow or blueprint:
             render.scene.particles(
                 lattice.position_screen,
                 radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
-            # Display ironbow gradient palette
-            # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
-            render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
         else:
             render.scene.particles(
                 lattice.position_screen,

--- a/openwave/xperiments/level0_granule_based/spherical_wave.py
+++ b/openwave/xperiments/level0_granule_based/spherical_wave.py
@@ -71,7 +71,7 @@ paused = False  # Pause toggle
 granule_type = False  # Granule type coloring toggle
 ironbow = False  # Ironbow coloring toggle
 blueprint = False  # Blueprint coloring toggle
-color_disp = True  # Displacement vs amplitude toggle
+var_displacement = True  # Displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -171,48 +171,52 @@ bp_palette_vertices, bp_palette_colors = config.blueprint_palette(0.92, 0.65, 0.
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, blueprint, color_disp
+    global granule_type, ironbow, blueprint, var_displacement
 
     with render.gui.sub_window("COLOR MENU", 0.87, 0.72, 0.13, 0.16) as sub:
-        if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
+        if sub.checkbox("Displacement (ironbow)", ironbow and var_displacement):
             granule_type = False
             ironbow = True
             blueprint = False
-            color_disp = True
-        if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
+            var_displacement = True
+        if sub.checkbox("Amplitude (ironbow)", ironbow and not var_displacement):
             granule_type = False
             ironbow = True
             blueprint = False
-            color_disp = False
-        if sub.checkbox("Amplitude (blueprint)", blueprint and not color_disp):
+            var_displacement = False
+        if sub.checkbox("Amplitude (blueprint)", blueprint and not var_displacement):
             granule_type = False
             ironbow = False
             blueprint = True
-            color_disp = False
+            var_displacement = False
         if sub.checkbox("Granule Type Color", granule_type):
             granule_type = True
             ironbow = False
             blueprint = False
-            color_disp = False
+            var_displacement = False
         if sub.checkbox("Medium Default Color", not (granule_type or ironbow or blueprint)):
             granule_type = False
             ironbow = False
             blueprint = False
-            color_disp = False
+            var_displacement = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+                "displacement" if var_displacement else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+                sub.text(
+                    f"0       {max_displacement if var_displacement else peak_amplitude:.0e}m"
+                )
         if blueprint:  # Display blueprint gradient palette
             # blueprint4: dark blue -> medium blue -> light blue -> extra-light blue
             render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+                "displacement" if var_displacement else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+                sub.text(
+                    f"0       {max_displacement if var_displacement else peak_amplitude:.0e}m"
+                )
 
 
 # ================================================================
@@ -264,7 +268,7 @@ def render_xperiment(lattice):
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
                 ironbow,  # Ironbow coloring toggle
-                color_disp,  # Displacement vs amplitude toggle
+                var_displacement,  # Displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )

--- a/openwave/xperiments/level0_granule_based/spherical_wave.py
+++ b/openwave/xperiments/level0_granule_based/spherical_wave.py
@@ -70,7 +70,7 @@ amp_boost = 5.0  # Initialize amplitude boost
 paused = False  # Pause toggle
 granule_type = False  # Granule type coloring toggle
 ironbow = False  # Ironbow coloring toggle
-ib_displacement = True  # Ironbow displacement vs amplitude toggle
+color_disp = True  # Ironbow displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -169,30 +169,30 @@ palette_vertices, palette_colors = config.ironbow_palette(0.92, 0.67, 0.079, 0.0
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, ib_displacement
+    global granule_type, ironbow, color_disp
 
     with render.gui.sub_window("COLOR MENU", 0.87, 0.74, 0.13, 0.14) as sub:
-        if sub.checkbox("Displacement (Ironbow)", ironbow and ib_displacement):
+        if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
             ironbow = True
-            ib_displacement = True
+            color_disp = True
             granule_type = False
-        if sub.checkbox("Amplitude (Ironbow)", ironbow and not ib_displacement):
+        if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
             ironbow = True
-            ib_displacement = False
+            color_disp = False
             granule_type = False
-        if sub.checkbox("Granule Type (Color)", granule_type):
+        if sub.checkbox("Granule Type (color)", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default (Color)", not (granule_type or ironbow)):
+        if sub.checkbox("Medium Default (color)", not (granule_type or ironbow)):
             granule_type = False
             ironbow = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
             with render.gui.sub_window(
-                "displacement" if ib_displacement else "amplitude", 0.92, 0.68, 0.08, 0.06
+                "displacement" if color_disp else "amplitude", 0.92, 0.68, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if ib_displacement else peak_amplitude:.0e}m")
+                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
 
 
 # ================================================================
@@ -243,7 +243,7 @@ def render_xperiment(lattice):
                 lattice.granule_var_color,  # Granule color variations
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
-                ib_displacement,  # Ironbow displacement vs amplitude toggle
+                color_disp,  # Ironbow displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )

--- a/openwave/xperiments/level0_granule_based/standing_wave.py
+++ b/openwave/xperiments/level0_granule_based/standing_wave.py
@@ -83,7 +83,7 @@ amp_boost = 0.1  # Initialize amplitude boost
 paused = False  # Pause toggle
 granule_type = False  # Granule type coloring toggle
 ironbow = True  # Ironbow coloring toggle
-ib_displacement = True  # Ironbow displacement vs amplitude toggle
+color_disp = True  # Ironbow displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -182,30 +182,30 @@ palette_vertices, palette_colors = config.ironbow_palette(0.92, 0.67, 0.079, 0.0
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, ib_displacement
+    global granule_type, ironbow, color_disp
 
     with render.gui.sub_window("COLOR MENU", 0.87, 0.74, 0.13, 0.14) as sub:
-        if sub.checkbox("Displacement (Ironbow)", ironbow and ib_displacement):
+        if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
             ironbow = True
-            ib_displacement = True
+            color_disp = True
             granule_type = False
-        if sub.checkbox("Amplitude (Ironbow)", ironbow and not ib_displacement):
+        if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
             ironbow = True
-            ib_displacement = False
+            color_disp = False
             granule_type = False
-        if sub.checkbox("Granule Type (Color)", granule_type):
+        if sub.checkbox("Granule Type (color)", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default (Color)", not (granule_type or ironbow)):
+        if sub.checkbox("Medium Default (color)", not (granule_type or ironbow)):
             granule_type = False
             ironbow = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
             with render.gui.sub_window(
-                "displacement" if ib_displacement else "amplitude", 0.92, 0.68, 0.08, 0.06
+                "displacement" if color_disp else "amplitude", 0.92, 0.68, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if ib_displacement else peak_amplitude:.0e}m")
+                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
 
 
 # ================================================================
@@ -256,7 +256,7 @@ def render_xperiment(lattice):
                 lattice.granule_var_color,  # Granule color variations
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
-                ib_displacement,  # Ironbow displacement vs amplitude toggle
+                color_disp,  # Ironbow displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )

--- a/openwave/xperiments/level0_granule_based/standing_wave.py
+++ b/openwave/xperiments/level0_granule_based/standing_wave.py
@@ -83,7 +83,8 @@ amp_boost = 0.1  # Initialize amplitude boost
 paused = False  # Pause toggle
 granule_type = False  # Granule type coloring toggle
 ironbow = True  # Ironbow coloring toggle
-color_disp = True  # Ironbow displacement vs amplitude toggle
+blueprint = False  # Blueprint coloring toggle
+color_disp = True  # Displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -176,34 +177,53 @@ def controls():
                 paused = True
 
 
-# Initialize ironbow palette vertices & colors for gradient rendering
-palette_vertices, palette_colors = config.ironbow_palette(0.92, 0.67, 0.079, 0.01)
+# Initialize palette vertices & colors for gradient rendering
+ib_palette_vertices, ib_palette_colors = config.ironbow_palette(0.92, 0.65, 0.079, 0.01)
+bp_palette_vertices, bp_palette_colors = config.blueprint_palette(0.92, 0.65, 0.079, 0.01)
 
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, color_disp
+    global granule_type, ironbow, blueprint, color_disp
 
-    with render.gui.sub_window("COLOR MENU", 0.87, 0.74, 0.13, 0.14) as sub:
+    with render.gui.sub_window("COLOR MENU", 0.87, 0.72, 0.13, 0.16) as sub:
         if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
+            granule_type = False
             ironbow = True
+            blueprint = False
             color_disp = True
-            granule_type = False
         if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
-            ironbow = True
-            color_disp = False
             granule_type = False
-        if sub.checkbox("Granule Type (color)", granule_type):
+            ironbow = True
+            blueprint = False
+            color_disp = False
+        if sub.checkbox("Amplitude (blueprint)", blueprint and not color_disp):
+            granule_type = False
+            ironbow = False
+            blueprint = True
+            color_disp = False
+        if sub.checkbox("Granule Type Color", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default (color)", not (granule_type or ironbow)):
+            blueprint = False
+            color_disp = False
+        if sub.checkbox("Medium Default Color", not (granule_type or ironbow or blueprint)):
             granule_type = False
             ironbow = False
+            blueprint = False
+            color_disp = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
-            render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
+            render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.68, 0.08, 0.06
+                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+            ) as sub:
+                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+        if blueprint:  # Display blueprint gradient palette
+            # blueprint4: dark blue -> medium blue -> light blue -> extra-light blue
+            render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
+            with render.gui.sub_window(
+                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
                 sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
 
@@ -256,7 +276,8 @@ def render_xperiment(lattice):
                 lattice.granule_var_color,  # Granule color variations
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
-                color_disp,  # Ironbow displacement vs amplitude toggle
+                ironbow,  # Ironbow coloring toggle
+                color_disp,  # Displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )
@@ -292,7 +313,7 @@ def render_xperiment(lattice):
                 radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
-        elif ironbow:
+        elif ironbow or blueprint:
             render.scene.particles(
                 lattice.position_screen,
                 radius=granule.radius_screen * radius_factor,

--- a/openwave/xperiments/level0_granule_based/standing_wave.py
+++ b/openwave/xperiments/level0_granule_based/standing_wave.py
@@ -84,7 +84,7 @@ paused = False  # Pause toggle
 granule_type = False  # Granule type coloring toggle
 ironbow = True  # Ironbow coloring toggle
 blueprint = False  # Blueprint coloring toggle
-color_disp = True  # Displacement vs amplitude toggle
+var_displacement = True  # Displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -184,48 +184,52 @@ bp_palette_vertices, bp_palette_colors = config.blueprint_palette(0.92, 0.65, 0.
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, blueprint, color_disp
+    global granule_type, ironbow, blueprint, var_displacement
 
     with render.gui.sub_window("COLOR MENU", 0.87, 0.72, 0.13, 0.16) as sub:
-        if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
+        if sub.checkbox("Displacement (ironbow)", ironbow and var_displacement):
             granule_type = False
             ironbow = True
             blueprint = False
-            color_disp = True
-        if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
+            var_displacement = True
+        if sub.checkbox("Amplitude (ironbow)", ironbow and not var_displacement):
             granule_type = False
             ironbow = True
             blueprint = False
-            color_disp = False
-        if sub.checkbox("Amplitude (blueprint)", blueprint and not color_disp):
+            var_displacement = False
+        if sub.checkbox("Amplitude (blueprint)", blueprint and not var_displacement):
             granule_type = False
             ironbow = False
             blueprint = True
-            color_disp = False
+            var_displacement = False
         if sub.checkbox("Granule Type Color", granule_type):
             granule_type = True
             ironbow = False
             blueprint = False
-            color_disp = False
+            var_displacement = False
         if sub.checkbox("Medium Default Color", not (granule_type or ironbow or blueprint)):
             granule_type = False
             ironbow = False
             blueprint = False
-            color_disp = False
+            var_displacement = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+                "displacement" if var_displacement else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+                sub.text(
+                    f"0       {max_displacement if var_displacement else peak_amplitude:.0e}m"
+                )
         if blueprint:  # Display blueprint gradient palette
             # blueprint4: dark blue -> medium blue -> light blue -> extra-light blue
             render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+                "displacement" if var_displacement else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+                sub.text(
+                    f"0       {max_displacement if var_displacement else peak_amplitude:.0e}m"
+                )
 
 
 # ================================================================
@@ -277,7 +281,7 @@ def render_xperiment(lattice):
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
                 ironbow,  # Ironbow coloring toggle
-                color_disp,  # Displacement vs amplitude toggle
+                var_displacement,  # Displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )

--- a/openwave/xperiments/level0_granule_based/wave_interference.py
+++ b/openwave/xperiments/level0_granule_based/wave_interference.py
@@ -87,7 +87,7 @@ paused = False  # Pause toggle
 granule_type = False  # Granule type coloring toggle
 ironbow = True  # Ironbow coloring toggle
 blueprint = False  # Blueprint coloring toggle
-color_disp = True  # Displacement vs amplitude toggle
+var_displacement = True  # Displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -187,48 +187,52 @@ bp_palette_vertices, bp_palette_colors = config.blueprint_palette(0.92, 0.65, 0.
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, blueprint, color_disp
+    global granule_type, ironbow, blueprint, var_displacement
 
     with render.gui.sub_window("COLOR MENU", 0.87, 0.72, 0.13, 0.16) as sub:
-        if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
+        if sub.checkbox("Displacement (ironbow)", ironbow and var_displacement):
             granule_type = False
             ironbow = True
             blueprint = False
-            color_disp = True
-        if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
+            var_displacement = True
+        if sub.checkbox("Amplitude (ironbow)", ironbow and not var_displacement):
             granule_type = False
             ironbow = True
             blueprint = False
-            color_disp = False
-        if sub.checkbox("Amplitude (blueprint)", blueprint and not color_disp):
+            var_displacement = False
+        if sub.checkbox("Amplitude (blueprint)", blueprint and not var_displacement):
             granule_type = False
             ironbow = False
             blueprint = True
-            color_disp = False
+            var_displacement = False
         if sub.checkbox("Granule Type Color", granule_type):
             granule_type = True
             ironbow = False
             blueprint = False
-            color_disp = False
+            var_displacement = False
         if sub.checkbox("Medium Default Color", not (granule_type or ironbow or blueprint)):
             granule_type = False
             ironbow = False
             blueprint = False
-            color_disp = False
+            var_displacement = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+                "displacement" if var_displacement else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+                sub.text(
+                    f"0       {max_displacement if var_displacement else peak_amplitude:.0e}m"
+                )
         if blueprint:  # Display blueprint gradient palette
             # blueprint4: dark blue -> medium blue -> light blue -> extra-light blue
             render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+                "displacement" if var_displacement else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+                sub.text(
+                    f"0       {max_displacement if var_displacement else peak_amplitude:.0e}m"
+                )
 
 
 # ================================================================
@@ -280,7 +284,7 @@ def render_xperiment(lattice):
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
                 ironbow,  # Ironbow coloring toggle
-                color_disp,  # Displacement vs amplitude toggle
+                var_displacement,  # Displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )

--- a/openwave/xperiments/level0_granule_based/wave_interference.py
+++ b/openwave/xperiments/level0_granule_based/wave_interference.py
@@ -86,7 +86,7 @@ amp_boost = 1.0  # Initialize amplitude boost
 paused = False  # Pause toggle
 granule_type = False  # Granule type coloring toggle
 ironbow = True  # Ironbow coloring toggle
-ib_displacement = True  # Ironbow displacement vs amplitude toggle
+color_disp = True  # Ironbow displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -185,30 +185,30 @@ palette_vertices, palette_colors = config.ironbow_palette(0.92, 0.67, 0.079, 0.0
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, ib_displacement
+    global granule_type, ironbow, color_disp
 
     with render.gui.sub_window("COLOR MENU", 0.87, 0.74, 0.13, 0.14) as sub:
-        if sub.checkbox("Displacement (Ironbow)", ironbow and ib_displacement):
+        if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
             ironbow = True
-            ib_displacement = True
+            color_disp = True
             granule_type = False
-        if sub.checkbox("Amplitude (Ironbow)", ironbow and not ib_displacement):
+        if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
             ironbow = True
-            ib_displacement = False
+            color_disp = False
             granule_type = False
-        if sub.checkbox("Granule Type (Color)", granule_type):
+        if sub.checkbox("Granule Type (color)", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default (Color)", not (granule_type or ironbow)):
+        if sub.checkbox("Medium Default (color)", not (granule_type or ironbow)):
             granule_type = False
             ironbow = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
             with render.gui.sub_window(
-                "displacement" if ib_displacement else "amplitude", 0.92, 0.68, 0.08, 0.06
+                "displacement" if color_disp else "amplitude", 0.92, 0.68, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if ib_displacement else peak_amplitude:.0e}m")
+                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
 
 
 # ================================================================
@@ -259,7 +259,7 @@ def render_xperiment(lattice):
                 lattice.granule_var_color,  # Granule color variations
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
-                ib_displacement,  # Ironbow displacement vs amplitude toggle
+                color_disp,  # Ironbow displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )

--- a/openwave/xperiments/level0_granule_based/wave_interference.py
+++ b/openwave/xperiments/level0_granule_based/wave_interference.py
@@ -86,7 +86,8 @@ amp_boost = 1.0  # Initialize amplitude boost
 paused = False  # Pause toggle
 granule_type = False  # Granule type coloring toggle
 ironbow = True  # Ironbow coloring toggle
-color_disp = True  # Ironbow displacement vs amplitude toggle
+blueprint = False  # Blueprint coloring toggle
+color_disp = True  # Displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -179,34 +180,53 @@ def controls():
                 paused = True
 
 
-# Initialize ironbow palette vertices & colors for gradient rendering
-palette_vertices, palette_colors = config.ironbow_palette(0.92, 0.67, 0.079, 0.01)
+# Initialize palette vertices & colors for gradient rendering
+ib_palette_vertices, ib_palette_colors = config.ironbow_palette(0.92, 0.65, 0.079, 0.01)
+bp_palette_vertices, bp_palette_colors = config.blueprint_palette(0.92, 0.65, 0.079, 0.01)
 
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, color_disp
+    global granule_type, ironbow, blueprint, color_disp
 
-    with render.gui.sub_window("COLOR MENU", 0.87, 0.74, 0.13, 0.14) as sub:
+    with render.gui.sub_window("COLOR MENU", 0.87, 0.72, 0.13, 0.16) as sub:
         if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
+            granule_type = False
             ironbow = True
+            blueprint = False
             color_disp = True
-            granule_type = False
         if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
-            ironbow = True
-            color_disp = False
             granule_type = False
-        if sub.checkbox("Granule Type (color)", granule_type):
+            ironbow = True
+            blueprint = False
+            color_disp = False
+        if sub.checkbox("Amplitude (blueprint)", blueprint and not color_disp):
+            granule_type = False
+            ironbow = False
+            blueprint = True
+            color_disp = False
+        if sub.checkbox("Granule Type Color", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default (color)", not (granule_type or ironbow)):
+            blueprint = False
+            color_disp = False
+        if sub.checkbox("Medium Default Color", not (granule_type or ironbow or blueprint)):
             granule_type = False
             ironbow = False
+            blueprint = False
+            color_disp = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
-            render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
+            render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.68, 0.08, 0.06
+                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+            ) as sub:
+                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+        if blueprint:  # Display blueprint gradient palette
+            # blueprint4: dark blue -> medium blue -> light blue -> extra-light blue
+            render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
+            with render.gui.sub_window(
+                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
                 sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
 
@@ -259,7 +279,8 @@ def render_xperiment(lattice):
                 lattice.granule_var_color,  # Granule color variations
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
-                color_disp,  # Ironbow displacement vs amplitude toggle
+                ironbow,  # Ironbow coloring toggle
+                color_disp,  # Displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )
@@ -295,15 +316,12 @@ def render_xperiment(lattice):
                 radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
-        elif ironbow:
+        elif ironbow or blueprint:
             render.scene.particles(
                 lattice.position_screen,
                 radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
-            # Display ironbow gradient palette
-            # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
-            render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
         else:
             render.scene.particles(
                 lattice.position_screen,

--- a/openwave/xperiments/level0_granule_based/wave_pulse.py
+++ b/openwave/xperiments/level0_granule_based/wave_pulse.py
@@ -70,7 +70,8 @@ amp_boost = 5.0  # Initialize amplitude boost
 paused = False  # Pause toggle
 granule_type = False  # Granule type coloring toggle
 ironbow = False  # Ironbow coloring toggle
-color_disp = True  # Ironbow displacement vs amplitude toggle
+blueprint = False  # Blueprint coloring toggle
+color_disp = True  # Displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -163,34 +164,53 @@ def controls():
                 paused = True
 
 
-# Initialize ironbow palette vertices & colors for gradient rendering
-palette_vertices, palette_colors = config.ironbow_palette(0.92, 0.67, 0.079, 0.01)
+# Initialize palette vertices & colors for gradient rendering
+ib_palette_vertices, ib_palette_colors = config.ironbow_palette(0.92, 0.65, 0.079, 0.01)
+bp_palette_vertices, bp_palette_colors = config.blueprint_palette(0.92, 0.65, 0.079, 0.01)
 
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, color_disp
+    global granule_type, ironbow, blueprint, color_disp
 
-    with render.gui.sub_window("COLOR MENU", 0.87, 0.74, 0.13, 0.14) as sub:
+    with render.gui.sub_window("COLOR MENU", 0.87, 0.72, 0.13, 0.16) as sub:
         if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
+            granule_type = False
             ironbow = True
+            blueprint = False
             color_disp = True
-            granule_type = False
         if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
-            ironbow = True
-            color_disp = False
             granule_type = False
-        if sub.checkbox("Granule Type (color)", granule_type):
+            ironbow = True
+            blueprint = False
+            color_disp = False
+        if sub.checkbox("Amplitude (blueprint)", blueprint and not color_disp):
+            granule_type = False
+            ironbow = False
+            blueprint = True
+            color_disp = False
+        if sub.checkbox("Granule Type Color", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default (color)", not (granule_type or ironbow)):
+            blueprint = False
+            color_disp = False
+        if sub.checkbox("Medium Default Color", not (granule_type or ironbow or blueprint)):
             granule_type = False
             ironbow = False
+            blueprint = False
+            color_disp = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
-            render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
+            render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.68, 0.08, 0.06
+                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+            ) as sub:
+                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+        if blueprint:  # Display blueprint gradient palette
+            # blueprint4: dark blue -> medium blue -> light blue -> extra-light blue
+            render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
+            with render.gui.sub_window(
+                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
                 sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
 
@@ -243,7 +263,8 @@ def render_xperiment(lattice):
                 lattice.granule_var_color,  # Granule color variations
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
-                color_disp,  # Ironbow displacement vs amplitude toggle
+                ironbow,  # Ironbow coloring toggle
+                color_disp,  # Displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )
@@ -279,15 +300,12 @@ def render_xperiment(lattice):
                 radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
-        elif ironbow:
+        elif ironbow or blueprint:
             render.scene.particles(
                 lattice.position_screen,
                 radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
-            # Display ironbow gradient palette
-            # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
-            render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
         else:
             render.scene.particles(
                 lattice.position_screen,

--- a/openwave/xperiments/level0_granule_based/wave_pulse.py
+++ b/openwave/xperiments/level0_granule_based/wave_pulse.py
@@ -71,7 +71,7 @@ paused = False  # Pause toggle
 granule_type = False  # Granule type coloring toggle
 ironbow = False  # Ironbow coloring toggle
 blueprint = False  # Blueprint coloring toggle
-color_disp = True  # Displacement vs amplitude toggle
+var_displacement = True  # Displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -171,48 +171,52 @@ bp_palette_vertices, bp_palette_colors = config.blueprint_palette(0.92, 0.65, 0.
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, blueprint, color_disp
+    global granule_type, ironbow, blueprint, var_displacement
 
     with render.gui.sub_window("COLOR MENU", 0.87, 0.72, 0.13, 0.16) as sub:
-        if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
+        if sub.checkbox("Displacement (ironbow)", ironbow and var_displacement):
             granule_type = False
             ironbow = True
             blueprint = False
-            color_disp = True
-        if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
+            var_displacement = True
+        if sub.checkbox("Amplitude (ironbow)", ironbow and not var_displacement):
             granule_type = False
             ironbow = True
             blueprint = False
-            color_disp = False
-        if sub.checkbox("Amplitude (blueprint)", blueprint and not color_disp):
+            var_displacement = False
+        if sub.checkbox("Amplitude (blueprint)", blueprint and not var_displacement):
             granule_type = False
             ironbow = False
             blueprint = True
-            color_disp = False
+            var_displacement = False
         if sub.checkbox("Granule Type Color", granule_type):
             granule_type = True
             ironbow = False
             blueprint = False
-            color_disp = False
+            var_displacement = False
         if sub.checkbox("Medium Default Color", not (granule_type or ironbow or blueprint)):
             granule_type = False
             ironbow = False
             blueprint = False
-            color_disp = False
+            var_displacement = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+                "displacement" if var_displacement else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+                sub.text(
+                    f"0       {max_displacement if var_displacement else peak_amplitude:.0e}m"
+                )
         if blueprint:  # Display blueprint gradient palette
             # blueprint4: dark blue -> medium blue -> light blue -> extra-light blue
             render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+                "displacement" if var_displacement else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+                sub.text(
+                    f"0       {max_displacement if var_displacement else peak_amplitude:.0e}m"
+                )
 
 
 # ================================================================
@@ -264,7 +268,7 @@ def render_xperiment(lattice):
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
                 ironbow,  # Ironbow coloring toggle
-                color_disp,  # Displacement vs amplitude toggle
+                var_displacement,  # Displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )

--- a/openwave/xperiments/level0_granule_based/wave_pulse.py
+++ b/openwave/xperiments/level0_granule_based/wave_pulse.py
@@ -70,7 +70,7 @@ amp_boost = 5.0  # Initialize amplitude boost
 paused = False  # Pause toggle
 granule_type = False  # Granule type coloring toggle
 ironbow = False  # Ironbow coloring toggle
-ib_displacement = True  # Ironbow displacement vs amplitude toggle
+color_disp = True  # Ironbow displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -169,30 +169,30 @@ palette_vertices, palette_colors = config.ironbow_palette(0.92, 0.67, 0.079, 0.0
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, ib_displacement
+    global granule_type, ironbow, color_disp
 
     with render.gui.sub_window("COLOR MENU", 0.87, 0.74, 0.13, 0.14) as sub:
-        if sub.checkbox("Displacement (Ironbow)", ironbow and ib_displacement):
+        if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
             ironbow = True
-            ib_displacement = True
+            color_disp = True
             granule_type = False
-        if sub.checkbox("Amplitude (Ironbow)", ironbow and not ib_displacement):
+        if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
             ironbow = True
-            ib_displacement = False
+            color_disp = False
             granule_type = False
-        if sub.checkbox("Granule Type (Color)", granule_type):
+        if sub.checkbox("Granule Type (color)", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default (Color)", not (granule_type or ironbow)):
+        if sub.checkbox("Medium Default (color)", not (granule_type or ironbow)):
             granule_type = False
             ironbow = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
             with render.gui.sub_window(
-                "displacement" if ib_displacement else "amplitude", 0.92, 0.68, 0.08, 0.06
+                "displacement" if color_disp else "amplitude", 0.92, 0.68, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if ib_displacement else peak_amplitude:.0e}m")
+                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
 
 
 # ================================================================
@@ -243,7 +243,7 @@ def render_xperiment(lattice):
                 lattice.granule_var_color,  # Granule color variations
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
-                ib_displacement,  # Ironbow displacement vs amplitude toggle
+                color_disp,  # Ironbow displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )

--- a/openwave/xperiments/level0_granule_based/xwaves.py
+++ b/openwave/xperiments/level0_granule_based/xwaves.py
@@ -91,7 +91,8 @@ amp_boost = 5.0  # Initialize amplitude boost
 paused = False  # Pause toggle
 granule_type = True  # Granule type coloring toggle
 ironbow = False  # Ironbow coloring toggle
-color_disp = True  # Ironbow displacement vs amplitude toggle
+blueprint = False  # Blueprint coloring toggle
+color_disp = True  # Displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -184,34 +185,53 @@ def controls():
                 paused = True
 
 
-# Initialize ironbow palette vertices & colors for gradient rendering
-palette_vertices, palette_colors = config.ironbow_palette(0.92, 0.67, 0.079, 0.01)
+# Initialize palette vertices & colors for gradient rendering
+ib_palette_vertices, ib_palette_colors = config.ironbow_palette(0.92, 0.65, 0.079, 0.01)
+bp_palette_vertices, bp_palette_colors = config.blueprint_palette(0.92, 0.65, 0.079, 0.01)
 
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, color_disp
+    global granule_type, ironbow, blueprint, color_disp
 
-    with render.gui.sub_window("COLOR MENU", 0.87, 0.74, 0.13, 0.14) as sub:
+    with render.gui.sub_window("COLOR MENU", 0.87, 0.72, 0.13, 0.16) as sub:
         if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
+            granule_type = False
             ironbow = True
+            blueprint = False
             color_disp = True
-            granule_type = False
         if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
-            ironbow = True
-            color_disp = False
             granule_type = False
-        if sub.checkbox("Granule Type (color)", granule_type):
+            ironbow = True
+            blueprint = False
+            color_disp = False
+        if sub.checkbox("Amplitude (blueprint)", blueprint and not color_disp):
+            granule_type = False
+            ironbow = False
+            blueprint = True
+            color_disp = False
+        if sub.checkbox("Granule Type Color", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default (color)", not (granule_type or ironbow)):
+            blueprint = False
+            color_disp = False
+        if sub.checkbox("Medium Default Color", not (granule_type or ironbow or blueprint)):
             granule_type = False
             ironbow = False
+            blueprint = False
+            color_disp = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
-            render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
+            render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.68, 0.08, 0.06
+                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+            ) as sub:
+                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+        if blueprint:  # Display blueprint gradient palette
+            # blueprint4: dark blue -> medium blue -> light blue -> extra-light blue
+            render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
+            with render.gui.sub_window(
+                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
                 sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
 
@@ -264,7 +284,8 @@ def render_xperiment(lattice):
                 lattice.granule_var_color,  # Granule color variations
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
-                color_disp,  # Ironbow displacement vs amplitude toggle
+                ironbow,  # Ironbow coloring toggle
+                color_disp,  # Displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )
@@ -300,15 +321,12 @@ def render_xperiment(lattice):
                 radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
-        elif ironbow:
+        elif ironbow or blueprint:
             render.scene.particles(
                 lattice.position_screen,
                 radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
-            # Display ironbow gradient palette
-            # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
-            render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
         else:
             render.scene.particles(
                 lattice.position_screen,

--- a/openwave/xperiments/level0_granule_based/xwaves.py
+++ b/openwave/xperiments/level0_granule_based/xwaves.py
@@ -91,7 +91,7 @@ amp_boost = 5.0  # Initialize amplitude boost
 paused = False  # Pause toggle
 granule_type = True  # Granule type coloring toggle
 ironbow = False  # Ironbow coloring toggle
-ib_displacement = True  # Ironbow displacement vs amplitude toggle
+color_disp = True  # Ironbow displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -190,30 +190,30 @@ palette_vertices, palette_colors = config.ironbow_palette(0.92, 0.67, 0.079, 0.0
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, ib_displacement
+    global granule_type, ironbow, color_disp
 
     with render.gui.sub_window("COLOR MENU", 0.87, 0.74, 0.13, 0.14) as sub:
-        if sub.checkbox("Displacement (Ironbow)", ironbow and ib_displacement):
+        if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
             ironbow = True
-            ib_displacement = True
+            color_disp = True
             granule_type = False
-        if sub.checkbox("Amplitude (Ironbow)", ironbow and not ib_displacement):
+        if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
             ironbow = True
-            ib_displacement = False
+            color_disp = False
             granule_type = False
-        if sub.checkbox("Granule Type (Color)", granule_type):
+        if sub.checkbox("Granule Type (color)", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default (Color)", not (granule_type or ironbow)):
+        if sub.checkbox("Medium Default (color)", not (granule_type or ironbow)):
             granule_type = False
             ironbow = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
             with render.gui.sub_window(
-                "displacement" if ib_displacement else "amplitude", 0.92, 0.68, 0.08, 0.06
+                "displacement" if color_disp else "amplitude", 0.92, 0.68, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if ib_displacement else peak_amplitude:.0e}m")
+                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
 
 
 # ================================================================
@@ -264,7 +264,7 @@ def render_xperiment(lattice):
                 lattice.granule_var_color,  # Granule color variations
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
-                ib_displacement,  # Ironbow displacement vs amplitude toggle
+                color_disp,  # Ironbow displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )

--- a/openwave/xperiments/level0_granule_based/xwaves.py
+++ b/openwave/xperiments/level0_granule_based/xwaves.py
@@ -92,7 +92,7 @@ paused = False  # Pause toggle
 granule_type = True  # Granule type coloring toggle
 ironbow = False  # Ironbow coloring toggle
 blueprint = False  # Blueprint coloring toggle
-color_disp = True  # Displacement vs amplitude toggle
+var_displacement = True  # Displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -192,48 +192,52 @@ bp_palette_vertices, bp_palette_colors = config.blueprint_palette(0.92, 0.65, 0.
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, blueprint, color_disp
+    global granule_type, ironbow, blueprint, var_displacement
 
     with render.gui.sub_window("COLOR MENU", 0.87, 0.72, 0.13, 0.16) as sub:
-        if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
+        if sub.checkbox("Displacement (ironbow)", ironbow and var_displacement):
             granule_type = False
             ironbow = True
             blueprint = False
-            color_disp = True
-        if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
+            var_displacement = True
+        if sub.checkbox("Amplitude (ironbow)", ironbow and not var_displacement):
             granule_type = False
             ironbow = True
             blueprint = False
-            color_disp = False
-        if sub.checkbox("Amplitude (blueprint)", blueprint and not color_disp):
+            var_displacement = False
+        if sub.checkbox("Amplitude (blueprint)", blueprint and not var_displacement):
             granule_type = False
             ironbow = False
             blueprint = True
-            color_disp = False
+            var_displacement = False
         if sub.checkbox("Granule Type Color", granule_type):
             granule_type = True
             ironbow = False
             blueprint = False
-            color_disp = False
+            var_displacement = False
         if sub.checkbox("Medium Default Color", not (granule_type or ironbow or blueprint)):
             granule_type = False
             ironbow = False
             blueprint = False
-            color_disp = False
+            var_displacement = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+                "displacement" if var_displacement else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+                sub.text(
+                    f"0       {max_displacement if var_displacement else peak_amplitude:.0e}m"
+                )
         if blueprint:  # Display blueprint gradient palette
             # blueprint4: dark blue -> medium blue -> light blue -> extra-light blue
             render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+                "displacement" if var_displacement else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+                sub.text(
+                    f"0       {max_displacement if var_displacement else peak_amplitude:.0e}m"
+                )
 
 
 # ================================================================
@@ -285,7 +289,7 @@ def render_xperiment(lattice):
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
                 ironbow,  # Ironbow coloring toggle
-                color_disp,  # Displacement vs amplitude toggle
+                var_displacement,  # Displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )

--- a/openwave/xperiments/level0_granule_based/yin_yang.py
+++ b/openwave/xperiments/level0_granule_based/yin_yang.py
@@ -85,7 +85,8 @@ amp_boost = 5.0  # Initialize amplitude boost
 paused = False  # Pause toggle
 granule_type = True  # Granule type coloring toggle
 ironbow = False  # Ironbow coloring toggle
-color_disp = True  # Ironbow displacement vs amplitude toggle
+blueprint = False  # Blueprint coloring toggle
+color_disp = True  # Displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -178,34 +179,53 @@ def controls():
                 paused = True
 
 
-# Initialize ironbow palette vertices & colors for gradient rendering
-palette_vertices, palette_colors = config.ironbow_palette(0.92, 0.67, 0.079, 0.01)
+# Initialize palette vertices & colors for gradient rendering
+ib_palette_vertices, ib_palette_colors = config.ironbow_palette(0.92, 0.65, 0.079, 0.01)
+bp_palette_vertices, bp_palette_colors = config.blueprint_palette(0.92, 0.65, 0.079, 0.01)
 
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, color_disp
+    global granule_type, ironbow, blueprint, color_disp
 
-    with render.gui.sub_window("COLOR MENU", 0.87, 0.74, 0.13, 0.14) as sub:
+    with render.gui.sub_window("COLOR MENU", 0.87, 0.72, 0.13, 0.16) as sub:
         if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
+            granule_type = False
             ironbow = True
+            blueprint = False
             color_disp = True
-            granule_type = False
         if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
-            ironbow = True
-            color_disp = False
             granule_type = False
-        if sub.checkbox("Granule Type (color)", granule_type):
+            ironbow = True
+            blueprint = False
+            color_disp = False
+        if sub.checkbox("Amplitude (blueprint)", blueprint and not color_disp):
+            granule_type = False
+            ironbow = False
+            blueprint = True
+            color_disp = False
+        if sub.checkbox("Granule Type Color", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default (color)", not (granule_type or ironbow)):
+            blueprint = False
+            color_disp = False
+        if sub.checkbox("Medium Default Color", not (granule_type or ironbow or blueprint)):
             granule_type = False
             ironbow = False
+            blueprint = False
+            color_disp = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
-            render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
+            render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.68, 0.08, 0.06
+                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+            ) as sub:
+                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+        if blueprint:  # Display blueprint gradient palette
+            # blueprint4: dark blue -> medium blue -> light blue -> extra-light blue
+            render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
+            with render.gui.sub_window(
+                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
                 sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
 
@@ -258,7 +278,8 @@ def render_xperiment(lattice):
                 lattice.granule_var_color,  # Granule color variations
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
-                color_disp,  # Ironbow displacement vs amplitude toggle
+                ironbow,  # Ironbow coloring toggle
+                color_disp,  # Displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )
@@ -294,15 +315,12 @@ def render_xperiment(lattice):
                 radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_type_color,
             )
-        elif ironbow:
+        elif ironbow or blueprint:
             render.scene.particles(
                 lattice.position_screen,
                 radius=granule.radius_screen * radius_factor,
                 per_vertex_color=lattice.granule_var_color,
             )
-            # Display ironbow gradient palette
-            # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
-            render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
         else:
             render.scene.particles(
                 lattice.position_screen,

--- a/openwave/xperiments/level0_granule_based/yin_yang.py
+++ b/openwave/xperiments/level0_granule_based/yin_yang.py
@@ -85,7 +85,7 @@ amp_boost = 5.0  # Initialize amplitude boost
 paused = False  # Pause toggle
 granule_type = True  # Granule type coloring toggle
 ironbow = False  # Ironbow coloring toggle
-ib_displacement = True  # Ironbow displacement vs amplitude toggle
+color_disp = True  # Ironbow displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -184,30 +184,30 @@ palette_vertices, palette_colors = config.ironbow_palette(0.92, 0.67, 0.079, 0.0
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, ib_displacement
+    global granule_type, ironbow, color_disp
 
     with render.gui.sub_window("COLOR MENU", 0.87, 0.74, 0.13, 0.14) as sub:
-        if sub.checkbox("Displacement (Ironbow)", ironbow and ib_displacement):
+        if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
             ironbow = True
-            ib_displacement = True
+            color_disp = True
             granule_type = False
-        if sub.checkbox("Amplitude (Ironbow)", ironbow and not ib_displacement):
+        if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
             ironbow = True
-            ib_displacement = False
+            color_disp = False
             granule_type = False
-        if sub.checkbox("Granule Type (Color)", granule_type):
+        if sub.checkbox("Granule Type (color)", granule_type):
             granule_type = True
             ironbow = False
-        if sub.checkbox("Medium Default (Color)", not (granule_type or ironbow)):
+        if sub.checkbox("Medium Default (color)", not (granule_type or ironbow)):
             granule_type = False
             ironbow = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(palette_vertices, per_vertex_color=palette_colors)
             with render.gui.sub_window(
-                "displacement" if ib_displacement else "amplitude", 0.92, 0.68, 0.08, 0.06
+                "displacement" if color_disp else "amplitude", 0.92, 0.68, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if ib_displacement else peak_amplitude:.0e}m")
+                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
 
 
 # ================================================================
@@ -258,7 +258,7 @@ def render_xperiment(lattice):
                 lattice.granule_var_color,  # Granule color variations
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
-                ib_displacement,  # Ironbow displacement vs amplitude toggle
+                color_disp,  # Ironbow displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )

--- a/openwave/xperiments/level0_granule_based/yin_yang.py
+++ b/openwave/xperiments/level0_granule_based/yin_yang.py
@@ -86,7 +86,7 @@ paused = False  # Pause toggle
 granule_type = True  # Granule type coloring toggle
 ironbow = False  # Ironbow coloring toggle
 blueprint = False  # Blueprint coloring toggle
-color_disp = True  # Displacement vs amplitude toggle
+var_displacement = True  # Displacement vs amplitude toggle
 
 # Initialize time tracking for harmonic oscillations
 elapsed_t = 0.0
@@ -186,48 +186,52 @@ bp_palette_vertices, bp_palette_colors = config.blueprint_palette(0.92, 0.65, 0.
 
 def color_menu():
     """Render color selection menu."""
-    global granule_type, ironbow, blueprint, color_disp
+    global granule_type, ironbow, blueprint, var_displacement
 
     with render.gui.sub_window("COLOR MENU", 0.87, 0.72, 0.13, 0.16) as sub:
-        if sub.checkbox("Displacement (ironbow)", ironbow and color_disp):
+        if sub.checkbox("Displacement (ironbow)", ironbow and var_displacement):
             granule_type = False
             ironbow = True
             blueprint = False
-            color_disp = True
-        if sub.checkbox("Amplitude (ironbow)", ironbow and not color_disp):
+            var_displacement = True
+        if sub.checkbox("Amplitude (ironbow)", ironbow and not var_displacement):
             granule_type = False
             ironbow = True
             blueprint = False
-            color_disp = False
-        if sub.checkbox("Amplitude (blueprint)", blueprint and not color_disp):
+            var_displacement = False
+        if sub.checkbox("Amplitude (blueprint)", blueprint and not var_displacement):
             granule_type = False
             ironbow = False
             blueprint = True
-            color_disp = False
+            var_displacement = False
         if sub.checkbox("Granule Type Color", granule_type):
             granule_type = True
             ironbow = False
             blueprint = False
-            color_disp = False
+            var_displacement = False
         if sub.checkbox("Medium Default Color", not (granule_type or ironbow or blueprint)):
             granule_type = False
             ironbow = False
             blueprint = False
-            color_disp = False
+            var_displacement = False
         if ironbow:  # Display ironbow gradient palette
             # ironbow5: black -> dark blue -> magenta -> red-orange -> yellow-white
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+                "displacement" if var_displacement else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+                sub.text(
+                    f"0       {max_displacement if var_displacement else peak_amplitude:.0e}m"
+                )
         if blueprint:  # Display blueprint gradient palette
             # blueprint4: dark blue -> medium blue -> light blue -> extra-light blue
             render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
             with render.gui.sub_window(
-                "displacement" if color_disp else "amplitude", 0.92, 0.66, 0.08, 0.06
+                "displacement" if var_displacement else "amplitude", 0.92, 0.66, 0.08, 0.06
             ) as sub:
-                sub.text(f"0       {max_displacement if color_disp else peak_amplitude:.0e}m")
+                sub.text(
+                    f"0       {max_displacement if var_displacement else peak_amplitude:.0e}m"
+                )
 
 
 # ================================================================
@@ -279,7 +283,7 @@ def render_xperiment(lattice):
                 freq_boost,  # Frequency visibility boost (will be applied over the slow-motion factor)
                 amp_boost,  # Amplitude visibility boost for scaled lattices
                 ironbow,  # Ironbow coloring toggle
-                color_disp,  # Displacement vs amplitude toggle
+                var_displacement,  # Displacement vs amplitude toggle
                 NUM_SOURCES,  # Number of active wave sources
                 elapsed_t,
             )

--- a/openwave/xperiments/level1_field_based/_docs/03_WAVE_ENGINE.md
+++ b/openwave/xperiments/level1_field_based/_docs/03_WAVE_ENGINE.md
@@ -210,12 +210,12 @@ After initial energy Charge, the wave field requires a **stabilization period** 
 
 **Steady-State Characteristics**:
 
-```python
-# After stabilization, the field exhibits:
-# - Waves coming from all directions (not just sources)
-# - Complex interference patterns throughout domain
-# - Energy density distributed (not localized)
-# - Dynamic equilibrium (total energy constant)
+```text
+After stabilization, the field exhibits:
+- Waves coming from all directions (not just sources)
+- Complex interference patterns throughout domain
+- Energy density distributed (not localized)
+- Dynamic equilibrium (total energy constant)
 ```
 
 **Visual Description**:

--- a/openwave/xperiments/level1_field_based/_docs/04_VISUALIZATION.md
+++ b/openwave/xperiments/level1_field_based/_docs/04_VISUALIZATION.md
@@ -56,9 +56,9 @@ LEVEL-1 visualization systems convert wave field data into observable visual rep
    - **Standing Wave Rings**: Positioned at λ/2 intervals around wave centers
    - **Particle Radius**: Visualize one or two wavelengths around particles
    - **Mesh Wireframe**: Use mesh wireframe to view see tru effects (sphere)
-   - **Target Lock**: Use small green>red squares (canvas.lines) to track positions
 
 3. **VECTOR/FLOW VISUALIZATION**:
+   - **Target Lock**: Use small green>red squares (canvas.lines) to track positions
    - **Taichi Lines**: Display vector fields (force, direction, amplitude gradient)
    - **Streamlines**: Follow flow/energy propagation paths
    - **Polylines**: Smooth curves showing wave dynamics


### PR DESCRIPTION
This pull request introduces a new "blueprint" color palette for displacement/amplitude visualization in addition to the existing "ironbow" palette, and refactors the color selection logic to support toggling between ironbow, blueprint, and standard color modes. The changes include new color mapping functions, updated UI controls, and adjustments to how palette gradients are rendered and selected in the simulation experiments.

Key changes:

**Palette and Color Mapping Enhancements**
* Added a new 4-color "blueprint" palette and a corresponding `get_blueprint_color` function to `config.py` for visualizing displacement/amplitude with a blueprint-style gradient.
* Created a `blueprint_palette` function to generate the blueprint gradient for on-screen palette indicators.

**Color Mode Refactoring in Experiments**
* Refactored color mode toggles in experiment scripts (`spacetime_vibration.py`, `spherical_wave.py`, `standing_wave.py`): replaced `ib_displacement` with `blueprint` and `var_displacement` to allow toggling between ironbow, blueprint, and default color schemes. [[1]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL94-R95) [[2]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L73-R74) [[3]](diffhunk://#diff-8db97d00a08512954d58ea87d77947aebd0a637a04326fddc47ad4938a0fcf8cL86-R87)
* Updated the color selection menus and rendering logic to support the new blueprint palette, including UI checkboxes and the display of the appropriate palette gradient. [[1]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL187-R240) [[2]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L166-R219)

**Wave Engine and Rendering Logic**
* Modified the `oscillate_granules` function to use the new color mode toggles (`ironbow`, `var_displacement`) and select the appropriate color mapping function (ironbow or blueprint) for visualization. [[1]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL129-R130) [[2]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL191-R194) [[3]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL285-R299)
* Updated experiment rendering functions to pass and handle the new color mode parameters and to render the correct palette gradient based on the selected mode. [[1]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL267-R292) [[2]](diffhunk://#diff-f6671c64376482a237d9f3d2977def82f1e5dcc3961b123f3ed1c08a18695f6dL303-L311) [[3]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L246-R271) [[4]](diffhunk://#diff-3d541cafc695ab161dc490a8b2f2c215177084c24741e22fd4c8fc284e9a6230L282-L290)

**Minor UI Adjustments**
* Adjusted the test resolution height in `render.py` for min supported resolution testing.

These changes collectively improve the flexibility and visual options for displacement/amplitude visualization in the simulation experiments.