### PR TITLE
add wave guide

### DIFF
--- a/dev_docs/RESEARCH_LEVEL1/01b_WAVE_FIELD_properties.md
+++ b/dev_docs/RESEARCH_LEVEL1/01b_WAVE_FIELD_properties.md
@@ -48,7 +48,7 @@ Wave field attributes represent physical quantities and wave disturbances stored
 
 ## WAVE PROPERTIES Terminology and Notation
 
-- Refer to [`WAVE_EQUATIONS.md`](../../openwave/spacetime/WAVE_EQUATIONS.md)
+- Refer to [`wave_guide.md`](../../openwave/wave_guide.md)
 
 ## Scalar Properties (Magnitude)
 

--- a/openwave/common/config.py
+++ b/openwave/common/config.py
@@ -17,7 +17,7 @@ from openwave.common import constants
 # Resolution & Magnification Settings
 # ================================================================
 TARGET_GRANULES = 1e6  # target particle count, wave granularity (impacts performance)
-TARGET_VOXELS = 1e9  # target voxel count, wave granularity (impacts performance)
+TARGET_VOXELS = 1e8  # target voxel count, wave granularity (impacts performance)
 SLOW_MO = constants.EWAVE_FREQUENCY  # slows frequency down to 1Hz for human visibility
 
 # ================================================================

--- a/openwave/wave_guide.md
+++ b/openwave/wave_guide.md
@@ -1,5 +1,5 @@
 
-# WAVE EQUATIONS & TERMINOLOGY
+# WAVE EQUATIONS & TERMINOLOGY GUIDE
 
 OpenWave uses wave equations & terminology based on standardized physics terminology, these are best practices used in scientific literature.
 
@@ -48,7 +48,7 @@ density)
 
 ## Wave Interaction
 
-- REFLECTION: changes direction of propagation (`ψ = 0` at boundary)
+- REFLECTION: changes direction of propagation (`ψ = 0` Dirichlet boundary conditions)
 - SUPERPOSITION: amplitude modulation/combination (constructive / destructive interference)
 - RESONANCE: harmonics, coherence, influence on [phase, motion, frequency]
 

--- a/openwave/xperiments/2_anti_gravity/proton_vibration.py
+++ b/openwave/xperiments/2_anti_gravity/proton_vibration.py
@@ -6,8 +6,13 @@ import sys
 
 print("Work in Progress XPERIMENT")
 print("- Gravity Attenuation by Proton Vibration")
-print("\nWanna join the Anti-Gravity Xperiment?")
-print("- Contact us at www.openwavelabs.com")
+print("- Read this paper for more info:")
+print(
+    "  https://www.researchgate.net/publication/396329338_Method_for_Controlling_the_Motion_of_Non-Magnetic_Objects_Utilizing_Proton_Vibration_Energy"
+)
+
+print("\nWanna join the Anti-Gravity Xperiment? Contact us at:")
+print("  https://www.openwavelabs.com")
 
 try:
     input("\nPress ENTER to return...")

--- a/openwave/xperiments/3_thermal_waves/thermo2.0.py
+++ b/openwave/xperiments/3_thermal_waves/thermo2.0.py
@@ -7,8 +7,9 @@ import sys
 print("Work in Progress XPERIMENT")
 print("- Heat as eWave Energy")
 print("- Thermodynamics 2.0")
-print("\nWanna join the Thermal Waves Xperiment?")
-print("- Contact us at www.openwavelabs.com")
+
+print("\nWanna join the Thermal Waves Xperiment? Contact us at:")
+print("  https://www.openwavelabs.com")
 
 try:
     input("\nPress ENTER to return...")

--- a/openwave/xperiments/5_level1_wave_field/launcher_L1.py
+++ b/openwave/xperiments/5_level1_wave_field/launcher_L1.py
@@ -285,7 +285,7 @@ def level_specs(state, level_bar_vertices):
         sub.text("Propagation: Radial from Source")
         if sub.button("Open Wave Equations Help"):
             webbrowser.open(
-                "https://github.com/openwave-labs/openwave/blob/main/openwave/spacetime/WAVE_EQUATIONS.md"
+                "https://github.com/openwave-labs/openwave/blob/main/openwave/wave_guide.md"
             )
 
 

--- a/openwave/xperiments/5_level1_wave_field/launcher_L1.py
+++ b/openwave/xperiments/5_level1_wave_field/launcher_L1.py
@@ -283,7 +283,7 @@ def level_specs(state, level_bar_vertices):
     with render.gui.sub_window("LEVEL-1: WAVE-FIELD MEDIUM", 0.82, 0.01, 0.18, 0.10) as sub:
         sub.text("Coupling: Phase Sync")
         sub.text("Propagation: Radial from Source")
-        if sub.button("Open Wave Equations Help"):
+        if sub.button("Open Wave Equations Guide"):
             webbrowser.open(
                 "https://github.com/openwave-labs/openwave/blob/main/openwave/wave_guide.md"
             )


### PR DESCRIPTION
This pull request updates documentation references, configuration settings, and user messaging for clarity and improved usability across the OpenWave codebase. The main changes include renaming and updating references to the wave equations documentation, reducing the target voxel count for performance, and improving experiment scripts with clearer instructions and resource links.

**Documentation and Reference Updates:**
* Renamed `openwave/spacetime/WAVE_EQUATIONS.md` to `openwave/wave_guide.md` and updated all references in documentation and code to point to the new file name for consistency. [[1]](diffhunk://#diff-d4c305f6400b140600c34c4d2595b5987fa7dfca29fd27df6a13466114cf289dL2-R2) [[2]](diffhunk://#diff-7a6576fb8a747d7adb60790d661b7bd61a908b62a38b99f74991435c1b16ebfaL51-R51) [[3]](diffhunk://#diff-cc34fd5e051ca61d2f1c23b993f4eb48cccf809018659ccbf7a88c9c5ed17ed8L286-R288)
* Clarified terminology in the wave guide, specifically updating the definition of reflection to reference Dirichlet boundary conditions.

**Configuration Improvements:**
* Reduced `TARGET_VOXELS` in `openwave/common/config.py` from `1e9` to `1e8` to improve simulation performance.

**User Messaging and Resource Links:**
* Enhanced experiment scripts (`proton_vibration.py`, `thermo2.0.py`) with more detailed instructions and direct links to relevant research and contact pages for better user engagement. [[1]](diffhunk://#diff-93c5a14b569fcd5fb74a6a039e70f38ffac9a579059a817e831ad95be05078a3L9-R15) [[2]](diffhunk://#diff-1f3c474ac2cd4c726306cb16bf46fc01829ca5c15e68c2f15016f3aaa5bf745aL10-R12)