### PR TITLE
Refactor force application to motion and UI improvements

### DIFF
--- a/openwave/xperiments/a_granule_motion/_launcher.py
+++ b/openwave/xperiments/a_granule_motion/_launcher.py
@@ -218,7 +218,7 @@ def display_xperiment_launcher(xperiment_mgr, state):
     """
     selected_xperiment = None
 
-    with render.gui.sub_window("XPERIMENT LAUNCHER", 0.00, 0.00, 0.14, 0.31) as sub:
+    with render.gui.sub_window("XPERIMENT LAUNCHER", 0.00, 0.00, 0.14, 0.32) as sub:
         sub.text("(needs window reload)", color=colormap.LIGHT_BLUE[1])
         for xp_name in xperiment_mgr.available_xperiments:
             display_name = xperiment_mgr.get_xperiment_display_name(xp_name)
@@ -235,7 +235,7 @@ def display_xperiment_launcher(xperiment_mgr, state):
 
 def display_controls(state):
     """Display the controls UI overlay."""
-    with render.gui.sub_window("CONTROLS", 0.00, 0.32, 0.16, 0.27) as sub:
+    with render.gui.sub_window("CONTROLS", 0.00, 0.33, 0.16, 0.27) as sub:
         state.SHOW_AXIS = sub.checkbox(f"Axis (ticks: {state.TICK_SPACING})", state.SHOW_AXIS)
         state.BLOCK_SLICE = sub.checkbox("Block Slice", state.BLOCK_SLICE)
         state.SHOW_SOURCES = sub.checkbox("Show Wave Centers (sources)", state.SHOW_SOURCES)
@@ -290,7 +290,8 @@ def display_level_specs(state, level_bar_vertices):
 
 def display_data_dashboard(state):
     """Display simulation data dashboard."""
-    with render.gui.sub_window("DATA-DASHBOARD", 0.84, 0.44, 0.16, 0.56) as sub:
+    with render.gui.sub_window("DATA-DASHBOARD", 0.84, 0.43, 0.16, 0.57) as sub:
+        state.INSTRUMENTATION = sub.checkbox("Instrumentation", state.INSTRUMENTATION)
         sub.text("--- SPACETIME ---", color=colormap.LIGHT_BLUE[1])
         sub.text(f"Medium Density: {constants.MEDIUM_DENSITY:.1e} kg/m³")
         sub.text(f"eWAVE Speed (c): {constants.EWAVE_SPEED:.1e} m/s")

--- a/openwave/xperiments/b_laplace_propagation/_launcher.py
+++ b/openwave/xperiments/b_laplace_propagation/_launcher.py
@@ -341,8 +341,9 @@ def display_data_dashboard(state):
     clock_time = time.time() - state.clock_start_time
     sim_time_years = clock_time / (state.elapsed_t_rs * constants.RONTOSECOND or 1) / 31_536_000
 
-    with render.gui.sub_window("DATA-DASHBOARD", 0.84, 0.35, 0.16, 0.65) as sub:
+    with render.gui.sub_window("DATA-DASHBOARD", 0.84, 0.34, 0.16, 0.66) as sub:
         state.INSTRUMENTATION = sub.checkbox("Instrumentation", state.INSTRUMENTATION)
+        sub.text("--- SPACETIME ---", color=colormap.LIGHT_BLUE[1])
         sub.text(f"Medium Density: {constants.MEDIUM_DENSITY:.1e} kg/m³")
         sub.text(f"eWAVE Speed (c): {constants.EWAVE_SPEED:.1e} m/s")
 

--- a/openwave/xperiments/b_laplace_propagation/_launcher.py
+++ b/openwave/xperiments/b_laplace_propagation/_launcher.py
@@ -208,8 +208,8 @@ class SimulationState:
         self.dt_rs = self.wave_field.dx_am / (self.c_amrs / self.SIM_SPEED * (3**0.5))  # rs
         self.cfl_factor = round((self.c_amrs * self.dt_rs / self.wave_field.dx_am) ** 2, 7)
 
-    def restart_sim(self):
-        """Restart simulation state."""
+    def reset_sim(self):
+        """Reset simulation state."""
         self.wave_field = None
         self.trackers = None
         self.c_amrs = 0.0
@@ -248,7 +248,7 @@ def display_xperiment_launcher(xperiment_mgr, state):
     """
     selected_xperiment = None
 
-    with render.gui.sub_window("XPERIMENT LAUNCHER", 0.00, 0.00, 0.14, 0.31) as sub:
+    with render.gui.sub_window("XPERIMENT LAUNCHER", 0.00, 0.00, 0.14, 0.32) as sub:
         sub.text("(needs window reload)", color=colormap.LIGHT_BLUE[1])
         for xp_name in xperiment_mgr.available_xperiments:
             display_name = xperiment_mgr.get_xperiment_display_name(xp_name)
