### PR TITLE
Constants review

### DIFF
--- a/openwave/common/constants.py
+++ b/openwave/common/constants.py
@@ -70,13 +70,15 @@ ELECTRON_SPIN_G = 0.9826905018  # electron spin g-factor (gA, dimensionless)
 # a relation of Earth’s outward velocity and spin velocity against a rest frame for the universe.
 
 # ================================================================
-#  Proton particle
+#  Proton & Neutron particle
 # ================================================================
 PROTON_K = 44  # proton wave center count (dimensionless)
 PROTON_RADIUS = 8.414e-16  # m, proton radius
 PROTON_ENERGY = 1.5033e-10  # J, CODATA proton rest energy (~ 938.272 MeV)
 PROTON_MASS = 1.67262192595e-27  # kg, proton mass from CODATA
 PROTON_ORBITAL_G = 0.9898125300  # proton orbital g-factor (gp, dimensionless)
+
+NEUTRON_MASS = 1.67492749804e-27  # kg, neutron mass from CODATA 2022
 
 # ================================================================
 # Classical constants
@@ -101,7 +103,48 @@ ELEMENTARY_CHARGE = 1.602176634e-19  # m, The elementary charge from CODATA valu
 COULOMB_CONSTANT = 8.9875517923e9  # N·m^2/C^2 (N when charge C is distance), k
 AVOGADRO_NUMBER = 6.02214076e23  # 1/mol, N_A, Avogadro's number
 BOHR_MAGNETON = 9.2740100657e-24  # J/T, μ_B, Bohr magneton (~ 5.788 e-5 eV/T)
+
+# ================================================================
+# De Broglie / Matter Wave Constants
+# ================================================================
+# De Broglie wavelength: λ_dB = h / p = h / (m*v)
+# At rest energy (Compton wavelength): λ_C = h / (m*c)
 COMPTON_WAVELENGTH_ELECTRON = 2.42631023538e-12  # m, λ_C, Compton wavelength of electron
+COMPTON_WAVELENGTH_PROTON = 1.32140985539e-15  # m, λ_C,p = h / (m_p * c), CODATA 2022
+COMPTON_WAVELENGTH_NEUTRON = 1.31959090581e-15  # m, λ_C,n = h / (m_n * c), CODATA 2022
+
+# Reduced Compton wavelengths: λ_bar = λ / (2π) = ℏ / (m * c)
+COMPTON_WAVELENGTH_ELECTRON_REDUCED = 3.8615926796e-13  # m, ℏ / (m_e * c), CODATA 2022
+COMPTON_WAVELENGTH_PROTON_REDUCED = 2.10308910336e-16  # m, ℏ / (m_p * c), CODATA 2022
+COMPTON_WAVELENGTH_NEUTRON_REDUCED = 2.10019415255e-16  # m, ℏ / (m_n * c), CODATA 2022
+
+# Rydberg constant & energy (fundamental atomic energy scale)
+RYDBERG_CONSTANT = 10973731.568157  # m^-1, R_∞, Rydberg constant, CODATA 2022
+RYDBERG_ENERGY = 2.1798723611035e-18  # J, E_∞ = R_∞ * h * c (~ 13.605693 eV)
+
+# ================================================================
+# Electromagnetic Wave Constants
+# ================================================================
+# Impedance of free space: Z_0 = √(μ_0 / ε_0) = μ_0 * c
+IMPEDANCE_VACUUM = 376.730313412  # Ω, Z_0, characteristic impedance of vacuum, CODATA 2022
+# Critical for EM wave energy density: u = (ε_0/2)*E^2 + (1/2μ_0)*B^2
+# and Poynting vector: S = (1/μ_0) * E × B = E^2 / Z_0
+
+# ================================================================
+# Energy Conversion Constants
+# ================================================================
+# For energy-frequency relation: E = h * f
+# Example: 1 eV photon → f = E/h ≈ 2.417989 × 10^14 Hz
+EV2J = 1.602176634e-19  # J, 1 eV in joules (exact, same as elementary charge)
+J2EV = 1 / EV2J  # eV, 1 J in electronvolts
+KWH2J = 3.6e6  # J, per kilowatt-hour, kWh
+J2KWH = 1 / KWH2J  # kWh, per joule
+CAL2J = 4.184  # J, per thermochemical calorie, cal
+J2CAL = 1 / CAL2J  # cal, per joule
+
+# ================================================================
+# Additional constants
+# ================================================================
 
 GOLDEN_RATIO = 1.6180339887  # φ = (1+sqrt(5))/2 (dimensionless)
 

