### PR TITLE
Add universe edge rendering

### DIFF
--- a/openwave/xperiments/5_L1_field_based/L1_launcher.py
+++ b/openwave/xperiments/5_L1_field_based/L1_launcher.py
@@ -15,6 +15,7 @@ import time
 from pathlib import Path
 
 import taichi as ti
+import numpy as np
 
 from openwave.common import colormap, constants
 from openwave._io import flux_mesh, render, video
@@ -131,6 +132,7 @@ class SimulationState:
         self.SHOW_AXIS = False
         self.TICK_SPACING = 0.25
         self.SHOW_GRID = False
+        self.SHOW_EDGES = False
         self.FLUX_MESH_SHOW = 0
         self.FLUX_MESH_PLANES = [0.5, 0.5, 0.5]
         self.SIM_SPEED = 1.0
@@ -167,6 +169,7 @@ class SimulationState:
         self.SHOW_AXIS = ui["SHOW_AXIS"]
         self.TICK_SPACING = ui["TICK_SPACING"]
         self.SHOW_GRID = ui["SHOW_GRID"]
+        self.SHOW_EDGES = ui["SHOW_EDGES"]
         self.FLUX_MESH_SHOW = ui["FLUX_MESH_SHOW"]
         self.FLUX_MESH_PLANES = ui["FLUX_MESH_PLANES"]
         self.SIM_SPEED = ui["SIM_SPEED"]
@@ -258,8 +261,9 @@ def display_xperiment_launcher(xperiment_mgr, state):
 
 def display_controls(state):
     """Display the controls UI overlay."""
-    with render.gui.sub_window("CONTROLS", 0.00, 0.34, 0.16, 0.17) as sub:
+    with render.gui.sub_window("CONTROLS", 0.00, 0.34, 0.16, 0.20) as sub:
         state.SHOW_AXIS = sub.checkbox(f"Axis (ticks: {state.TICK_SPACING})", state.SHOW_AXIS)
+        state.SHOW_EDGES = sub.checkbox("Sim Universe Edges", state.SHOW_EDGES)
         state.FLUX_MESH_SHOW = sub.slider_int("Flux Mesh", state.FLUX_MESH_SHOW, 0, 3)
         state.SIM_SPEED = sub.slider_float("Speed", state.SIM_SPEED, 0.5, 1.0)
         if state.PAUSED:
@@ -454,19 +458,22 @@ def compute_wave_motion(state):
 
 
 def render_elements(state):
-    """Render grid, flux mesh and test particles."""
+    """Render grid, edges, flux mesh and test particles."""
     if state.SHOW_GRID:
         render.scene.lines(state.wave_field.grid_lines, width=1, color=colormap.COLOR_MEDIUM[1])
+
+    if state.SHOW_EDGES:
+        render.scene.lines(state.wave_field.edge_lines, width=1, color=colormap.COLOR_MEDIUM[1])
 
     if state.FLUX_MESH_SHOW > 0:
         ewave.update_flux_mesh_colors(state.wave_field, state.trackers, state.COLOR_PALETTE)
         flux_mesh.render_flux_mesh(render.scene, state.wave_field, state.FLUX_MESH_SHOW)
 
     # TODO: remove test particles for visual reference
-    # position1 = np.array([[0.5, 0.5, 0.5]], dtype=np.float32)
-    # render.scene.particles(position1, radius=0.01, color=colormap.COLOR_PARTICLE[1])
-    # position2 = np.array([[0.5, 0.7, 0.5]], dtype=np.float32)
-    # render.scene.particles(position2, radius=0.01, color=colormap.COLOR_ANTI[1])
+    position1 = np.array([[0.5, 0.5, 0.5]], dtype=np.float32)
+    render.scene.particles(position1, radius=0.01, color=colormap.COLOR_PARTICLE[1])
+    position2 = np.array([[0.5, 0.7, 0.5]], dtype=np.float32)
+    render.scene.particles(position2, radius=0.01, color=colormap.COLOR_ANTI[1])
 
 
 # ================================================================

--- a/openwave/xperiments/5_L1_field_based/_xparameters/007_waves.py
+++ b/openwave/xperiments/5_L1_field_based/_xparameters/007_waves.py
@@ -26,8 +26,9 @@ XPARAMETERS = {
         "SHOW_AXIS": False,  # Toggle to show/hide axis lines
         "TICK_SPACING": 0.25,  # Axis tick marks spacing for position reference
         "SHOW_GRID": False,  # Toggle to show/hide the voxel data-grid
+        "SHOW_EDGES": False,  # Toggle to show/hide universe edges
         "FLUX_MESH_SHOW": 3,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
-        "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # Normalized positions [x, y, z]
+        "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
         "SIM_SPEED": 1.0,  # Frequency boost multiplier
         "PAUSED": False,  # Pause/Start simulation toggle
     },