@@ -265,10 +265,9 @@ def display_xperiment_launcher(xperiment_mgr, state):
 
 def display_controls(state):
     """Display the controls UI overlay."""
-    with render.gui.sub_window("CONTROLS", 0.00, 0.32, 0.16, 0.25) as sub:
+    with render.gui.sub_window("CONTROLS", 0.00, 0.33, 0.16, 0.27) as sub:
         state.SHOW_AXIS = sub.checkbox(f"Axis (ticks: {state.TICK_SPACING})", state.SHOW_AXIS)
         state.SHOW_EDGES = sub.checkbox("Sim Universe Edges", state.SHOW_EDGES)
-        state.INSTRUMENTATION = sub.checkbox("Instrumentation", state.INSTRUMENTATION)
         state.SHOW_FLUX_MESH = sub.slider_int("Flux Mesh", state.SHOW_FLUX_MESH, 0, 3)
         state.WARP_MESH = sub.slider_int("Warp Mesh", state.WARP_MESH, 0, 30)
         state.SIM_SPEED = sub.slider_float("Speed", state.SIM_SPEED, 0.5, 1.0)
@@ -278,8 +277,8 @@ def display_controls(state):
         else:
             if sub.button("Pause"):
                 state.PAUSED = True
-        if sub.button("Restart Simulation"):
-            state.restart_sim()
+        if sub.button("Reset Simulation"):
+            state.reset_sim()
 
 
 def display_wave_menu(state):
@@ -342,8 +341,8 @@ def display_data_dashboard(state):
     clock_time = time.time() - state.clock_start_time
     sim_time_years = clock_time / (state.elapsed_t_rs * constants.RONTOSECOND or 1) / 31_536_000
 
-    with render.gui.sub_window("DATA-DASHBOARD", 0.84, 0.37, 0.16, 0.63) as sub:
-        sub.text("--- SPACETIME ---", color=colormap.LIGHT_BLUE[1])
+    with render.gui.sub_window("DATA-DASHBOARD", 0.84, 0.35, 0.16, 0.65) as sub:
+        state.INSTRUMENTATION = sub.checkbox("Instrumentation", state.INSTRUMENTATION)
         sub.text(f"Medium Density: {constants.MEDIUM_DENSITY:.1e} kg/m³")
         sub.text(f"eWAVE Speed (c): {constants.EWAVE_SPEED:.1e} m/s")
 

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/0007_waves.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/0007_waves.py
@@ -28,7 +28,7 @@ XPARAMETERS = {
         ],
         # Phase offsets for each wave-center (integer degrees, converted to radians internally)
         "PHASE_OFFSETS_DEG": [0],
