### PR TITLE
Wave Equations Documentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,7 @@ CLAUDE.md export-ignore
 CONTRIBUTING.md export-ignore
 CODE_OF_CONDUCT.md export-ignore
 TRADEMARK export-ignore
-THIRD-PARTY-NOTICES export-ignore
+THIRD_PARTY_NOTICES export-ignore
 
 # Exclude documentation directories
 /docs export-ignore

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ This means:
 
 ### Third-Party Software
 
-OpenWave uses several open-source libraries. See [THIRD-PARTY-NOTICES](THIRD-PARTY-NOTICES) for full attribution and license information for:
+OpenWave uses several open-source libraries. See [THIRD_PARTY_NOTICES](THIRD_PARTY_NOTICES) for full attribution and license information for:
 
 - **Taichi Lang** (Apache 2.0) - GPU-accelerated computing and rendering
 - **NumPy** (BSD-3) - Numerical computing

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -10,14 +10,14 @@ OpenWave uses the following open-source software components. We are grateful to 
 
 **Copyright:** Copyright (c) Taichi Graphics
 
-**Website:** https://www.taichi-lang.org/
+**Website:** <https://www.taichi-lang.org/>
 
-**Repository:** https://github.com/taichi-dev/taichi
+**Repository:** <https://github.com/taichi-dev/taichi>
 
 **Usage:** GPU-accelerated parallel computing for high-performance physics simulations
 
 Taichi is licensed under the Apache License 2.0. Full license text available at:
-https://www.apache.org/licenses/LICENSE-2.0
+<https://www.apache.org/licenses/LICENSE-2.0>
 
 ---
 
@@ -27,14 +27,14 @@ https://www.apache.org/licenses/LICENSE-2.0
 
 **Copyright:** Copyright (c) 2005-2025, NumPy Developers
 
-**Website:** https://numpy.org/
+**Website:** <https://numpy.org/>
 
-**Repository:** https://github.com/numpy/numpy
+**Repository:** <https://github.com/numpy/numpy>
 
 **Usage:** Fundamental package for numerical computing with arrays and mathematical functions
 
 NumPy is licensed under the BSD 3-Clause License. Full license text available at:
-https://numpy.org/doc/stable/license.html
+<https://numpy.org/doc/stable/license.html>
 
 ---
 
@@ -44,14 +44,14 @@ https://numpy.org/doc/stable/license.html
 
 **Copyright:** Copyright (c) 2001-2025, SciPy Developers
 
-**Website:** https://scipy.org/
+**Website:** <https://scipy.org/>
 
-**Repository:** https://github.com/scipy/scipy
+**Repository:** <https://github.com/scipy/scipy>
 
 **Usage:** Scientific computing library for optimization, integration, and advanced mathematics
 
 SciPy is licensed under the BSD 3-Clause License. Full license text available at:
-https://scipy.org/scipylib/license.html
+<https://scipy.org/scipylib/license.html>
 
 ---
 
@@ -61,14 +61,14 @@ https://scipy.org/scipylib/license.html
 
 **Copyright:** Copyright (c) 2002-2025, Matplotlib Development Team
 
-**Website:** https://matplotlib.org/
+**Website:** <https://matplotlib.org/>
 
-**Repository:** https://github.com/matplotlib/matplotlib
+**Repository:** <https://github.com/matplotlib/matplotlib>
 
 **Usage:** Comprehensive library for creating static, animated, and interactive visualizations
 
 Matplotlib is licensed under a PSF-based license (BSD-compatible). Full license text available at:
-https://matplotlib.org/stable/users/project/license.html
+<https://matplotlib.org/stable/users/project/license.html>
 
 ---
 
@@ -78,14 +78,14 @@ https://matplotlib.org/stable/users/project/license.html
 
 **Copyright:** Copyright (c) Al Sweigart
 
-**Website:** https://pyautogui.readthedocs.io/
+**Website:** <https://pyautogui.readthedocs.io/>
 
-**Repository:** https://github.com/asweigart/pyautogui
+**Repository:** <https://github.com/asweigart/pyautogui>
 
 **Usage:** GUI automation for programmatic control of mouse and keyboard
 
 PyAutoGUI is licensed under the BSD 3-Clause License. Full license text available at:
-https://github.com/asweigart/pyautogui/blob/master/LICENSE.txt
+<https://github.com/asweigart/pyautogui/blob/master/LICENSE.txt>
 
 ---
 
@@ -106,7 +106,7 @@ This means OpenWave can legally use these libraries while maintaining its AGPL-3
 
 When using or distributing OpenWave, you must:
 