--- a/openwave/xperiments/5_L1_field_based/_xparameters/035_waves.py
+++ b/openwave/xperiments/5_L1_field_based/_xparameters/035_waves.py
@@ -26,8 +26,9 @@ XPARAMETERS = {
         "SHOW_AXIS": False,  # Toggle to show/hide axis lines
         "TICK_SPACING": 0.25,  # Axis tick marks spacing for position reference
         "SHOW_GRID": False,  # Toggle to show/hide the voxel data-grid
+        "SHOW_EDGES": False,  # Toggle to show/hide universe edges
         "FLUX_MESH_SHOW": 1,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
-        "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # Normalized positions [x, y, z]
+        "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
         "SIM_SPEED": 1.0,  # Frequency boost multiplier
         "PAUSED": False,  # Pause/Start simulation toggle
     },

--- a/openwave/xperiments/5_L1_field_based/_xparameters/210_waves.py
+++ b/openwave/xperiments/5_L1_field_based/_xparameters/210_waves.py
@@ -26,8 +26,9 @@ XPARAMETERS = {
         "SHOW_AXIS": False,  # Toggle to show/hide axis lines
         "TICK_SPACING": 0.25,  # Axis tick marks spacing for position reference
         "SHOW_GRID": False,  # Toggle to show/hide the voxel data-grid
+        "SHOW_EDGES": False,  # Toggle to show/hide universe edges
         "FLUX_MESH_SHOW": 1,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
-        "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # Normalized positions [x, y, z]
+        "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
         "SIM_SPEED": 1.0,  # Frequency boost multiplier
         "PAUSED": False,  # Pause/Start simulation toggle
     },

--- a/openwave/xperiments/5_L1_field_based/_xparameters/the_grid.py
+++ b/openwave/xperiments/5_L1_field_based/_xparameters/the_grid.py
@@ -26,8 +26,9 @@ XPARAMETERS = {
         "SHOW_AXIS": True,  # Toggle to show/hide axis lines
         "TICK_SPACING": 0.25,  # Axis tick marks spacing for position reference
         "SHOW_GRID": True,  # Toggle to show/hide the voxel data-grid
+        "SHOW_EDGES": False,  # Toggle to show/hide universe edges
         "FLUX_MESH_SHOW": 0,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
-        "FLUX_MESH_PLANES": [0.0, 0.0, 0.0],  # Normalized positions of flux mesh planes [x, y, z]
+        "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
         "SIM_SPEED": 1.0,  # Frequency boost multiplier
         "PAUSED": True,  # Pause/Start simulation toggle
     },

--- a/openwave/xperiments/5_L1_field_based/_xparameters/the_queen.py
+++ b/openwave/xperiments/5_L1_field_based/_xparameters/the_queen.py
@@ -13,7 +13,7 @@ XPARAMETERS = {
         "DESCRIPTION": "Energy Wave Charging, Propagation and Interaction",
     },
     "camera": {
-        "INITIAL_POSITION": [1.40, 1.40, 1.20],  # [x, y, z] in normalized coordinates
+        "INITIAL_POSITION": [1.17, 1.59, 0.81],  # [x, y, z] in normalized coordinates
     },
     "universe": {
         "SIZE": [UNIVERSE_EDGE, UNIVERSE_EDGE, UNIVERSE_EDGE],  # m, simulation domain [x, y, z]
@@ -26,8 +26,9 @@ XPARAMETERS = {
         "SHOW_AXIS": False,  # Toggle to show/hide axis lines
         "TICK_SPACING": 0.25,  # Axis tick marks spacing for position reference
         "SHOW_GRID": False,  # Toggle to show/hide the voxel data-grid
+        "SHOW_EDGES": True,  # Toggle to show/hide universe edges
         "FLUX_MESH_SHOW": 3,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
-        "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # Normalized positions [x, y, z]
+        "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
         "SIM_SPEED": 1.0,  # Frequency boost multiplier
         "PAUSED": False,  # Pause/Start simulation toggle
     },


### PR DESCRIPTION
Introduces edge line rendering for the simulation universe bounding box in L1_field_grid.py, with a new edge_lines field and population method. Updates the UI and state management in L1_launcher.py to allow toggling edge visibility, adds the SHOW_EDGES parameter to experiment configs, and adjusts camera and flux mesh plane defaults in the_queen.py and the_grid.py. Also enables test particle rendering for visual reference.