-        "APPLY_FORCE": True,  # Toggle to apply force at wave-centers each iteration
+        "APPLY_MOTION": True,  # Toggle to apply motion at wave-centers, from force at each iteration
     },
     "ui_defaults": {
         "SHOW_AXIS": False,  # Toggle to show/hide axis lines

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/2000_waves.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/2000_waves.py
@@ -29,7 +29,7 @@ XPARAMETERS = {
         ],
         # Phase offsets for each wave-center (integer degrees, converted to radians internally)
         "PHASE_OFFSETS_DEG": [0, 0],
-        "APPLY_FORCE": True,  # Toggle to apply force at wave-centers each iteration
+        "APPLY_MOTION": True,  # Toggle to apply motion at wave-centers, from force at each iteration
     },
     "ui_defaults": {
         "SHOW_AXIS": False,  # Toggle to show/hide axis lines

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction.py
@@ -29,7 +29,7 @@ XPARAMETERS = {
         ],
         # Phase offsets for each wave-center (integer degrees, converted to radians internally)
         "PHASE_OFFSETS_DEG": [0, 180],
-        "APPLY_FORCE": True,  # Toggle to apply force at wave-centers each iteration
+        "APPLY_MOTION": True,  # Toggle to apply motion at wave-centers, from force at each iteration
     },
     "ui_defaults": {
         "SHOW_AXIS": False,  # Toggle to show/hide axis lines

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction2.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction2.py
@@ -29,7 +29,7 @@ XPARAMETERS = {
         ],
         # Phase offsets for each wave-center (integer degrees, converted to radians internally)
         "PHASE_OFFSETS_DEG": [0, 180],
-        "APPLY_FORCE": True,  # Toggle to apply force at wave-centers each iteration
+        "APPLY_MOTION": True,  # Toggle to apply motion at wave-centers, from force at each iteration
     },
     "ui_defaults": {
         "SHOW_AXIS": False,  # Toggle to show/hide axis lines

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction3.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction3.py
@@ -29,7 +29,7 @@ XPARAMETERS = {
         ],
         # Phase offsets for each wave-center (integer degrees, converted to radians internally)
         "PHASE_OFFSETS_DEG": [0, 180],
-        "APPLY_FORCE": True,  # Toggle to apply force at wave-centers each iteration
+        "APPLY_MOTION": True,  # Toggle to apply motion at wave-centers, from force at each iteration
     },
     "ui_defaults": {
         "SHOW_AXIS": True,  # Toggle to show/hide axis lines

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_repulsion.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_repulsion.py
@@ -29,7 +29,7 @@ XPARAMETERS = {
         ],
         # Phase offsets for each wave-center (integer degrees, converted to radians internally)
         "PHASE_OFFSETS_DEG": [0, 0],
-        "APPLY_FORCE": True,  # Toggle to apply force at wave-centers each iteration
+        "APPLY_MOTION": True,  # Toggle to apply motion at wave-centers, from force at each iteration
     },
     "ui_defaults": {
         "SHOW_AXIS": False,  # Toggle to show/hide axis lines

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_repulsion2.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_repulsion2.py
@@ -29,7 +29,7 @@ XPARAMETERS = {
         ],
         # Phase offsets for each wave-center (integer degrees, converted to radians internally)
         "PHASE_OFFSETS_DEG": [0, 0],
-        "APPLY_FORCE": True,  # Toggle to apply force at wave-centers each iteration
+        "APPLY_MOTION": True,  # Toggle to apply motion at wave-centers, from force at each iteration
     },
     "ui_defaults": {
         "SHOW_AXIS": False,  # Toggle to show/hide axis lines

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/test_max.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/test_max.py
@@ -32,7 +32,7 @@ XPARAMETERS = {
         ],
         # Phase offsets for each wave-center (integer degrees, converted to radians internally)
         "PHASE_OFFSETS_DEG": [0],
-        "APPLY_FORCE": True,  # Toggle to apply force at wave-centers each iteration
+        "APPLY_MOTION": True,  # Toggle to apply motion at wave-centers, from force at each iteration
     },
     "ui_defaults": {
         "SHOW_AXIS": False,  # Toggle to show/hide axis lines

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/test_stress.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/test_stress.py
@@ -28,7 +28,7 @@ XPARAMETERS = {
         ],
         # Phase offsets for each wave-center (integer degrees, converted to radians internally)
         "PHASE_OFFSETS_DEG": [0],
-        "APPLY_FORCE": True,  # Toggle to apply force at wave-centers each iteration
+        "APPLY_MOTION": True,  # Toggle to apply motion at wave-centers, from force at each iteration
     },
     "ui_defaults": {
         "SHOW_AXIS": False,  # Toggle to show/hide axis lines


### PR DESCRIPTION
This pull request makes several improvements and refactorings across the experiment launcher modules, focusing on unifying terminology, improving UI layout, and clarifying simulation controls. The most significant changes involve renaming the "Apply Force" feature to "Apply Motion" for clarity, updating related parameters and UI controls, and refining the reset behavior for simulations. Additionally, several UI window positions and sizes have been adjusted for better layout consistency.

**Terminology and Parameter Updates:**

* Renamed the `APPLY_FORCE` variable and parameter to `APPLY_MOTION` throughout the `c_wolff_lafreniere` experiment code, including all references in the launcher, UI, and xparameter files, to better reflect its function (applying motion derived from force) and improve clarity in both code and UI. [[1]](diffhunk://#diff-bb339a673d18424352db252472883cde67260b4fe0ba8247684b48e1bbd7e027L131-R131) [[2]](diffhunk://#diff-bb339a673d18424352db252472883cde67260b4fe0ba8247684b48e1bbd7e027L172-R172) [[3]](diffhunk://#diff-bb339a673d18424352db252472883cde67260b4fe0ba8247684b48e1bbd7e027L278-R293) [[4]](diffhunk://#diff-bb339a673d18424352db252472883cde67260b4fe0ba8247684b48e1bbd7e027L519-R530) [[5]](diffhunk://#diff-e9bb5a22a944787fd31f48804e41296fc61941d0e961843114526022682954f9L31-R31) [[6]](diffhunk://#diff-e002e3c3f74e03d6eaad5515b367890c1e6ea7449d1b2c9992fe6b3e2761452bL32-R32) [[7]](diffhunk://#diff-f6b73834b8d4b3c704f8a7241ae47201c5ec26816c00e69246b1ef8b1d7104c3L32-R32) [[8]](diffhunk://#diff-a857bc1f7b00e12a8a05b362ef913699a6ec01b3034a42a5179e96566d524db5L32-R32) [[9]](diffhunk://#diff-4882bb7993bd841e616474ca5f82c2cf27c24a410982480d773c41270ee3f028L32-R32) [[10]](diffhunk://#diff-ac821236affd340a8acb5a04a8679f2ee5cb9e3c188cffb0f91ad140f639e92aL32-R32) [[11]](diffhunk://#diff-663025f025a9df055a275554a6bd4fda38213c4a5c7c3919918f6b22934a1a91L32-R32) [[12]](diffhunk://#diff-7c8357fcc31515df1f6fd579e15e6aac8f276932612085c062087e38937c3ae8L35-R35) [[13]](diffhunk://#diff-cc48848eef2c79d4413ce4a93431a1421b022b905d0c89f71a53a6f35bc08788L31-R31)

**Simulation Control Refactoring:**

* Renamed the `restart_sim` method to `reset_sim` in both `b_laplace_propagation` and `c_wolff_lafreniere` experiment launchers, and updated all UI buttons and calls accordingly, to standardize terminology and better describe the action. [[1]](diffhunk://#diff-b8d86515f866fa331c7d78ec483c94ad4323ceca5e4fe4b6889a4ba79eca6139L211-R212) [[2]](diffhunk://#diff-b8d86515f866fa331c7d78ec483c94ad4323ceca5e4fe4b6889a4ba79eca6139L281-R281) [[3]](diffhunk://#diff-bb339a673d18424352db252472883cde67260b4fe0ba8247684b48e1bbd7e027L225-R226) [[4]](diffhunk://#diff-bb339a673d18424352db252472883cde67260b4fe0ba8247684b48e1bbd7e027L278-R293)

**UI and Layout Improvements:**

* Adjusted the positions and sizes of the "XPERIMENT LAUNCHER", "CONTROLS", and "DATA-DASHBOARD" sub-windows in all three experiment launchers (`a_granule_motion`, `b_laplace_propagation`, `c_wolff_lafreniere`) for improved layout consistency and usability. [[1]](diffhunk://#diff-44ec29082236014fa054b5dfaa91d883490c176aaf7bc6cc1b7a9cae365e8766L221-R221) [[2]](diffhunk://#diff-44ec29082236014fa054b5dfaa91d883490c176aaf7bc6cc1b7a9cae365e8766L238-R238) [[3]](diffhunk://#diff-44ec29082236014fa054b5dfaa91d883490c176aaf7bc6cc1b7a9cae365e8766L293-R294) [[4]](diffhunk://#diff-b8d86515f866fa331c7d78ec483c94ad4323ceca5e4fe4b6889a4ba79eca6139L251-R251) [[5]](diffhunk://#diff-b8d86515f866fa331c7d78ec483c94ad4323ceca5e4fe4b6889a4ba79eca6139L268-L271) [[6]](diffhunk://#diff-b8d86515f866fa331c7d78ec483c94ad4323ceca5e4fe4b6889a4ba79eca6139L345-R345) [[7]](diffhunk://#diff-bb339a673d18424352db252472883cde67260b4fe0ba8247684b48e1bbd7e027L261-R261) [[8]](diffhunk://#diff-bb339a673d18424352db252472883cde67260b4fe0ba8247684b48e1bbd7e027L278-R293) [[9]](diffhunk://#diff-bb339a673d18424352db252472883cde67260b4fe0ba8247684b48e1bbd7e027L357-R357)

**UI Control Placement:**

* Moved the "Instrumentation" checkbox from the controls overlay to the data dashboard in both `b_laplace_propagation` and `c_wolff_lafreniere` launchers, to better group related controls and reduce clutter. [[1]](diffhunk://#diff-b8d86515f866fa331c7d78ec483c94ad4323ceca5e4fe4b6889a4ba79eca6139L268-L271) [[2]](diffhunk://#diff-b8d86515f866fa331c7d78ec483c94ad4323ceca5e4fe4b6889a4ba79eca6139L345-R345) [[3]](diffhunk://#diff-bb339a673d18424352db252472883cde67260b4fe0ba8247684b48e1bbd7e027L278-R293) [[4]](diffhunk://#diff-bb339a673d18424352db252472883cde67260b4fe0ba8247684b48e1bbd7e027L357-R357)

These changes collectively improve code clarity, user experience, and maintainability across the experiment modules.