### PR TITLE
Wall-Chargers

### DIFF
--- a/openwave/spacetime/L1_wave_engine.py
+++ b/openwave/spacetime/L1_wave_engine.py
@@ -329,6 +329,138 @@ def charge_oscillator_falloff(
         )
 
 
+@ti.kernel
+def charge_oscillator_wall(
+    wave_field: ti.template(),  # type: ignore
+    elapsed_t_rs: ti.f32,  # type: ignore
+):
+    """
+    Apply harmonic oscillation to all voxels at boundary walls.
+
+    Creates a uniform displacement on 2D planes using:
+        ψ(t) = A·cos(ωt)
+
+    The oscillators act as coherent wave sources, with all voxels on
+    the wall oscillating in phase.
+
+    Args:
+        wave_field: WaveField instance containing displacement arrays and grid info
+        elapsed_t_rs: Elapsed simulation time (rs)
+    """
+    # Compute angular frequency (ω = 2πf) for temporal phase variation
+    omega_rs = 2.0 * ti.math.pi * base_frequency_rHz  # angular frequency (rad/rs)
+
+    # Apply oscillating displacement on 6 boundary planes
+    # Harmonic motion: A·cos(ωt), positive = expansion, negative = compression
+    for i, j in ti.ndrange((wave_field.nx), (wave_field.ny)):
+        wave_field.displacement_am[i, j, 0] = base_amplitude_am * ti.cos(omega_rs * elapsed_t_rs)
+        wave_field.displacement_am[i, j, wave_field.nz - 1] = base_amplitude_am * ti.cos(
+            omega_rs * elapsed_t_rs
+        )
+    for i, k in ti.ndrange((wave_field.nx), (wave_field.nz)):
+        wave_field.displacement_am[i, 0, k] = base_amplitude_am * ti.cos(omega_rs * elapsed_t_rs)
+        wave_field.displacement_am[i, wave_field.ny - 1, k] = base_amplitude_am * ti.cos(
+            omega_rs * elapsed_t_rs
+        )
+    for j, k in ti.ndrange((wave_field.ny), (wave_field.nz)):
+        wave_field.displacement_am[0, j, k] = base_amplitude_am * ti.cos(omega_rs * elapsed_t_rs)
+        wave_field.displacement_am[wave_field.nx - 1, j, k] = base_amplitude_am * ti.cos(
+            omega_rs * elapsed_t_rs
+        )
+
+
+@ti.kernel
+def charge_oscillator_wall_even(
+    wave_field: ti.template(),  # type: ignore
+    elapsed_t_rs: ti.f32,  # type: ignore
+):
+    """
+    Apply harmonic oscillation to boundary walls skipping every other voxel.
+
+    Creates a uniform displacement on 2D planes using:
+        ψ(t) = A·cos(ωt)
+
+    The oscillators act as coherent wave sources, with half voxels on
+    the wall oscillating in phase.
+
+    Args:
+        wave_field: WaveField instance containing displacement arrays and grid info
+        elapsed_t_rs: Elapsed simulation time (rs)
+    """
+    # Compute angular frequency (ω = 2πf) for temporal phase variation
+    omega_rs = 2.0 * ti.math.pi * base_frequency_rHz  # angular frequency (rad/rs)
+
+    # Apply oscillating displacement on 6 boundary planes
+    # Harmonic motion: A·cos(ωt), positive = expansion, negative = compression
+    for i, j in ti.ndrange((wave_field.nx // 2), (wave_field.ny // 2)):
+        wave_field.displacement_am[i * 2, j * 2, 0] = base_amplitude_am * ti.cos(
+            omega_rs * elapsed_t_rs
+        )
+        wave_field.displacement_am[i * 2, j * 2, wave_field.nz - 1] = base_amplitude_am * ti.cos(
+            omega_rs * elapsed_t_rs
+        )
+    for i, k in ti.ndrange((wave_field.nx // 2), (wave_field.nz // 2)):
+        wave_field.displacement_am[i * 2, 0, k * 2] = base_amplitude_am * ti.cos(
+            omega_rs * elapsed_t_rs
+        )
+        wave_field.displacement_am[i * 2, wave_field.ny - 1, k * 2] = base_amplitude_am * ti.cos(
+            omega_rs * elapsed_t_rs
+        )
+    for j, k in ti.ndrange((wave_field.ny // 2), (wave_field.nz // 2)):
+        wave_field.displacement_am[0, j * 2, k * 2] = base_amplitude_am * ti.cos(
+            omega_rs * elapsed_t_rs
+        )
+        wave_field.displacement_am[wave_field.nx - 1, j * 2, k * 2] = base_amplitude_am * ti.cos(
+            omega_rs * elapsed_t_rs
+        )
+
+
+@ti.kernel
+def charge_oscillator_wall_quart(
+    wave_field: ti.template(),  # type: ignore
+    elapsed_t_rs: ti.f32,  # type: ignore
+):
+    """
+    Apply harmonic oscillation to boundary walls skipping every 4 voxel.
+
+    Creates a uniform displacement on 2D planes using:
+        ψ(t) = A·cos(ωt)
+
+    The oscillators act as coherent wave sources, with a quart voxels on
+    the wall oscillating in phase.
+
+    Args:
+        wave_field: WaveField instance containing displacement arrays and grid info
+        elapsed_t_rs: Elapsed simulation time (rs)
+    """
+    # Compute angular frequency (ω = 2πf) for temporal phase variation
+    omega_rs = 2.0 * ti.math.pi * base_frequency_rHz  # angular frequency (rad/rs)
+
+    # Apply oscillating displacement on 6 boundary planes
+    # Harmonic motion: A·cos(ωt), positive = expansion, negative = compression
+    for i, j in ti.ndrange((wave_field.nx // 4), (wave_field.ny // 4)):
+        wave_field.displacement_am[i * 4, j * 4, 0] = (
+            4 * base_amplitude_am * ti.cos(omega_rs * elapsed_t_rs)
+        )
+        wave_field.displacement_am[i * 4, j * 4, wave_field.nz - 1] = (
+            4 * base_amplitude_am * ti.cos(omega_rs * elapsed_t_rs)
+        )
+    for i, k in ti.ndrange((wave_field.nx // 4), (wave_field.nz // 4)):
+        wave_field.displacement_am[i * 4, 0, k * 4] = (
+            4 * base_amplitude_am * ti.cos(omega_rs * elapsed_t_rs)
+        )
+        wave_field.displacement_am[i * 4, wave_field.ny - 1, k * 4] = (
+            4 * base_amplitude_am * ti.cos(omega_rs * elapsed_t_rs)
+        )
+    for j, k in ti.ndrange((wave_field.ny // 4), (wave_field.nz // 4)):
+        wave_field.displacement_am[0, j * 4, k * 4] = (
+            4 * base_amplitude_am * ti.cos(omega_rs * elapsed_t_rs)
+        )
+        wave_field.displacement_am[wave_field.nx - 1, j * 4, k * 4] = (
+            4 * base_amplitude_am * ti.cos(omega_rs * elapsed_t_rs)
+        )
+
+
 @ti.func
 def compute_laplacian_am(
     wave_field: ti.template(),  # type: ignore

--- a/openwave/xperiments/5_level1_field_based/L1_launcher.py
+++ b/openwave/xperiments/5_level1_field_based/L1_launcher.py
@@ -387,9 +387,9 @@ def initialize_xperiment(state):
     # STATIC CHARGING methods (one-time init pattern) ==================================
     # Uncomment to test different initial wave configurations
     ewave.charge_full(state.wave_field, state.dt_rs)
-    # TODO: beautiful but inaccurate: ewave.charge_gaussian(state.wave_field)
-    # TODO: too-light: ewave.charge_falloff(state.wave_field, state.dt_rs)
-    # TODO: too-light: ewave.charge_1lambda(state.wave_field, state.dt_rs)
+    # NOTE: (beautiful but inaccurate) ewave.charge_gaussian(state.wave_field)
+    # NOTE: (too-light) ewave.charge_falloff(state.wave_field, state.dt_rs)
+    # NOTE: (too-light) ewave.charge_1lambda(state.wave_field, state.dt_rs)
     # TODO: code toggle to plot initial charging pattern
     # ewave.plot_charge_profile(state.wave_field)
 
@@ -407,10 +407,10 @@ def compute_wave_motion(state):
     # Charger runs BEFORE propagation to inject energy into displacement_am
     if state.charging and state.frame > 300:
         ewave.charge_oscillator_sphere(state.wave_field, state.elapsed_t_rs)  # energy injection
-        # TODO: too-light: ewave.charge_oscillator_falloff(state.wave_field, state.elapsed_t_rs)
-        # TODO: ewave.charge_oscillator_wall(state.wave_field, state.elapsed_t_rs)
-        # TODO: ewave.charge_oscillator_wall_even(state.wave_field, state.elapsed_t_rs)
-        # TODO: ewave.charge_oscillator_wall_quart(state.wave_field, state.elapsed_t_rs)
+        # NOTE: (too-light) ewave.charge_oscillator_falloff(state.wave_field, state.elapsed_t_rs)
+        # NOTE: ewave.charge_oscillator_wall(state.wave_field, state.elapsed_t_rs)
+        # NOTE: ewave.charge_oscillator_wall_even(state.wave_field, state.elapsed_t_rs)
+        # NOTE: ewave.charge_oscillator_wall_quart(state.wave_field, state.elapsed_t_rs)
 
     ewave.propagate_ewave(
         state.wave_field,
@@ -423,7 +423,7 @@ def compute_wave_motion(state):
     # DYNAMIC DAMPING runs AFTER propagation to reduce displacement values
     if state.damping:
         ewave.damp_load_full(state.wave_field, 0.99)  # energy absorption
-        # TODO: too-light: ewave.damp_load_sphere(state.wave_field, 0.99)  # energy absorption
+        # NOTE: (too-light) ewave.damp_load_sphere(state.wave_field, 0.99)  # energy absorption
 
     # IN-FRAME DATA SAMPLING & DIAGNOSTICS ==================================
     # Frame skip reduces GPU->CPU transfer overhead

--- a/openwave/xperiments/5_level1_field_based/L1_launcher.py
+++ b/openwave/xperiments/5_level1_field_based/L1_launcher.py
@@ -407,7 +407,10 @@ def compute_wave_motion(state):
     # Charger runs BEFORE propagation to inject energy into displacement_am
     if state.charging and state.frame > 300:
         ewave.charge_oscillator_sphere(state.wave_field, state.elapsed_t_rs)  # energy injection
-    # TODO: too-light: ewave.charge_oscillator_falloff(state.wave_field, state.elapsed_t_rs)
+        # TODO: too-light: ewave.charge_oscillator_falloff(state.wave_field, state.elapsed_t_rs)
+        # TODO: ewave.charge_oscillator_wall(state.wave_field, state.elapsed_t_rs)
+        # TODO: ewave.charge_oscillator_wall_even(state.wave_field, state.elapsed_t_rs)
+        # TODO: ewave.charge_oscillator_wall_quart(state.wave_field, state.elapsed_t_rs)
 
     ewave.propagate_ewave(
         state.wave_field,


### PR DESCRIPTION
This pull request refactors and extends the boundary wave charging and damping features in the wave simulation engine. It introduces new kernel functions for harmonic oscillation at the simulation boundaries with varying spatial patterns, restores and relocates the previous damping kernels, and updates experiment launcher comments for clarity and easier toggling between charging/damping methods.

**Boundary charging enhancements:**

* Added new kernel functions: `charge_oscillator_wall`, `charge_oscillator_wall_even`, and `charge_oscillator_wall_quart` in `L1_wave_engine.py`, enabling harmonic oscillation at boundary walls with full, even, and quart (every 4th voxel) spatial patterns, respectively. Each applies a coherent oscillating displacement to boundary voxels, acting as wave sources with different spatial densities.
* Updated docstrings and logic to clarify the behavior and intent of these new charging patterns.

**Damping kernel restoration and relocation:**

* Restored and moved `damp_load_sphere` and `damp_load_full` kernel functions from their previous location to after the main propagation kernel in `L1_wave_engine.py`, ensuring they are called after wave propagation. These kernels provide spherical and full-grid exponential damping options, respectively.

**Experiment launcher improvements:**

* Updated comments in `L1_launcher.py` to clarify the effects and suitability of different charging and damping methods, replacing TODOs with NOTE annotations and making it easier to toggle between different methods for testing. [[1]](diffhunk://#diff-cf5febe60899bc80c1ff7813ec710b5b9336993408b35a83fe13337ad9f480fdL390-R392) [[2]](diffhunk://#diff-cf5febe60899bc80c1ff7813ec710b5b9336993408b35a83fe13337ad9f480fdL410-R413) [[3]](diffhunk://#diff-cf5febe60899bc80c1ff7813ec710b5b9336993408b35a83fe13337ad9f480fdL423-R426)