-1. Include this THIRD-PARTY-NOTICES file
+1. Include this THIRD_PARTY_NOTICES file
 1. Maintain all copyright notices from dependencies
 1. Comply with AGPL-3.0 license terms for OpenWave
 1. Comply with individual license terms for each dependency

--- a/WAVE_EQUATIONS.md
+++ b/WAVE_EQUATIONS.md
@@ -1,0 +1,57 @@
+
+# WAVE EQUATIONS & TERMINOLOGY
+
+OpenWave uses wave equations & terminology based on standardized physics terminology, these are best practices researched from scientific literature.
+
+## Wave Medium
+
+- MEDIUM-DENSITY: `ρ = 3.86e22 [kg/m³]`, propagates momentum, defines c (EWT constant)
+- WAVE-SPEED: `c = 3e8 [m/s]`, constant defined by medium property, √(medium elasticity/
+density)
+- WAVE-SOURCE: defines amplitude and frequency (rhythm, vibration), charges energy
+
+## Wave Character (WIP equation derivations)
+
+- WAVE-MODE: `cos(θ) = k̂·û`, longitudinal / transverse (polarization, fraction [0,1])
+- WAVE-TYPE: standing / traveling (fraction [0,1])
+- WAVE-FORM: temporal / spatial profile (sine, square, triangle, sawtooth)
+- WAVE-DIRECTION: `k̂ = S / |S|`, unit vector (from energy flux)
+- DISPLACEMENT-DIRECTION: `û = ∇ψ / |∇ψ|`, unit vector (from displacement gradient)
+
+## Wave Rhythm
+
+- WAVE-FREQUENCY: `f = c/λ [Hz]`, temporal oscillation rate (can change locally, multiple FT decomposition). Defines TIME = the wave frequency, rhythm
+  - angular frequency: `ω = 2πf [rad/s]`
+  - ωt = temporal phase (controls rhythm, time-varying component)
+- WAVE-PERIOD: `T = 1/f [s]`, time for one complete cycle
+- WAVE-PHASE: `φ [radians]`, 0 to 2π, position in wave cycle, interference patterns
+
+## Wave Size
+
+- WAVE-DISPLACEMENT: `ψ [m]`, harmonic oscillation
+- WAVE-AMPLITUDE: `A = max|ψ| [m]`, displacement envelope (running maximum, falloff at 1/r, near/far fields, force/pressure/density)
+- WAVE-LENGTH: `λ = c/f [m]`, spatial period (changes when moving particle, doppler, wave fronts distance)
+  - spatial frequency: `ξ = 1/λ [1/m]`
+  - angular wave number: `k = 2π/λ [rad/m]`
+  - kr = spatial phase
+
+## Wave Energy
+
+- WAVE-ENERGY: `E = ρV(fA)² [J]`, total energy (EWT equation, conserved property)
+- ENERGY-FLUX: `S = -c²ρ(∂ψ/∂t)∇ψ [W/m²]`, Poynting-like vector (energy flux density)
+- MOMENTUM-DENSITY: `g = S/c² = -ρ(∂ψ/∂t)∇ψ [kg/(m²·s)]`, momentum per unit volume (vector field)
+
+## Wave Motion
+
+- WAVE-FUNCTION: `ψ(r,t) = A·e^(iωt)·sin(kr)/r [m]`, exponential spherical wave
+- WAVE-PROPAGATION: `ψ̈ = c²∇²ψ [m/s²]`, wave equation (propagates instantaneous oscillating scalar value)
+
+## Wave Interaction
+
+- REFLECTION: changes direction of propagation (`ψ = 0` at boundary)
+- SUPERPOSITION: amplitude modulation/combination (constructive / destructive interference)
+- RESONANCE: harmonics, coherence, influence on [phase, motion, frequency]
+
+## Wave Profiling
+
+- Diagnostic tool (measures wave properties per voxel, comprehensive wave data)

--- a/dev_docs/RESEARCH_LEVEL1/01b_WAVE_FIELD_properties.md
+++ b/dev_docs/RESEARCH_LEVEL1/01b_WAVE_FIELD_properties.md
@@ -48,57 +48,7 @@ Wave field attributes represent physical quantities and wave disturbances stored
 
 ## WAVE PROPERTIES Terminology and Notation
 
