### PR TITLE
Refactor UI layout and overlays in launcher_L0

### DIFF
--- a/openwave/_io/render.py
+++ b/openwave/_io/render.py
@@ -30,7 +30,7 @@ def init_UI(universe_size=[1.0, 1.0, 1.0], tick_spacing=0.25, cam_init_pos=[2.0,
     pkg_name = "OPENWAVE"
     title = pkg_name + " (v" + pkg_version + ")"
     width, height = pyautogui.size()
-    # width, height = 1470, 916  # uncomment to test on min supported resolution
+    # width, height = 1470, 884  # uncomment to test on min supported resolution
 
     window = ti.ui.Window(title, (width, height), vsync=True)
     camera = ti.ui.Camera()  # Camera object for 3D view control
@@ -208,10 +208,10 @@ def handle_camera():
 def cam_instructions():
     """Overlay camera movement instructions."""
     global cam_x, cam_y, cam_z
-    with gui.sub_window("CAMERA MOVEMENT", 0.87, 0.88, 0.13, 0.12) as sub:
+    with gui.sub_window("CAMERA MOVEMENT", 0.00, 0.88, 0.13, 0.12) as sub:
         sub.text("Orbit: RMB or Shift+LMB")
-        sub.text("Zoom: Q/Z keys")
         sub.text("Pan: Arrow keys")
+        sub.text("Zoom: Q/Z keys")
         sub.text("Cam Pos: %.2f, %.2f, %.2f" % (cam_x, cam_y, cam_z), color=config.LIGHT_BLUE[1])
 
 
@@ -221,7 +221,7 @@ def init_scene(show_axis=True):
 
     scene_lighting()  # Lighting must be set each frame in GGUI
     handle_camera()  # Handle camera input and update position
-    cam_instructions()  # Overlay camera instructions
+    cam_instructions()  # Overlay camera movement instructions
     if show_axis:
         # Render the pre-populated axis field (very fast, no data transfer)
         scene.lines(axis_field, color=config.COLOR_INFRA[1], width=2)

--- a/openwave/xperiments/level0_granule_based/_parameters/spacetime_vibration.py
+++ b/openwave/xperiments/level0_granule_based/_parameters/spacetime_vibration.py
@@ -9,7 +9,6 @@ This XPERIMENT showcases:
 - Multiple wave sources (9 sources: center + 8 corners)
 - Wave superposition and interference patterns
 - Phase control between sources (constructive/destructive interference)
-- No spring coupling (pure wave propagation)
 """
 
 PARAMETERS = {

--- a/openwave/xperiments/level0_granule_based/_parameters/spherical_wave.py
+++ b/openwave/xperiments/level0_granule_based/_parameters/spherical_wave.py
@@ -9,7 +9,6 @@ This XPERIMENT showcases:
 - Single wave source at center
 - Pure spherical wave propagation
 - Radial wave patterns
-- No spring coupling (pure wave propagation)
 """
 
 PARAMETERS = {

--- a/openwave/xperiments/level0_granule_based/_parameters/standing_wave.py
+++ b/openwave/xperiments/level0_granule_based/_parameters/standing_wave.py
@@ -10,7 +10,6 @@ This XPERIMENT showcases:
 - Standing wave formation
 - Complex interference patterns
 - Thin Z dimension for 2.5D visualization
-- No spring coupling (pure wave propagation)
 """
 
 import math

--- a/openwave/xperiments/level0_granule_based/_parameters/wave_interference.py
+++ b/openwave/xperiments/level0_granule_based/_parameters/wave_interference.py
@@ -9,7 +9,6 @@ This XPERIMENT showcases:
 - 3 wave sources in equilateral triangle pattern
 - Wave superposition and interference patterns
 - Thin Z dimension for 2.5D visualization
-- No spring coupling (pure wave propagation)
 """
 
 import math

--- a/openwave/xperiments/level0_granule_based/_parameters/wave_pulse.py
+++ b/openwave/xperiments/level0_granule_based/_parameters/wave_pulse.py
@@ -8,7 +8,6 @@ This XPERIMENT showcases:
 - Single wave source at center
 - Wave pulse radiation
 - Wave diagnostics enabled for speed and wavelength measurements
-- No spring coupling (pure wave propagation)
 """
 
 PARAMETERS = {

--- a/openwave/xperiments/level0_granule_based/_parameters/xwaves.py
+++ b/openwave/xperiments/level0_granule_based/_parameters/xwaves.py
@@ -10,7 +10,6 @@ This XPERIMENT showcases:
 - Crossing wave patterns
 - Phase control between sources (constructive/destructive interference)
 - DESERT color theme for different visual experience
-- No spring coupling (pure wave propagation)
 """
 
 PARAMETERS = {

--- a/openwave/xperiments/level0_granule_based/_parameters/yin_yang.py
+++ b/openwave/xperiments/level0_granule_based/_parameters/yin_yang.py
@@ -9,7 +9,6 @@ This XPERIMENT showcases:
 - 12 wave sources arranged in golden ratio spiral pattern
 - Progressive phase offsets (30° increments)
 - Spiral wave interference patterns
-- No spring coupling (pure wave propagation)
 """
 
 import math


### PR DESCRIPTION
Reorganized UI overlays to improve layout consistency, moving dashboard and experiment specs to the right side and controls to the left. Updated sub-window positions and sizes for better usability. Removed duplicate definitions and adjusted rendering order for overlays. Minor text and comment tweaks for clarity. Also removed redundant 'No spring coupling' line from experiment parameter docstrings.