--- a/openwave/common/constants.py
+++ b/openwave/common/constants.py
@@ -52,14 +52,16 @@ EWAVE_PERIOD = 9.520241169e-26  # s, energy-wave period (T = 1 / EWAVE_FREQUENCY
 # Neutrino particle (seed particle)
 # ================================================================
 NEUTRINO_K = 1  # neutrino wave center count (dimensionless)
+NEUTRINO_RADIUS = EWAVE_LENGTH  # m, neutrino radius = 1 λ
 NEUTRINO_ENERGY = 3.8280e-19  # J, neutrino "seed" energy used by EWT (~ 2.39 eV)
 
 # ================================================================
 # Electron particle
 # ================================================================
 ELECTRON_K = 10  # electron wave center count (dimensionless)
-ELECTRON_ENERGY = 8.1871e-14  # J, electron rest energy (~ 0.511 MeV)
 ELECTRON_RADIUS = 2.8179403262e-15  # m, electron classical radius
+ELECTRON_ENERGY = 8.1871e-14  # J, electron rest energy (~ 0.511 MeV)
+ELECTRON_MASS = 9.1093837139e-31  # kg, electron mass from CODATA
 ELECTRON_OUTER_SHELL = 2.138743820  # electron outer shell multiplier
 ELECTRON_ORBITAL_G = 0.9873318320  # electron orbital g-factor (gλ, dimensionless)
 ELECTRON_SPIN_G = 0.9826905018  # electron spin g-factor (gA, dimensionless)
@@ -71,9 +73,10 @@ ELECTRON_SPIN_G = 0.9826905018  # electron spin g-factor (gA, dimensionless)
 #  Proton particle
 # ================================================================
 PROTON_K = 44  # proton wave center count (dimensionless)
+PROTON_RADIUS = 8.414e-16  # m, proton radius
 PROTON_ENERGY = 1.5033e-10  # J, CODATA proton rest energy (~ 938.272 MeV)
+PROTON_MASS = 1.67262192595e-27  # kg, proton mass from CODATA
 PROTON_ORBITAL_G = 0.9898125300  # proton orbital g-factor (gp, dimensionless)
-PROTON_MASS = 1.67262192369e-27  # kg, proton mass from CODATA
 
 # ================================================================
 # Classical constants
@@ -81,20 +84,24 @@ PROTON_MASS = 1.67262192369e-27  # kg, proton mass from CODATA
 PLANCK_LENGTH = 1.616255e-35  # m, Planck length
 PLANCK_TIME = 5.391247e-44  # s, Planck time
 PLANCK_MASS = 2.176434e-8  # kg, Planck mass
-PLANCK_CHARGE = 1.875545956e-18  # m, Planck charge
+PLANCK_CHARGE = 1.875459e-18  # m, Planck charge
 PLANCK_CONSTANT = 6.62607015e-34  # J·s, h = Planck constant
 PLANCK_CONSTANT_REDUCED = PLANCK_CONSTANT / (2 * np.pi)  # J·s, ħ = reduced Planck constant
 
-FINE_STRUCTURE = 7.2973525693e-3  # fine-structure constant, alpha
-ELECTRIC_CONSTANT = 8.8541878128e-12  # F/m, vacuum permittivity, epsilon_0
-MAGNETIC_CONSTANT = 1.25663706212e-6  # kg/m, vacuum permeability, 2π.10-7, mu_0
+FINE_STRUCTURE = 7.2973525643e-3  # fine-structure constant, alpha
+ELECTRIC_CONSTANT = 8.8541878188e-12  # F/m, vacuum permittivity, epsilon_0
+MAGNETIC_CONSTANT = 1.25663706127e-6  # kg/m, vacuum permeability, 2π.10-7, mu_0
+GRAVITATIONAL_CONSTANT = 6.67430e-11  # m^3/kg/s^2, G, Newtonian constant of gravitation
 
