### PR TITLE
Refactor wave source and camera variable names

### DIFF
--- a/dev_docs/COORDINATE_SYSTEM.md
+++ b/dev_docs/COORDINATE_SYSTEM.md
@@ -23,7 +23,7 @@ All positions in experiments are specified using normalized coordinates in the r
 When defining wave sources in experiment files:
 
 ```python
-sources_position = [
+SOURCES_POSITION = [
     [x, y, z],  # where z ∈ [0,1] represents vertical position
     [0.5, 0.5, 1.0],  # Example: center top (Z=1 is top)
     [0.5, 0.5, 0.0],  # Example: center bottom (Z=0 is bottom)

--- a/openwave/xperiments/level0_granule_based/spacetime_vibration.py
+++ b/openwave/xperiments/level0_granule_based/spacetime_vibration.py
@@ -31,6 +31,7 @@ ti.init(arch=ti.gpu, log_level=ti.WARN)  # Use GPU if available, suppress info l
 # ================================================================
 # Xperiment Parameters & Subatomic Objects Instantiation
 # ================================================================
+CAM_INIT = [2.00, 1.50, 1.75]  # Initial camera position [x, y, z] in normalized coordinates
 
 UNIVERSE_SIZE = [
     4 * constants.EWAVE_LENGTH,
@@ -45,7 +46,7 @@ NUM_SOURCES = 9
 # Wave Source positions: normalized coordinates (0-1 range, relative to max universe edge)
 # Each row represents [x, y, z] coordinates for one source (Z-up coordinate system)
 # Only provide NUM_SOURCES entries (only active sources needed)
-sources_position = [
+SOURCES_POSITION = [
     [0.5, 0.5, 0.5],  # Wave Source 0 - Center
     [0.0, 1.0, 1.0],  # Wave Source 1 - Back-top-left corner
     [1.0, 0.0, 1.0],  # Wave Source 2 - Front-top-right corner
@@ -61,7 +62,7 @@ sources_position = [
 # Allows creating constructive/destructive interference patterns
 # Only provide NUM_SOURCES entries (only active sources needed)
 # Common patterns: 0° = in phase, 180° = opposite phase, 90° = quarter-cycle offset
-sources_phase_deg = [
+SOURCES_PHASE_DEG = [
     180,  # Wave Source 0 (eg. 0 = in phase)
     0,  # Wave Source 1 (eg. 180 = opposite phase, creates destructive interference nodes)
     0,  # Wave Source 2
@@ -110,9 +111,7 @@ VIDEO_FRAMES = 24  # The target frame number to stop recording and finalize vide
 # Xperiment UI and overlay windows
 # ================================================================
 
-render.init_UI(
-    UNIVERSE_SIZE, TICK_SPACING, cam_init_pos=[2.00, 1.50, 1.75]
-)  # Initialize the GGUI window
+render.init_UI(UNIVERSE_SIZE, TICK_SPACING, CAM_INIT)  # Initialize GGUI UI
 
 
 def xperiment_specs():
@@ -257,7 +256,7 @@ def render_xperiment(lattice):
     global elapsed_t, last_time, frame, max_displacement, peak_amplitude
 
     ewave.build_source_vectors(
-        sources_position, sources_phase_deg, NUM_SOURCES, lattice
+        SOURCES_POSITION, SOURCES_PHASE_DEG, NUM_SOURCES, lattice
     )  # compute distance & direction vectors to all sources
 
     # Print diagnostics header if enabled

--- a/openwave/xperiments/level0_granule_based/spherical_wave.py
+++ b/openwave/xperiments/level0_granule_based/spherical_wave.py
@@ -31,6 +31,7 @@ ti.init(arch=ti.gpu, log_level=ti.WARN)  # Use GPU if available, suppress info l
 # ================================================================
 # Xperiment Parameters & Subatomic Objects Instantiation
 # ================================================================
+CAM_INIT = [0.97, 2.06, 0.82]  # Initial camera position [x, y, z] in normalized coordinates
 
 UNIVERSE_SIZE = [
     4 * constants.EWAVE_LENGTH,
@@ -45,13 +46,13 @@ NUM_SOURCES = 1
 # Wave Source positions: normalized coordinates (0-1 range, relative to max universe edge)
 # Each row represents [x, y, z] coordinates for one source (Z-up coordinate system)
 # Only provide NUM_SOURCES entries (only active sources needed)
-sources_position = [[0.5, 0.5, 0.5]]  # Wave Source position - Center
+SOURCES_POSITION = [[0.5, 0.5, 0.5]]  # Wave Source position - Center
 
 # Phase offsets for each source (integer degrees, converted to radians internally)
 # Allows creating constructive/destructive interference patterns
 # Only provide NUM_SOURCES entries (only active sources needed)
 # Common patterns: 0° = in phase, 180° = opposite phase, 90° = quarter-cycle offset
-sources_phase_deg = [0]  # Wave Source phase offsets in degrees
+SOURCES_PHASE_DEG = [0]  # Wave Source phase offsets in degrees
 
 # Choose color theme for rendering (OCEAN, DESERT, FOREST)
 COLOR_THEME = "OCEAN"
@@ -89,9 +90,7 @@ VIDEO_FRAMES = 24  # The target frame number to stop recording and finalize vide
 # Xperiment UI and overlay windows
 # ================================================================
 
-render.init_UI(
-    UNIVERSE_SIZE, TICK_SPACING, cam_init_pos=[0.97, 2.06, 0.82]
-)  # Initialize the GGUI window
+render.init_UI(UNIVERSE_SIZE, TICK_SPACING, CAM_INIT)  # Initialize GGUI UI
 
 
 def xperiment_specs():
@@ -236,7 +235,7 @@ def render_xperiment(lattice):
     global elapsed_t, last_time, frame, max_displacement, peak_amplitude
 
     ewave.build_source_vectors(
-        sources_position, sources_phase_deg, NUM_SOURCES, lattice
+        SOURCES_POSITION, SOURCES_PHASE_DEG, NUM_SOURCES, lattice
     )  # compute distance & direction vectors to all sources
 
     # Print diagnostics header if enabled

--- a/openwave/xperiments/level0_granule_based/standing_wave.py
+++ b/openwave/xperiments/level0_granule_based/standing_wave.py
@@ -31,6 +31,7 @@ ti.init(arch=ti.gpu, log_level=ti.WARN)  # Use GPU if available, suppress info l
 # ================================================================
 # Xperiment Parameters & Subatomic Objects Instantiation
 # ================================================================
+CAM_INIT = [1.33, 0.67, 1.52]  # Initial camera position [x, y, z] in normalized coordinates
 
 UNIVERSE_SIZE = [
     6 * constants.EWAVE_LENGTH,
@@ -46,10 +47,10 @@ NUM_SOURCES = 64
 # Each row represents [x, y, z] coordinates for one source (Z-up coordinate system)
 # Only provide NUM_SOURCES entries (only active sources needed)
 z_position = [0.09]  # Initialize Z positions
-sources_position = []  # Initialize source positions list
+SOURCES_POSITION = []  # Initialize source positions list
 # Generate positions for remaining sources in a circle around center top
 for i in range(NUM_SOURCES):
-    sources_position.append(
+    SOURCES_POSITION.append(
         [
             ti.cos(i * 2 * ti.math.pi / (NUM_SOURCES)) * 0.333 + 0.5,
             ti.sin(i * 2 * ti.math.pi / (NUM_SOURCES)) * 0.333 + 0.5,
@@ -61,10 +62,10 @@ for i in range(NUM_SOURCES):
 # Allows creating constructive/destructive interference patterns
 # Only provide NUM_SOURCES entries (only active sources needed)
 # Common patterns: 0° = in phase, 180° = opposite phase, 90° = quarter-cycle offset
-sources_phase_deg = []  # Initialize source phases list
+SOURCES_PHASE_DEG = []  # Initialize source phases list
 # Generate phase for remaining sources in a circle around center top
 for i in range(NUM_SOURCES):
-    sources_phase_deg.append(0)  # Wave Sources Phase (eg. 0 = in phase)
+    SOURCES_PHASE_DEG.append(0)  # Wave Sources Phase (eg. 0 = in phase)
 
 # Choose color theme for rendering (OCEAN, DESERT, FOREST)
 COLOR_THEME = "OCEAN"
@@ -102,9 +103,7 @@ VIDEO_FRAMES = 24  # The target frame number to stop recording and finalize vide
 # Xperiment UI and overlay windows
 # ================================================================
 
-render.init_UI(
-    UNIVERSE_SIZE, TICK_SPACING, cam_init_pos=[1.33, 0.67, 1.52]
-)  # Initialize the GGUI window
+render.init_UI(UNIVERSE_SIZE, TICK_SPACING, CAM_INIT)  # Initialize GGUI UI
 
 
 def xperiment_specs():
@@ -249,7 +248,7 @@ def render_xperiment(lattice):
     global elapsed_t, last_time, frame, max_displacement, peak_amplitude
 
     ewave.build_source_vectors(
-        sources_position, sources_phase_deg, NUM_SOURCES, lattice
+        SOURCES_POSITION, SOURCES_PHASE_DEG, NUM_SOURCES, lattice
     )  # compute distance & direction vectors to all sources
 
     # Print diagnostics header if enabled

--- a/openwave/xperiments/level0_granule_based/wave_interference.py
+++ b/openwave/xperiments/level0_granule_based/wave_interference.py
@@ -31,6 +31,7 @@ ti.init(arch=ti.gpu, log_level=ti.WARN)  # Use GPU if available, suppress info l
 # ================================================================
 # Xperiment Parameters & Subatomic Objects Instantiation
 # ================================================================
+CAM_INIT = [0.25, 0.91, 1.00]  # Initial camera position [x, y, z] in normalized coordinates
 
 UNIVERSE_SIZE = [
     8 * constants.EWAVE_LENGTH,
@@ -47,7 +48,7 @@ NUM_SOURCES = 3  # This xperiment has pre-populated list for 6 sources, change t
 # Only provide NUM_SOURCES entries (only active sources needed)
 z_position = [0.12]  # Initialize Z positions
 equilateral = ti.sqrt(0.5**2 - 0.25**2)  # Factor for perfect triangle arrangement
-sources_position = [
+SOURCES_POSITION = [
     [0.25, 0.15 + equilateral, z_position[0]],  # Wave Source 0
     [0.75, 0.15 + equilateral, z_position[0]],  # Wave Source 1
     [0.5, 0.15, z_position[0]],  # Wave Source 2
@@ -60,7 +61,7 @@ sources_position = [
 # Allows creating constructive/destructive interference patterns
 # Only provide NUM_SOURCES entries (only active sources needed)
 # Common patterns: 0° = in phase, 180° = opposite phase, 90° = quarter-cycle offset
-sources_phase_deg = [
+SOURCES_PHASE_DEG = [
     0,  # Wave Source 0 (eg. 0 = in phase)
     0,  # Wave Source 1 (eg. 180 = opposite phase, creates destructive interference nodes)
     0,  # Wave Source 2
@@ -105,9 +106,7 @@ VIDEO_FRAMES = 24  # The target frame number to stop recording and finalize vide
 # Xperiment UI and overlay windows
 # ================================================================
 
-render.init_UI(
-    UNIVERSE_SIZE, TICK_SPACING, cam_init_pos=[0.25, 0.91, 1.00]
-)  # Initialize the GGUI window
+render.init_UI(UNIVERSE_SIZE, TICK_SPACING, CAM_INIT)  # Initialize GGUI UI
 
 
 def xperiment_specs():
@@ -252,7 +251,7 @@ def render_xperiment(lattice):
     global elapsed_t, last_time, frame, max_displacement, peak_amplitude
 
     ewave.build_source_vectors(
-        sources_position, sources_phase_deg, NUM_SOURCES, lattice
+        SOURCES_POSITION, SOURCES_PHASE_DEG, NUM_SOURCES, lattice
     )  # compute distance & direction vectors to all sources
 
     # Print diagnostics header if enabled

--- a/openwave/xperiments/level0_granule_based/wave_pulse.py
+++ b/openwave/xperiments/level0_granule_based/wave_pulse.py
@@ -31,6 +31,7 @@ ti.init(arch=ti.gpu, log_level=ti.WARN)  # Use GPU if available, suppress info l
 # ================================================================
 # Xperiment Parameters & Subatomic Objects Instantiation
 # ================================================================
+CAM_INIT = [1.35, 0.91, 0.68]  # Initial camera position [x, y, z] in normalized coordinates
 
 UNIVERSE_SIZE = [
     4 * constants.EWAVE_LENGTH,
@@ -45,13 +46,13 @@ NUM_SOURCES = 1
 # Wave Source positions: normalized coordinates (0-1 range, relative to max universe edge)
 # Each row represents [x, y, z] coordinates for one source (Z-up coordinate system)
 # Only provide NUM_SOURCES entries (only active sources needed)
-sources_position = [[0.5, 0.5, 0.5]]  # Wave Source position - Center
+SOURCES_POSITION = [[0.5, 0.5, 0.5]]  # Wave Source position - Center
 
 # Phase offsets for each source (integer degrees, converted to radians internally)
 # Allows creating constructive/destructive interference patterns
 # Only provide NUM_SOURCES entries (only active sources needed)
 # Common patterns: 0° = in phase, 180° = opposite phase, 90° = quarter-cycle offset
-sources_phase_deg = [0]  # Wave Source phase offsets in degrees
+SOURCES_PHASE_DEG = [0]  # Wave Source phase offsets in degrees
 
 # Choose color theme for rendering (OCEAN, DESERT, FOREST)
 COLOR_THEME = "OCEAN"
@@ -89,9 +90,7 @@ VIDEO_FRAMES = 24  # The target frame number to stop recording and finalize vide
 # Xperiment UI and overlay windows
 # ================================================================
 
-render.init_UI(
-    UNIVERSE_SIZE, TICK_SPACING, cam_init_pos=[1.35, 0.91, 0.68]
-)  # Initialize the GGUI window
+render.init_UI(UNIVERSE_SIZE, TICK_SPACING, CAM_INIT)  # Initialize GGUI UI
 
 
 def xperiment_specs():
@@ -236,7 +235,7 @@ def render_xperiment(lattice):
     global elapsed_t, last_time, frame, max_displacement, peak_amplitude
 
     ewave.build_source_vectors(
-        sources_position, sources_phase_deg, NUM_SOURCES, lattice
+        SOURCES_POSITION, SOURCES_PHASE_DEG, NUM_SOURCES, lattice
     )  # compute distance & direction vectors to all sources
 
     # Print diagnostics header if enabled

--- a/openwave/xperiments/level0_granule_based/xwaves.py
+++ b/openwave/xperiments/level0_granule_based/xwaves.py
@@ -31,6 +31,7 @@ ti.init(arch=ti.gpu, log_level=ti.WARN)  # Use GPU if available, suppress info l
 # ================================================================
 # Xperiment Parameters & Subatomic Objects Instantiation
 # ================================================================
+CAM_INIT = [2.00, 1.50, 1.75]  # Initial camera position [x, y, z] in normalized coordinates
 
 UNIVERSE_SIZE = [
     4 * constants.EWAVE_LENGTH,
@@ -45,7 +46,7 @@ NUM_SOURCES = 9
 # Wave Source positions: normalized coordinates (0-1 range, relative to max universe edge)
 # Each row represents [x, y, z] coordinates for one source (Z-up coordinate system)
 # Only provide NUM_SOURCES entries (only active sources needed)
-sources_position = [
+SOURCES_POSITION = [
     [0.5, 0.5, 0.5],  # Wave Source 0 - Center
     [0.0, 1.0, 1.0],  # Wave Source 1 - Back-top-left corner
     [1.0, 0.0, 1.0],  # Wave Source 2 - Front-top-right corner
@@ -61,7 +62,7 @@ sources_position = [
 # Allows creating constructive/destructive interference patterns
 # Only provide NUM_SOURCES entries (only active sources needed)
 # Common patterns: 0° = in phase, 180° = opposite phase, 90° = quarter-cycle offset
-sources_phase_deg = [
+SOURCES_PHASE_DEG = [
     180,  # Wave Source 0 (eg. 0 = in phase)
     0,  # Wave Source 1 (eg. 180 = opposite phase, creates destructive interference nodes)
     0,  # Wave Source 2
@@ -110,9 +111,7 @@ VIDEO_FRAMES = 24  # The target frame number to stop recording and finalize vide
 # Xperiment UI and overlay windows
 # ================================================================
 
-render.init_UI(
-    UNIVERSE_SIZE, TICK_SPACING, cam_init_pos=[2.00, 1.50, 1.75]
-)  # Initialize the GGUI window
+render.init_UI(UNIVERSE_SIZE, TICK_SPACING, CAM_INIT)  # Initialize GGUI UI
 
 
 def xperiment_specs():
@@ -257,7 +256,7 @@ def render_xperiment(lattice):
     global elapsed_t, last_time, frame, max_displacement, peak_amplitude
 
     ewave.build_source_vectors(
-        sources_position, sources_phase_deg, NUM_SOURCES, lattice
+        SOURCES_POSITION, SOURCES_PHASE_DEG, NUM_SOURCES, lattice
     )  # compute distance & direction vectors to all sources
 
     # Print diagnostics header if enabled

--- a/openwave/xperiments/level0_granule_based/yin_yang.py
+++ b/openwave/xperiments/level0_granule_based/yin_yang.py
@@ -31,6 +31,7 @@ ti.init(arch=ti.gpu, log_level=ti.WARN)  # Use GPU if available, suppress info l
 # ================================================================
 # Xperiment Parameters & Subatomic Objects Instantiation
 # ================================================================
+CAM_INIT = [1.50, 0.80, 1.50]  # Initial camera position [x, y, z] in normalized coordinates
 
 UNIVERSE_SIZE = [
     6 * constants.EWAVE_LENGTH,
@@ -46,11 +47,11 @@ NUM_SOURCES = 12
 # Each row represents [x, y, z] coordinates for one source (Z-up coordinate system)
 # Only provide NUM_SOURCES entries (only active sources needed)
 z_position = [0]  # Initialize Z positions
-sources_position = []  # Initialize source positions list
+SOURCES_POSITION = []  # Initialize source positions list
 # Generate positions for remaining sources in a circle around center top
 # r = λ / φ, where φ = golden ratio ~1.618, for yin-yang spiral effect
 for i in range(NUM_SOURCES):
-    sources_position.append(
+    SOURCES_POSITION.append(
         [
             ti.cos(i * 2 * ti.math.pi / (NUM_SOURCES - 1)) / (6 * 1.618) + 0.5,
             ti.sin(i * 2 * ti.math.pi / (NUM_SOURCES - 1)) / (6 * 1.618) + 0.5,
@@ -62,11 +63,11 @@ for i in range(NUM_SOURCES):
 # Allows creating constructive/destructive interference patterns
 # Only provide NUM_SOURCES entries (only active sources needed)
 # Common patterns: 0° = in phase, 180° = opposite phase, 90° = quarter-cycle offset
-sources_phase_deg = []  # Initialize source phases list
+SOURCES_PHASE_DEG = []  # Initialize source phases list
 # Generate phase for remaining sources in a circle around center top
 # 30° offset between each source for yin-yang pattern
 for i in range(NUM_SOURCES):
-    sources_phase_deg.append(i * 30)  # 0°, 30°, 60°, ..., 330°
+    SOURCES_PHASE_DEG.append(i * 30)  # 0°, 30°, 60°, ..., 330°
 
 # Choose color theme for rendering (OCEAN, DESERT, FOREST)
 COLOR_THEME = "OCEAN"
@@ -104,9 +105,7 @@ VIDEO_FRAMES = 24  # The target frame number to stop recording and finalize vide
 # Xperiment UI and overlay windows
 # ================================================================
 
-render.init_UI(
-    UNIVERSE_SIZE, TICK_SPACING, cam_init_pos=[1.50, 0.80, 1.50]
-)  # Initialize the GGUI window
+render.init_UI(UNIVERSE_SIZE, TICK_SPACING, CAM_INIT)  # Initialize GGUI UI
 
 
 def xperiment_specs():
@@ -251,7 +250,7 @@ def render_xperiment(lattice):
     global elapsed_t, last_time, frame, max_displacement, peak_amplitude
 
     ewave.build_source_vectors(
-        sources_position, sources_phase_deg, NUM_SOURCES, lattice
+        SOURCES_POSITION, SOURCES_PHASE_DEG, NUM_SOURCES, lattice
     )  # compute distance & direction vectors to all sources
 
     # Print diagnostics header if enabled


### PR DESCRIPTION
Standardizes variable names for wave source positions and phases to uppercase (SOURCES_POSITION, SOURCES_PHASE_DEG) and introduces CAM_INIT for initial camera position in all level0_granule_based xperiments. Updates usage throughout code and documentation for consistency and clarity.