### PR TITLE
On Screen Instrumentation Toggle & show plot

### DIFF
--- a/openwave/_io/flux_mesh.py
+++ b/openwave/_io/flux_mesh.py
@@ -77,9 +77,9 @@ def initialize_flux_mesh_fields(wave_field):
     _flux_mesh_fields_initialized = True
 
 
-def render_flux_mesh(scene, wave_field, flux_mesh_show):
+def render_flux_mesh(scene, wave_field, show_flux_mesh):
     """
-    Render all three flux mesh to the scene with two-sided rendering.
+    Render flux mesh planes to the scene with two-sided rendering.
 
     Displays XY, XZ, and YZ flux mesh as colored meshes visualizing wave
     displacement through the universe domain. Uses two-sided rendering to
@@ -112,7 +112,7 @@ def render_flux_mesh(scene, wave_field, flux_mesh_show):
     # ================================================================
     # Render flux mesh planes
     # ================================================================
-    if flux_mesh_show in (1, 2, 3):
+    if show_flux_mesh in (1, 2, 3):
         scene.mesh(
             _xy_vertices_flat,
             indices=_xy_indices_flat,
@@ -121,7 +121,7 @@ def render_flux_mesh(scene, wave_field, flux_mesh_show):
             show_wireframe=True,
         )
 
-    if flux_mesh_show in (2, 3):
+    if show_flux_mesh in (2, 3):
         scene.mesh(
             _xz_vertices_flat,
             indices=_xz_indices_flat,
@@ -130,7 +130,7 @@ def render_flux_mesh(scene, wave_field, flux_mesh_show):
             show_wireframe=True,
         )
 
-    if flux_mesh_show == 3:
+    if show_flux_mesh == 3:
         scene.mesh(
             _yz_vertices_flat,
             indices=_yz_indices_flat,

--- a/openwave/xperiments/5_L1_field_based/L1_launcher.py
+++ b/openwave/xperiments/5_L1_field_based/L1_launcher.py
@@ -261,9 +261,10 @@ def display_xperiment_launcher(xperiment_mgr, state):
 
 def display_controls(state):
     """Display the controls UI overlay."""
-    with render.gui.sub_window("CONTROLS", 0.00, 0.34, 0.16, 0.20) as sub:
+    with render.gui.sub_window("CONTROLS", 0.00, 0.34, 0.16, 0.22) as sub:
         state.SHOW_AXIS = sub.checkbox(f"Axis (ticks: {state.TICK_SPACING})", state.SHOW_AXIS)
         state.SHOW_EDGES = sub.checkbox("Sim Universe Edges", state.SHOW_EDGES)
+        state.INSTRUMENTATION = sub.checkbox("Instrumentation", state.INSTRUMENTATION)
         state.SHOW_FLUX_MESH = sub.slider_int("Flux Mesh", state.SHOW_FLUX_MESH, 0, 3)
         state.SIM_SPEED = sub.slider_float("Speed", state.SIM_SPEED, 0.5, 1.0)
         if state.PAUSED:

--- a/openwave/xperiments/5_L1_field_based/L1_launcher.py
+++ b/openwave/xperiments/5_L1_field_based/L1_launcher.py
@@ -133,7 +133,7 @@ class SimulationState:
         self.TICK_SPACING = 0.25
         self.SHOW_GRID = False
         self.SHOW_EDGES = False
-        self.FLUX_MESH_SHOW = 0
+        self.SHOW_FLUX_MESH = 0
         self.FLUX_MESH_PLANES = [0.5, 0.5, 0.5]
         self.SIM_SPEED = 1.0
         self.PAUSED = False
@@ -170,7 +170,7 @@ class SimulationState:
         self.TICK_SPACING = ui["TICK_SPACING"]
         self.SHOW_GRID = ui["SHOW_GRID"]
         self.SHOW_EDGES = ui["SHOW_EDGES"]
-        self.FLUX_MESH_SHOW = ui["FLUX_MESH_SHOW"]
+        self.SHOW_FLUX_MESH = ui["SHOW_FLUX_MESH"]
         self.FLUX_MESH_PLANES = ui["FLUX_MESH_PLANES"]
         self.SIM_SPEED = ui["SIM_SPEED"]
         self.PAUSED = ui["PAUSED"]
@@ -264,7 +264,7 @@ def display_controls(state):
     with render.gui.sub_window("CONTROLS", 0.00, 0.34, 0.16, 0.20) as sub:
         state.SHOW_AXIS = sub.checkbox(f"Axis (ticks: {state.TICK_SPACING})", state.SHOW_AXIS)
         state.SHOW_EDGES = sub.checkbox("Sim Universe Edges", state.SHOW_EDGES)
-        state.FLUX_MESH_SHOW = sub.slider_int("Flux Mesh", state.FLUX_MESH_SHOW, 0, 3)
+        state.SHOW_FLUX_MESH = sub.slider_int("Flux Mesh", state.SHOW_FLUX_MESH, 0, 3)
         state.SIM_SPEED = sub.slider_float("Speed", state.SIM_SPEED, 0.5, 1.0)
         if state.PAUSED:
             if sub.button("Propagate eWave"):
@@ -465,9 +465,9 @@ def render_elements(state):
     if state.SHOW_EDGES:
         render.scene.lines(state.wave_field.edge_lines, width=1, color=colormap.COLOR_MEDIUM[1])
 
-    if state.FLUX_MESH_SHOW > 0:
+    if state.SHOW_FLUX_MESH > 0:
         ewave.update_flux_mesh_colors(state.wave_field, state.trackers, state.COLOR_PALETTE)
-        flux_mesh.render_flux_mesh(render.scene, state.wave_field, state.FLUX_MESH_SHOW)
+        flux_mesh.render_flux_mesh(render.scene, state.wave_field, state.SHOW_FLUX_MESH)
 
     # TODO: remove test particles for visual reference
     position1 = np.array([[0.5, 0.5, 0.5]], dtype=np.float32)

--- a/openwave/xperiments/5_L1_field_based/_L1_instrumentation.py
+++ b/openwave/xperiments/5_L1_field_based/_L1_instrumentation.py
@@ -235,6 +235,7 @@ def plot_charge_log():
     save_path = PLOT_DIR / "charge_levels.png"
     plt.savefig(save_path, dpi=150, bbox_inches="tight")
     print("\nPlot charge_levels saved to:\n", save_path, "\n")
+    plt.show()
 
 
 def plot_probe_log():
@@ -308,6 +309,7 @@ def plot_probe_log():
     save_path = PLOT_DIR / "probe_values.png"
     plt.savefig(save_path, dpi=150, bbox_inches="tight")
     print("\nPlot probe values saved to:\n", save_path, "\n")
+    plt.show()
 
 
 def generate_plots():

--- a/openwave/xperiments/5_L1_field_based/_L1_launcher_archive.py
+++ b/openwave/xperiments/5_L1_field_based/_L1_launcher_archive.py
@@ -133,7 +133,7 @@ class SimulationState:
         self.SHOW_AXIS = False
         self.TICK_SPACING = 0.25
         self.SHOW_GRID = False
-        self.FLUX_MESH_SHOW = 0
+        self.SHOW_FLUX_MESH = 0
         self.FLUX_MESH_PLANES = [0.5, 0.5, 0.5]
         self.SIM_SPEED = 1.0
         self.PAUSED = False
@@ -171,7 +171,7 @@ class SimulationState:
         self.SHOW_AXIS = ui["SHOW_AXIS"]
         self.TICK_SPACING = ui["TICK_SPACING"]
         self.SHOW_GRID = ui["SHOW_GRID"]
-        self.FLUX_MESH_SHOW = ui["FLUX_MESH_SHOW"]
+        self.SHOW_FLUX_MESH = ui["SHOW_FLUX_MESH"]
         self.FLUX_MESH_PLANES = ui["FLUX_MESH_PLANES"]
         self.SIM_SPEED = ui["SIM_SPEED"]
         self.PAUSED = ui["PAUSED"]
@@ -264,7 +264,7 @@ def display_controls(state):
     """Display the controls UI overlay."""
     with render.gui.sub_window("CONTROLS", 0.00, 0.34, 0.16, 0.17) as sub:
         state.SHOW_AXIS = sub.checkbox(f"Axis (ticks: {state.TICK_SPACING})", state.SHOW_AXIS)
-        state.FLUX_MESH_SHOW = sub.slider_int("Flux Mesh", state.FLUX_MESH_SHOW, 0, 3)
+        state.SHOW_FLUX_MESH = sub.slider_int("Flux Mesh", state.SHOW_FLUX_MESH, 0, 3)
         state.SIM_SPEED = sub.slider_float("Speed", state.SIM_SPEED, 0.5, 1.0)
         if state.PAUSED:
             if sub.button("Propagate eWave"):
@@ -506,9 +506,9 @@ def render_elements(state):
     if state.SHOW_GRID:
         render.scene.lines(state.wave_field.grid_lines, width=1, color=colormap.COLOR_MEDIUM[1])
 
-    if state.FLUX_MESH_SHOW > 0:
+    if state.SHOW_FLUX_MESH > 0:
         ewave.update_flux_mesh_colors(state.wave_field, state.trackers, state.COLOR_PALETTE)
-        flux_mesh.render_flux_mesh(render.scene, state.wave_field, state.FLUX_MESH_SHOW)
+        flux_mesh.render_flux_mesh(render.scene, state.wave_field, state.SHOW_FLUX_MESH)
 
     # TODO: remove test particles for visual reference
     # position1 = np.array([[0.5, 0.5, 0.5]], dtype=np.float32)

--- a/openwave/xperiments/5_L1_field_based/_xparameters/007_waves.py
+++ b/openwave/xperiments/5_L1_field_based/_xparameters/007_waves.py
@@ -29,7 +29,7 @@ XPARAMETERS = {
         "SHOW_EDGES": False,  # Toggle to show/hide universe edges
         "SHOW_FLUX_MESH": 3,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
-        "SIM_SPEED": 1.0,  # Frequency boost multiplier
+        "SIM_SPEED": 1.0,  # Simulation speed multiplier
         "PAUSED": False,  # Pause/Start simulation toggle
     },
     "color_defaults": {

--- a/openwave/xperiments/5_L1_field_based/_xparameters/007_waves.py
+++ b/openwave/xperiments/5_L1_field_based/_xparameters/007_waves.py
@@ -27,7 +27,7 @@ XPARAMETERS = {
         "TICK_SPACING": 0.25,  # Axis tick marks spacing for position reference
         "SHOW_GRID": False,  # Toggle to show/hide the voxel data-grid
         "SHOW_EDGES": False,  # Toggle to show/hide universe edges
-        "FLUX_MESH_SHOW": 3,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
+        "SHOW_FLUX_MESH": 3,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
         "SIM_SPEED": 1.0,  # Frequency boost multiplier
         "PAUSED": False,  # Pause/Start simulation toggle

--- a/openwave/xperiments/5_L1_field_based/_xparameters/035_waves.py
+++ b/openwave/xperiments/5_L1_field_based/_xparameters/035_waves.py
@@ -27,7 +27,7 @@ XPARAMETERS = {
         "TICK_SPACING": 0.25,  # Axis tick marks spacing for position reference
         "SHOW_GRID": False,  # Toggle to show/hide the voxel data-grid
         "SHOW_EDGES": False,  # Toggle to show/hide universe edges
-        "FLUX_MESH_SHOW": 1,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
+        "SHOW_FLUX_MESH": 1,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
         "SIM_SPEED": 1.0,  # Frequency boost multiplier
         "PAUSED": False,  # Pause/Start simulation toggle

--- a/openwave/xperiments/5_L1_field_based/_xparameters/035_waves.py
+++ b/openwave/xperiments/5_L1_field_based/_xparameters/035_waves.py
@@ -29,7 +29,7 @@ XPARAMETERS = {
         "SHOW_EDGES": False,  # Toggle to show/hide universe edges
         "SHOW_FLUX_MESH": 1,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
-        "SIM_SPEED": 1.0,  # Frequency boost multiplier
+        "SIM_SPEED": 1.0,  # Simulation speed multiplier
         "PAUSED": False,  # Pause/Start simulation toggle
     },
     "color_defaults": {

--- a/openwave/xperiments/5_L1_field_based/_xparameters/210_waves.py
+++ b/openwave/xperiments/5_L1_field_based/_xparameters/210_waves.py
@@ -27,7 +27,7 @@ XPARAMETERS = {
         "TICK_SPACING": 0.25,  # Axis tick marks spacing for position reference
         "SHOW_GRID": False,  # Toggle to show/hide the voxel data-grid
         "SHOW_EDGES": False,  # Toggle to show/hide universe edges
-        "FLUX_MESH_SHOW": 1,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
+        "SHOW_FLUX_MESH": 1,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
         "SIM_SPEED": 1.0,  # Frequency boost multiplier
         "PAUSED": False,  # Pause/Start simulation toggle

--- a/openwave/xperiments/5_L1_field_based/_xparameters/210_waves.py
+++ b/openwave/xperiments/5_L1_field_based/_xparameters/210_waves.py
@@ -29,7 +29,7 @@ XPARAMETERS = {
         "SHOW_EDGES": False,  # Toggle to show/hide universe edges
         "SHOW_FLUX_MESH": 1,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
-        "SIM_SPEED": 1.0,  # Frequency boost multiplier
+        "SIM_SPEED": 1.0,  # Simulation speed multiplier
         "PAUSED": False,  # Pause/Start simulation toggle
     },
     "color_defaults": {

--- a/openwave/xperiments/5_L1_field_based/_xparameters/the_grid.py
+++ b/openwave/xperiments/5_L1_field_based/_xparameters/the_grid.py
@@ -27,7 +27,7 @@ XPARAMETERS = {
         "TICK_SPACING": 0.25,  # Axis tick marks spacing for position reference
         "SHOW_GRID": True,  # Toggle to show/hide the voxel data-grid
         "SHOW_EDGES": False,  # Toggle to show/hide universe edges
-        "FLUX_MESH_SHOW": 0,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
+        "SHOW_FLUX_MESH": 0,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
         "SIM_SPEED": 1.0,  # Frequency boost multiplier
         "PAUSED": True,  # Pause/Start simulation toggle

--- a/openwave/xperiments/5_L1_field_based/_xparameters/the_grid.py
+++ b/openwave/xperiments/5_L1_field_based/_xparameters/the_grid.py
@@ -29,7 +29,7 @@ XPARAMETERS = {
         "SHOW_EDGES": False,  # Toggle to show/hide universe edges
         "SHOW_FLUX_MESH": 0,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
-        "SIM_SPEED": 1.0,  # Frequency boost multiplier
+        "SIM_SPEED": 1.0,  # Simulation speed multiplier
         "PAUSED": True,  # Pause/Start simulation toggle
     },
     "color_defaults": {

--- a/openwave/xperiments/5_L1_field_based/_xparameters/the_queen.py
+++ b/openwave/xperiments/5_L1_field_based/_xparameters/the_queen.py
@@ -29,7 +29,7 @@ XPARAMETERS = {
         "SHOW_EDGES": True,  # Toggle to show/hide universe edges
         "SHOW_FLUX_MESH": 3,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
-        "SIM_SPEED": 1.0,  # Frequency boost multiplier
+        "SIM_SPEED": 1.0,  # Simulation speed multiplier
         "PAUSED": False,  # Pause/Start simulation toggle
     },
     "color_defaults": {

--- a/openwave/xperiments/5_L1_field_based/_xparameters/the_queen.py
+++ b/openwave/xperiments/5_L1_field_based/_xparameters/the_queen.py
@@ -27,7 +27,7 @@ XPARAMETERS = {
         "TICK_SPACING": 0.25,  # Axis tick marks spacing for position reference
         "SHOW_GRID": False,  # Toggle to show/hide the voxel data-grid
         "SHOW_EDGES": True,  # Toggle to show/hide universe edges
-        "FLUX_MESH_SHOW": 3,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
+        "SHOW_FLUX_MESH": 3,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
         "SIM_SPEED": 1.0,  # Frequency boost multiplier
         "PAUSED": False,  # Pause/Start simulation toggle


### PR DESCRIPTION
This pull request standardizes the naming of the "flux mesh" visibility control variable across the codebase by renaming all instances of `FLUX_MESH_SHOW` to `SHOW_FLUX_MESH`. Additionally, it updates function arguments and UI controls to use the new naming, and improves plot display in instrumentation scripts. These changes enhance code consistency and clarity, making it easier to maintain and understand.

**Variable renaming and code consistency:**

* Renamed all occurrences of `FLUX_MESH_SHOW` to `SHOW_FLUX_MESH` in launcher classes, UI state handling, and parameter files for experiment configurations, ensuring consistent naming throughout the codebase. [[1]](diffhunk://#diff-a6f859c5626beb75049bbd08ee620bd173d9b47886dd92a070bb979c6d3b7667L136-R136) [[2]](diffhunk://#diff-a6f859c5626beb75049bbd08ee620bd173d9b47886dd92a070bb979c6d3b7667L173-R173) [[3]](diffhunk://#diff-a6f859c5626beb75049bbd08ee620bd173d9b47886dd92a070bb979c6d3b7667L264-R268) [[4]](diffhunk://#diff-a6f859c5626beb75049bbd08ee620bd173d9b47886dd92a070bb979c6d3b7667L468-R471) [[5]](diffhunk://#diff-a35208df2456a486fa32d8070778f5fcf40a20d7811a1ecb3e21b03c8691430bL136-R136) [[6]](diffhunk://#diff-a35208df2456a486fa32d8070778f5fcf40a20d7811a1ecb3e21b03c8691430bL174-R174) [[7]](diffhunk://#diff-a35208df2456a486fa32d8070778f5fcf40a20d7811a1ecb3e21b03c8691430bL267-R267) [[8]](diffhunk://#diff-a35208df2456a486fa32d8070778f5fcf40a20d7811a1ecb3e21b03c8691430bL509-R511) [[9]](diffhunk://#diff-88d5df4cc45ccc63d828a8ab53d794de38bdbc471e440fdd7f6feb31e88e0461L30-R32) [[10]](diffhunk://#diff-7c084da2b53164e10a3065b4042eeacc58742bb85936740a65646b6a623b228cL30-R32) [[11]](diffhunk://#diff-2bd0f3aafb8dce9ea54d03e3256fa9f4c765684a10d54b09f54a131d2a7d9fb9L30-R32) [[12]](diffhunk://#diff-9346d252d39d89e4d238ff6317a583245b79ddd1c590762fa4f6ee54440709aeL30-R32) [[13]](diffhunk://#diff-b1ca63f242b611ed63f62ee7f9dfd589a2ba0e57dfc2e28d602d85cdb174038bL30-R32)

* Updated the `render_flux_mesh` function and its callers to use `show_flux_mesh` as the argument name instead of `flux_mesh_show`, and adjusted internal variable references accordingly. [[1]](diffhunk://#diff-323c742b8e4ced49e21954a5deba5909ecbe8c0152beb325b4c4fb2eba34fb54L80-R82) [[2]](diffhunk://#diff-323c742b8e4ced49e21954a5deba5909ecbe8c0152beb325b4c4fb2eba34fb54L115-R115) [[3]](diffhunk://#diff-323c742b8e4ced49e21954a5deba5909ecbe8c0152beb325b4c4fb2eba34fb54L124-R124) [[4]](diffhunk://#diff-323c742b8e4ced49e21954a5deba5909ecbe8c0152beb325b4c4fb2eba34fb54L133-R133)

**UI and display improvements:**

* Added an "Instrumentation" checkbox to the controls UI and slightly increased the height of the controls sub-window for better layout.

**Instrumentation and plotting:**

* Ensured that plots are displayed interactively by adding `plt.show()` after saving figures in charge and probe log plotting functions. [[1]](diffhunk://#diff-99cce54a9194784558f89cae9f70c2da54168d672f43a238ba29a1af18aca0ceR238) [[2]](diffhunk://#diff-99cce54a9194784558f89cae9f70c2da54168d672f43a238ba29a1af18aca0ceR312)

**Documentation and clarity:**

* Updated comments in parameter files to clarify that `SIM_SPEED` refers to the simulation speed multiplier, not frequency boost. [[1]](diffhunk://#diff-88d5df4cc45ccc63d828a8ab53d794de38bdbc471e440fdd7f6feb31e88e0461L30-R32) [[2]](diffhunk://#diff-7c084da2b53164e10a3065b4042eeacc58742bb85936740a65646b6a623b228cL30-R32) [[3]](diffhunk://#diff-2bd0f3aafb8dce9ea54d03e3256fa9f4c765684a10d54b09f54a131d2a7d9fb9L30-R32) [[4]](diffhunk://#diff-9346d252d39d89e4d238ff6317a583245b79ddd1c590762fa4f6ee54440709aeL30-R32) [[5]](diffhunk://#diff-b1ca63f242b611ed63f62ee7f9dfd589a2ba0e57dfc2e28d602d85cdb174038bL30-R32)