-BOHR_RADIUS = 5.29177210903e-11  # m, rₕ = Hydrogen 1s radius (Bohr Radius)
+BOHR_RADIUS = 5.29177210544e-11  # m, rₕ = Hydrogen 1s radius (Bohr Radius)
 HYDROGEN_LINE = 1.420405751e9  # Hz, Hydrogen 21cm line frequency, spin-flip transition
 HYDROGEN_LYMAN_ALPHA = 2.4660677e15  # Hz, Hydrogen Lyman-alpha frequency
 
-ELEMENTARY_CHARGE = 1.6022e-19  # m, The elementary charge from CODATA values
+ELEMENTARY_CHARGE = 1.602176634e-19  # m, The elementary charge from CODATA values
 COULOMB_CONSTANT = 8.9875517923e9  # N·m^2/C^2 (N when charge C is distance), k
+AVOGADRO_NUMBER = 6.02214076e23  # 1/mol, N_A, Avogadro's number
+BOHR_MAGNETON = 9.2740100657e-24  # J/T, μ_B, Bohr magneton (~ 5.788 e-5 eV/T)
+COMPTON_WAVELENGTH_ELECTRON = 2.42631023538e-12  # m, λ_C, Compton wavelength of electron
 
 GOLDEN_RATIO = 1.6180339887  # φ = (1+sqrt(5))/2 (dimensionless)
 

