### PR TITLE
Switch particle mass units to quectograms for GPU precision

### DIFF
--- a/openwave/common/constants.py
+++ b/openwave/common/constants.py
@@ -63,6 +63,8 @@ NEUTRINO_RADIUS = 2.854096501e-17  # m, neutrino radius = 1 λ
 NEUTRINO_ENERGY = 3.827997e-19  # J, neutrino "seed" energy used by EWT (~ 2.39 eV)
 NEUTRINO_MASS = 4.259222e-36  # kg, neutrino "seed" mass used by EWT (~ 0.38 meV/c²)
 
+NEUTRINO_MASS_QG = 4.259222e-3  # qg, f32 friendly
+
 # ================================================================
 # ELECTRON Particle
 # ================================================================

--- a/openwave/xperiments/c_wolff_lafreniere/particle.py
+++ b/openwave/xperiments/c_wolff_lafreniere/particle.py
@@ -62,8 +62,8 @@ class WaveCenter:
         self.debug_dA_dx = ti.field(dtype=ti.f32, shape=num_sources)
         self.debug_force_scale = ti.field(dtype=ti.f32, shape=num_sources)
 
-        # Mass in kilograms (SI) - initialized to electron mass
-        self.mass = ti.field(dtype=ti.f32, shape=num_sources)
+        # Mass in quectogram (qg) - initialized to neutrino mass, f32 friendly
+        self.mass_qg = ti.field(dtype=ti.f32, shape=num_sources)
 
         # ================================================================
         # Wave properties
@@ -94,7 +94,7 @@ class WaveCenter:
             # Initialize motion fields (at rest, no force)
             self.velocity_amrs[i] = [0.0, 0.0, 0.0]
             self.force[i] = [0.0, 0.0, 0.0]  # Newtons
-            self.mass[i] = constants.NEUTRINO_MASS  # Default to neutrino mass, kg
+            self.mass_qg[i] = constants.NEUTRINO_MASS_QG  # Default to neutrino mass, qg
 
             # Set phase offset (charge)
             self.offset[i] = sources_offset_rad[i]


### PR DESCRIPTION
Replaces mass representation from kilograms to quectograms (qg) in particle and force motion modules to improve f32 precision on GPU. Updates conversion factors and debug output accordingly, and adds NEUTRINO_MASS_QG constant for consistency.