-This section documents the Standardized Physics Terminology, these are best practices researched from Scientific Literature.
-
-### Wave Profiling
-
-- Diagnostic tool (measures wave properties per voxel, comprehensive wave data)
-
-### Wave Medium
-
-- MEDIUM-DENSITY (ρ): propagates momentum, carries energy, defines wave-speed
-- WAVE-SPEED (c): constant by medium property, √medium elasticity/density
-- WAVE-SOURCE: defines amplitude and frequency (rhythm, vibration), charges energy
-
-### Wave Character & Direction
-
-- WAVE-MODE: longitudinal / transverse (polarization, fraction [0,1])
-- WAVE-TYPE: standing / traveling (fraction [0,1])
-- WAVE-FORM: temporal / spacial profile (sine, square, triangle, sawtooth)
-- WAVE-DIRECTION (k̂): unit vector
-- DISPLACEMENT-DIRECTION (û): unit vector
-
-### Wave Rhythm
-
-- WAVE-FREQUENCY (f): `c/λ` (can change locally)
-  - Defines TIME =  the wave frequency, rhythm
-- WAVE-PERIOD (T): `1/f`
-- WAVE-PHASE (φ): position in wave cycle (0 to 2π radians), interference patterns
-
-### Wave Size
-
-- WAVE-DISPLACEMENT (ψ): `ψ̈ = c²Δψ`, propagated instantaneous oscillating scalar value
-- WAVE-AMPLITUDE (A): `running max|ψ|`, displacement envelop (falloff at 1/r, near/far fields)
-- WAVE-LENGTH (λ): `c/f` (changes when moving particle, doppler)
-
-### Wave Energy
-
-- WAVE-ENERGY (E): `ρV(fA)²`, conserved property
-- ENERGY-DENSITY (u): `ρ(fA)²`, constant, in J/m³
-- ENERGY-FLUX (S): Poynting-like vector in W/m²
-- MOMENTUM-DENSITY (p): `ρ × ψ × ∇ψ`
-
-### Wave Interaction
-
-- REFLECTION: changes direction of propagation (velocity vector)
-- SUPERPOSITION: fA combinations (interference)
-- RESONANCE: harmonics, coherence, influence, polarization [phase, motion, frequency]
-
-### Additional Notation
-
-- ω (omega) = angular frequency (2πf)
-- ωt = temporal oscillation (controls rhythm, time-varying component)
-- k = angular wave number (2π/λ)
+- Refer to [`WAVE_EQUATIONS.md`](../../WAVE_EQUATIONS.md)
 
 ## Scalar Properties (Magnitude)
 

--- a/dev_docs/RESEARCH_LEVEL1/02b_WAVE_ENGINE_propagate.md
+++ b/dev_docs/RESEARCH_LEVEL1/02b_WAVE_ENGINE_propagate.md
@@ -25,8 +25,7 @@ LEVEL-1 uses **PDEs (Partial Differential Equations)** to propagate waves throug
 ∂²ψ/∂t² = c²∇²ψ
 
 or simplified as:
-
-ψ̈ = c²Δψ
+ψ̈ = c²∇²ψ
 ```
 
 Where:

--- a/dev_docs/RESEARCH_LEVEL1/support_material/taichi_waterwave_v2.py
+++ b/dev_docs/RESEARCH_LEVEL1/support_material/taichi_waterwave_v2.py
@@ -85,7 +85,7 @@ def charge_wave(amplitude: ti.f32, x: ti.f32, y: ti.f32):  # type: ignore
     """
     for i, j in ti.ndrange((1, shape[0] - 1), (1, shape[1] - 1)):
         r2 = (i - x) ** 2 + (j - y) ** 2
-        displacement[i, j] = displacement[i, j] + amplitude * ti.exp(-0.02 * r2)
+        displacement[i, j] += amplitude * ti.exp(-0.02 * r2)
 
 
 @ti.func
@@ -132,7 +132,7 @@ def propagate():
         ∇²ψ = laplacian(i, j) (spatial curvature)
         γ = damping coefficient (energy dissipation)
 
-    Integration scheme (velocity Verlet):
+    Integration scheme (Euler Integration):
         1. Compute acceleration from spatial curvature and damping
         2. Update velocity: v(t+dt) = v(t) + a(t)*dt
         3. Update displacement: ψ(t+dt) = ψ(t) + v(t+dt)*dt
@@ -152,8 +152,8 @@ def propagate():
     """
     for i, j in ti.ndrange((1, shape[0] - 1), (1, shape[1] - 1)):
         acceleration = wave_speed * laplacian(i, j) - damping * velocity[i, j]
-        velocity[i, j] = velocity[i, j] + acceleration * dt
-        displacement[i, j] = displacement[i, j] + velocity[i, j] * dt
+        velocity[i, j] += acceleration * dt
+        displacement[i, j] += velocity[i, j] * dt
 
 
 @ti.func

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -48,7 +48,7 @@ Third-Party Licenses
 --------------------
 
 OpenWave uses several open-source libraries with compatible licenses.
-See `THIRD-PARTY-NOTICES <https://github.com/openwave-labs/openwave/blob/main/THIRD-PARTY-NOTICES>`_
+See `THIRD_PARTY_NOTICES <https://github.com/openwave-labs/openwave/blob/main/THIRD_PARTY_NOTICES>`_
 for details.
 
 **Dependencies:**

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -210,7 +210,7 @@ See :doc:`license` for details.
 
 **Dependency Licenses:**
 