--- a/openwave/common/equations.py
+++ b/openwave/common/equations.py
@@ -636,42 +636,15 @@ def magnetic_out_wave_energy(
     return energy
 
 
-# ================================================================
-# Conversion constants
-# ================================================================
-EV2J = 1.602176634e-19  # J, per electron-volt, eV
-KWH2J = 3.6e6  # J, per kilowatt-hour, kWh
-CAL2J = 4.184  # J, per thermochemical calorie, cal
-
-
-# ================================================================
-# Unit converters
-# ================================================================
-def J_to_eV(energy_J: float) -> float:
-    """Convert joules to electron-volts."""
-    return energy_J / EV2J
-
-
-def eV_to_J(energy_eV: float) -> float:
-    """Convert electron-volts to joules."""
-    return energy_eV * EV2J
-
-
-def J_to_kWh(energy_J: float) -> float:
-    """Convert joules to kilowatt-hours."""
-    return energy_J / KWH2J
-
-
-def kWh_to_J(energy_kWh: float) -> float:
-    """Convert kilowatt-hours to joules."""
-    return energy_kWh * KWH2J
-
-
 if __name__ == "__main__":
+    print("\n================================================================")
+    print("SMOKE TEST: EQUATIONS MODULE")
+    print("================================================================")
+
     print("\n_______________________________")
     print("ENERGY WAVE EQUATION")
     print(f"1 cm³ of vacuum: {energy_wave_equation(1e-6):.2e} J")
-    print(f"1 cm³ of vacuum: {J_to_kWh(energy_wave_equation(1e-6)):.2e} kWh")
+    print(f"1 cm³ of vacuum: {energy_wave_equation(1e-6) * constants.J2KWH:.2e} kWh")
 
     print("\n_______________________________")
     print("PARTICLE ENERGY")
@@ -701,7 +674,7 @@ if __name__ == "__main__":
 
     print(f"\nExample 1: Electron transition n=2 to n=1 (emission)")
     print(f"  r0={r0:.2e} m, r={r:.2e} m")
-    print(f"  Photon Energy: {abs(photon_E):.2e} J ({abs(J_to_eV(photon_E)):.2f} eV)")
+    print(f"  Photon Energy: {abs(photon_E):.2e} J ({abs(photon_E * constants.J2EV):.2f} eV)")
     print(f"  Photon Frequency: {abs(photon_f):.2e} Hz")
     print(f"  Photon Wavelength: {abs(photon_lambda):.2e} m")
 
@@ -715,7 +688,7 @@ if __name__ == "__main__":
 
     print(f"\nExample 2: Electron transition n=1 to n=2 (absorption)")
     print(f"  r0={r0:.2e} m, r={r:.2e} m")
-    print(f"  Photon Energy: {photon_E2:.2e} J ({J_to_eV(photon_E2):.2f} eV)")
+    print(f"  Photon Energy: {photon_E2:.2e} J ({photon_E2 * constants.J2EV:.2f} eV)")
     print(f"  Photon Frequency: {photon_f2:.2e} Hz")
     print(f"  Photon Wavelength: {photon_lambda2:.2e} m")
 
@@ -748,7 +721,7 @@ if __name__ == "__main__":
     # Lyman alpha (n=2→1): 121.6 nm, 10.2 eV
     print(f"\nComparison with Hydrogen Lyman Series:")
     print(f"  Lyman alpha (n=2→1): 121.6 nm, 10.2 eV (observed)")
-    print(f"  Our calculation: {wavelength_nm:.1f} nm, {abs(J_to_eV(photon_E)):.1f} eV")
+    print(f"  Our calculation: {wavelength_nm:.1f} nm, {abs(photon_E * constants.J2EV):.1f} eV")
 
     #   The calculation above gives us 182.3 nm,
     #   which is in the ultraviolet spectrum.

--- a/openwave/spacetime/medium_level0.py
+++ b/openwave/spacetime/medium_level0.py
@@ -146,7 +146,7 @@ class BCCLattice:
 
         # Compute lattice total energy from energy-wave equation
         self.energy = equations.energy_wave_equation(self.universe_volume)  # in Joules
-        self.energy_kWh = equations.J_to_kWh(self.energy)  # in KWh
+        self.energy_kWh = self.energy * constants.J2KWH  # in KWh
         self.energy_years = self.energy_kWh / (183230 * 1e9)  # global energy use
 
         # Initialize position and velocity 1D arrays
@@ -641,7 +641,7 @@ class SCLattice:
 
         # Compute lattice total energy from energy-wave equation
         self.energy = equations.energy_wave_equation(self.universe_volume)  # in Joules
-        self.energy_kWh = equations.J_to_kWh(self.energy)  # in KWh
+        self.energy_kWh = self.energy * constants.J2KWH  # in KWh
         self.energy_years = self.energy_kWh / (183230 * 1e9)  # global energy use
 
         # Initialize position and velocity 1D arrays

--- a/openwave/spacetime/medium_level1.py
+++ b/openwave/spacetime/medium_level1.py
@@ -114,7 +114,7 @@ class WaveField:
 
         # Compute grid total energy from energy-wave equation
         self.energy = equations.energy_wave_equation(self.universe_volume)  # in Joules
-        self.energy_kWh = equations.J_to_kWh(self.energy)  # in KWh
+        self.energy_kWh = self.energy * constants.J2KWH  # in KWh
         self.energy_years = self.energy_kWh / (183230 * 1e9)  # global energy use
 
         # MEASURED SCALAR FIELDS (values in attometers for f32 precision)

--- a/openwave/spacetime/wave_engine_level0.py
+++ b/openwave/spacetime/wave_engine_level0.py
@@ -328,5 +328,5 @@ def update_lattice_energy(lattice):
     lattice.energy = equations.energy_wave_equation(
         volume=lattice.universe_volume, amplitude=avg_amplitude_am[None] * constants.ATTOMETER
     )
-    lattice.energy_kWh = equations.J_to_kWh(lattice.energy)  # in KWh
+    lattice.energy_kWh = lattice.energy * constants.J2KWH  # in KWh
     lattice.energy_years = lattice.energy_kWh / (183230 * 1e9)  # global energy use

--- a/openwave/xperiments/_archives/radial_wave/medium_bccgranule.py
+++ b/openwave/xperiments/_archives/radial_wave/medium_bccgranule.py
@@ -70,7 +70,7 @@ class BCCLattice:
         """
         # Compute lattice total energy from energy-wave equation
         self.energy = equations.energy_wave_equation(universe_edge**3)  # in Joules
-        self.energy_kWh = equations.J_to_kWh(self.energy)  # in KWh
+        self.energy_kWh = self.energy * constants.J2KWH  # in KWh
         self.energy_years = self.energy_kWh / (183230 * 1e9)  # global energy use
 
         # Set universe properties (simulation domain)

--- a/openwave/xperiments/_archives/spring_mass/medium_bccgranule.py
+++ b/openwave/xperiments/_archives/spring_mass/medium_bccgranule.py
@@ -70,7 +70,7 @@ class BCCLattice:
         """
         # Compute lattice total energy from energy-wave equation
         self.energy = equations.energy_wave_equation(universe_edge**3)  # in Joules
-        self.energy_kWh = equations.J_to_kWh(self.energy)  # in KWh
+        self.energy_kWh = self.energy * constants.J2KWH  # in KWh
         self.energy_years = self.energy_kWh / (183230 * 1e9)  # global energy use
 
         # Set universe properties (simulation domain)


### PR DESCRIPTION
This pull request refactors the handling of physical constants and unit conversions throughout the codebase. The main changes include centralizing all constants (including unit conversion factors) in `openwave/common/constants.py`, updating their values to match the latest CODATA recommendations, and removing redundant unit conversion functions from `openwave/common/equations.py`. The code now consistently uses these constants for energy conversions, improving maintainability and accuracy.

**Constants and Physical Quantities Updates:**

* Added and updated numerous physical constants in `openwave/common/constants.py`, including particle radii, masses, energies, electromagnetic constants, conversion factors, and de Broglie/Compton wavelengths, all using the latest CODATA 2022 values. [[1]](diffhunk://#diff-090f6f932a28d1d1cb99321f96b46b8d9cfd170d9ea0d4cdfe726f4a558d33b4R55-R64) [[2]](diffhunk://#diff-090f6f932a28d1d1cb99321f96b46b8d9cfd170d9ea0d4cdfe726f4a558d33b4L71-R147)

**Unit Conversion Refactor:**

* Removed all unit conversion functions (`J_to_eV`, `eV_to_J`, `J_to_kWh`, `kWh_to_J`, etc.) from `openwave/common/equations.py`, and replaced their usages with direct multiplication using conversion constants from `openwave/common/constants.py`.

**Codebase Consistency Improvements:**

* Updated all usages of energy conversions in `openwave/spacetime/medium_level0.py`, `openwave/spacetime/medium_level1.py`, `openwave/spacetime/wave_engine_level0.py`, and experimental modules to use the new constants directly instead of function calls. [[1]](diffhunk://#diff-a1d03c4ac0417a2333f0626af21ef55105994e9f2aead28872ed00e0758ea54dL149-R149) [[2]](diffhunk://#diff-a1d03c4ac0417a2333f0626af21ef55105994e9f2aead28872ed00e0758ea54dL644-R644) [[3]](diffhunk://#diff-417358f92852935e3a2121b3a1a6ef19285ea5c16363fb62250658c61a4765a8L117-R117) [[4]](diffhunk://#diff-cbc184ab43ade5aed9ec5c5812bc4d1381acb6b549a23bb6194b0a01b08cff8aL331-R331) [[5]](diffhunk://#diff-c841e80a90f35d92cf1ea03b42993672c075e0b094232265172f689cd2eaf501L73-R73) [[6]](diffhunk://#diff-6e548e2bc38bacf86b9b596a0968503c334603245b244013e3cc666ded3150fcL73-R73)
* Updated print statements in `openwave/common/equations.py` to use the new constant-based conversions for displaying energy in electron-volts and kilowatt-hours. [[1]](diffhunk://#diff-ae23110baeec7de71ca21352afcca07cc141f454b9600afdba77e84985c60ddeL704-R677) [[2]](diffhunk://#diff-ae23110baeec7de71ca21352afcca07cc141f454b9600afdba77e84985c60ddeL718-R691) [[3]](diffhunk://#diff-ae23110baeec7de71ca21352afcca07cc141f454b9600afdba77e84985c60ddeL751-R724)

These changes make the code more robust, accurate, and easier to maintain by ensuring all physical and conversion constants are defined in a single place and used consistently throughout the project.