-See `THIRD-PARTY-NOTICES <https://github.com/openwave-labs/openwave/blob/main/THIRD-PARTY-NOTICES>`_
+See `THIRD_PARTY_NOTICES <https://github.com/openwave-labs/openwave/blob/main/THIRD_PARTY_NOTICES>`_
 for third-party software licenses.
 
 Contact

--- a/openwave/xperiments/5_level1_wave_field/launcher_L1.py
+++ b/openwave/xperiments/5_level1_wave_field/launcher_L1.py
@@ -274,7 +274,7 @@ def color_menu(
 
 def level_specs(state, level_bar_vertices):
     """Display OpenWave level specifications overlay."""
-    render.canvas.triangles(level_bar_vertices, color=config.DARK_BLUE[1])
+    render.canvas.triangles(level_bar_vertices, color=config.LIGHT_BLUE[1])
     with render.gui.sub_window("LEVEL-1: WAVE-FIELD MEDIUM", 0.82, 0.01, 0.18, 0.10) as sub:
         sub.text("Coupling: Phase Sync")
         sub.text("Propagation: Radial from Source")


### PR DESCRIPTION
This pull request primarily improves documentation consistency, and makes minor code and documentation updates for clarity and accuracy. 

**Wave Equations Documentation:**

* Added a new `WAVE_EQUATIONS.md` file detailing standardized wave equations and terminology used in the project, providing a clear reference for physics concepts.
* Updated `dev_docs/RESEARCH_LEVEL1/01b_WAVE_FIELD_properties.md` to refer to the new `WAVE_EQUATIONS.md` for wave properties and terminology, consolidating documentation.

**Documentation and Naming Consistency:**

* Renamed the third-party notices file from `THIRD-PARTY-NOTICES` to `THIRD_PARTY_NOTICES` throughout the repository, including `.gitattributes`, `README.md`, documentation files, and internal references. [[1]](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eL8-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L455-R455) [[3]](diffhunk://#diff-3abdd32b0d29abccd6aac474642336434d09b2435fb02a2078836b6cc91b4d4eL51-R51) [[4]](diffhunk://#diff-b2e9d8e3658f1cd05bcc8661f3577a2ba5a9931f88b3a9cbf27795336372f7d4L213-R213) [[5]](diffhunk://#diff-3e1b4e657cd56b183bdfa5ea10c3e1770f17540ae0e307b2b163a1f73050aa8dL109-R109)
* Updated the formatting in `THIRD_PARTY_NOTICES` to use angle brackets for URLs to improve readability. [[1]](diffhunk://#diff-3e1b4e657cd56b183bdfa5ea10c3e1770f17540ae0e307b2b163a1f73050aa8dL13-R20) [[2]](diffhunk://#diff-3e1b4e657cd56b183bdfa5ea10c3e1770f17540ae0e307b2b163a1f73050aa8dL30-R37) [[3]](diffhunk://#diff-3e1b4e657cd56b183bdfa5ea10c3e1770f17540ae0e307b2b163a1f73050aa8dL47-R54) [[4]](diffhunk://#diff-3e1b4e657cd56b183bdfa5ea10c3e1770f17540ae0e307b2b163a1f73050aa8dL64-R71) [[5]](diffhunk://#diff-3e1b4e657cd56b183bdfa5ea10c3e1770f17540ae0e307b2b163a1f73050aa8dL81-R88)

**Code and Algorithm Improvements:**

* Corrected the wave equation notation in documentation for clarity (`ψ̈ = c²∇²ψ`).

**UI and Visualization:**

* Updated the color of level specifications overlay in the launcher to use `config.LIGHT_BLUE[1]` instead of `config.DARK_BLUE[1]` for improved visual clarity.
[Copilot is generating a summary...]