### PR TITLE
Refactor WAVE_MENU indices for color scheme selection

### DIFF
--- a/openwave/common/colormap.py
+++ b/openwave/common/colormap.py
@@ -79,7 +79,7 @@ yellowgreen_palette = [
     ["#000000", (0.0, 0.0, 0.0)],  # black
     ["#1E7A1E", (0.118, 0.478, 0.118)],  # dark green
     ["#35B779", (0.208, 0.718, 0.475)],  # green
-]  # "color_palette" = 1
+]
 
 # ================================================================
 # Redblue Gradient: PALETTE [used in get_redblue_color()]
@@ -90,7 +90,7 @@ redblue_palette = [
     ["#000000", (0.0, 0.0, 0.0)],  # black
     ["#00008B", (0.0, 0.0, 0.545)],  # dark blue
     ["#4169E1", (0.255, 0.412, 0.882)],  # bright blue
-]  # "color_palette" = 2
+]
 
 # ================================================================
 # Orange Gradient: PALETTE [used in get_orange_color()]
@@ -101,7 +101,7 @@ orange_palette = [
     ["#E64616", (0.902, 0.275, 0.086)],  # red-orange
     ["#FF7B00", (1.0, 0.5, 0.0)],  # bright orange
     ["#FFFFF6", (1.0, 1.0, 0.965)],  # yellow-white
-]  # "color_palette" = 3
+]
 
 # ================================================================
 # Viridis Gradient: PALETTE [used in get_viridis_color()]
@@ -112,7 +112,7 @@ viridis_palette = [
     ["#35B779", (0.208, 0.718, 0.475)],  # green
     ["#BDD93A", (0.741, 0.851, 0.227)],  # yellow-green
     ["#FDE724", (0.992, 0.906, 0.141)],  # bright yellow
-]  # "color_palette" = 4
+]
 
 # ================================================================
 # Ironbow Gradient: PALETTE [used in get_ironbow_color()]
@@ -123,7 +123,7 @@ ironbow_palette = [
     ["#91009C", (0.569, 0.0, 0.612)],  # magenta
     ["#E64616", (0.902, 0.275, 0.086)],  # red-orange
     ["#FFFFF6", (1.0, 1.0, 0.965)],  # yellow-white
-]  # "color_palette" = 5
+]
 
 # ================================================================
 # Blueprint Gradient: PALETTE [used in get_blueprint_color()]
@@ -134,7 +134,7 @@ blueprint_palette = [
     ["#607DBD", (0.376, 0.490, 0.741)],  # blue
     ["#98AEDD", (0.596, 0.682, 0.867)],  # light blue
     ["#E4EAF6", (0.894, 0.918, 0.965)],  # extra-light blue
-]  # "color_palette" = 6
+]
 
 
 # ================================================================

--- a/openwave/xperiments/a_granule_motion/_launcher.py
+++ b/openwave/xperiments/a_granule_motion/_launcher.py
@@ -134,7 +134,7 @@ class SimulationState:
 
         # Color control variables
         self.COLOR_THEME = "OCEAN"
-        self.COLOR_PALETTE = 0
+        self.WAVE_MENU = 0
 
         # Data Analytics & video export toggles
         self.INSTRUMENTATION = False
@@ -183,7 +183,7 @@ class SimulationState:
         # Color defaults
         color = params["color_defaults"]
         self.COLOR_THEME = color["COLOR_THEME"]
-        self.COLOR_PALETTE = color["COLOR_PALETTE"]
+        self.WAVE_MENU = color["WAVE_MENU"]
 
         # Data Analytics & video export toggles
         diag = params["analytics"]
@@ -255,19 +255,19 @@ def display_controls(state):
 def display_wave_menu(state):
     """Display wave properties selection menu."""
     with render.gui.sub_window("WAVE MENU", 0.00, 0.73, 0.14, 0.14) as sub:
-        if sub.checkbox("Displacement (orange)", state.COLOR_PALETTE == 3):
-            state.COLOR_PALETTE = 3
-        if sub.checkbox("Amplitude (ironbow)", state.COLOR_PALETTE == 5):
-            state.COLOR_PALETTE = 5
-        if sub.checkbox("Granule Type Color", state.COLOR_PALETTE == 0):
-            state.COLOR_PALETTE = 0
-        if sub.checkbox("Default Color", state.COLOR_PALETTE == 99):
-            state.COLOR_PALETTE = 99
-        if state.COLOR_PALETTE == 6:  # Display orange gradient palette
+        if sub.checkbox("Displacement (orange)", state.WAVE_MENU == 3):
+            state.WAVE_MENU = 3
+        if sub.checkbox("Amplitude (ironbow)", state.WAVE_MENU == 5):
+            state.WAVE_MENU = 5
+        if sub.checkbox("Granule Type Color", state.WAVE_MENU == 0):
+            state.WAVE_MENU = 0
+        if sub.checkbox("Default Color", state.WAVE_MENU == 99):
+            state.WAVE_MENU = 99
+        if state.WAVE_MENU == 6:  # Display orange gradient palette
             render.canvas.triangles(og_palette_vertices, per_vertex_color=og_palette_colors)
             with render.gui.sub_window("displacement", 0.00, 0.67, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.peak_amplitude:.0e}m")
-        if state.COLOR_PALETTE == 3:  # Display ironbow gradient palette
+        if state.WAVE_MENU == 3:  # Display ironbow gradient palette
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window("amplitude", 0.00, 0.67, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.peak_amplitude:.0e}m")
@@ -379,7 +379,7 @@ def compute_wave_motion(state):
         state.lattice.granule_var_color,
         state.FREQ_BOOST,
         state.AMP_BOOST,
-        state.COLOR_PALETTE,
+        state.WAVE_MENU,
         state.NUM_SOURCES,
         state.IN_WAVE_TOGGLE,
         state.OUT_WAVE_TOGGLE,
@@ -404,13 +404,13 @@ def render_elements(state):
     radius_render = state.granule.radius_screen * state.RADIUS_FACTOR
 
     # Render granules with color scheme
-    if state.COLOR_PALETTE == 0:
+    if state.WAVE_MENU == 0:
         render.scene.particles(
             state.lattice.position_screen,
             radius=radius_render,
             per_vertex_color=state.lattice.granule_type_color,
         )
-    elif state.COLOR_PALETTE == 3 or state.COLOR_PALETTE == 5:
+    elif state.WAVE_MENU == 3 or state.WAVE_MENU == 5:
         render.scene.particles(
             state.lattice.position_screen,
             radius=radius_render,

--- a/openwave/xperiments/a_granule_motion/_launcher.py
+++ b/openwave/xperiments/a_granule_motion/_launcher.py
@@ -255,19 +255,19 @@ def display_controls(state):
 def display_wave_menu(state):
     """Display wave properties selection menu."""
     with render.gui.sub_window("WAVE MENU", 0.00, 0.73, 0.14, 0.14) as sub:
-        if sub.checkbox("Displacement (orange)", state.WAVE_MENU == 3):
+        if sub.checkbox("Displacement (orange)", state.WAVE_MENU == 1):
+            state.WAVE_MENU = 1
+        if sub.checkbox("Amplitude (ironbow)", state.WAVE_MENU == 2):
+            state.WAVE_MENU = 2
+        if sub.checkbox("Granule Type Color", state.WAVE_MENU == 3):
             state.WAVE_MENU = 3
-        if sub.checkbox("Amplitude (ironbow)", state.WAVE_MENU == 5):
-            state.WAVE_MENU = 5
-        if sub.checkbox("Granule Type Color", state.WAVE_MENU == 0):
-            state.WAVE_MENU = 0
-        if sub.checkbox("Default Color", state.WAVE_MENU == 99):
-            state.WAVE_MENU = 99
-        if state.WAVE_MENU == 6:  # Display orange gradient palette
+        if sub.checkbox("Default Color", state.WAVE_MENU == 4):
+            state.WAVE_MENU = 4
+        if state.WAVE_MENU == 1:  # Display orange gradient palette
             render.canvas.triangles(og_palette_vertices, per_vertex_color=og_palette_colors)
             with render.gui.sub_window("displacement", 0.00, 0.67, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.peak_amplitude:.0e}m")
-        if state.WAVE_MENU == 3:  # Display ironbow gradient palette
+        if state.WAVE_MENU == 2:  # Display ironbow gradient palette
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window("amplitude", 0.00, 0.67, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.peak_amplitude:.0e}m")
@@ -404,13 +404,13 @@ def render_elements(state):
     radius_render = state.granule.radius_screen * state.RADIUS_FACTOR
 
     # Render granules with color scheme
-    if state.WAVE_MENU == 0:
+    if state.WAVE_MENU == 3:
         render.scene.particles(
             state.lattice.position_screen,
             radius=radius_render,
             per_vertex_color=state.lattice.granule_type_color,
         )
-    elif state.WAVE_MENU == 3 or state.WAVE_MENU == 5:
+    elif state.WAVE_MENU == 1 or state.WAVE_MENU == 2:
         render.scene.particles(
             state.lattice.position_screen,
             radius=radius_render,

--- a/openwave/xperiments/a_granule_motion/docs/README.md
+++ b/openwave/xperiments/a_granule_motion/docs/README.md
@@ -116,7 +116,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 1,  # Color palette list: default (99), granule-type (0), ironbow (1), blueprint (2)
+        "WAVE_MENU": 1,  # Color palette list: default (99), granule-type (0), ironbow (1), blueprint (2)
     },
     "diagnostics": {
         "WAVE_DIAGNOSTICS": False,  # Toggle wave diagnostics (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/spacetime_ewave.py
+++ b/openwave/xperiments/a_granule_motion/spacetime_ewave.py
@@ -323,13 +323,13 @@ def oscillate_granules(
 
         # COLOR CONVERSION OF DISPLACEMENT/AMPLITUDE VALUES
         # Map value to color using selected gradient
-        if wave_menu == 3:  # orange (magnitude only)
+        if wave_menu == 1:  # orange (magnitude only)
             granule_var_color[granule_idx] = colormap.get_orange_color(
                 displacement_am,
                 0.0,
                 amp_global_peak_am[None],
             )
-        elif wave_menu == 5:  # ironbow (magnitude only: thermal scale)
+        elif wave_menu == 2:  # ironbow (magnitude only: thermal scale)
             granule_var_color[granule_idx] = colormap.get_ironbow_color(
                 amp_local_peak_am[granule_idx],
                 0.0,

--- a/openwave/xperiments/a_granule_motion/spacetime_ewave.py
+++ b/openwave/xperiments/a_granule_motion/spacetime_ewave.py
@@ -146,7 +146,7 @@ def oscillate_granules(
     granule_var_color: ti.template(),  # type: ignore
     freq_boost: ti.f32,  # type: ignore
     amp_boost: ti.f32,  # type: ignore
-    color_palette: ti.i32,  # type: ignore
+    wave_menu: ti.i32,  # type: ignore
     num_sources: ti.i32,  # type: ignore
     in_wave_toggle: ti.i32,  # type: ignore
     out_wave_toggle: ti.i32,  # type: ignore
@@ -213,7 +213,7 @@ def oscillate_granules(
         granule_var_color: Color field for displacement/amplitude visualization
         freq_boost: Frequency multiplier (applied after slowed frequency)
         amp_boost: Amplitude multiplier (for visibility in scaled lattices)
-        color_palette: Coloring palette selection
+        wave_menu: Selected Wave displayed with color palette
         num_sources: Number of wave sources
         in_wave_toggle: Toggle for in_wave (1 = enable, 0 = disable)
         out_wave_toggle: Toggle for out_wave (1 = enable, 0 = disable)
@@ -323,13 +323,13 @@ def oscillate_granules(
 
         # COLOR CONVERSION OF DISPLACEMENT/AMPLITUDE VALUES
         # Map value to color using selected gradient
-        if color_palette == 3:  # orange (magnitude only)
+        if wave_menu == 3:  # orange (magnitude only)
             granule_var_color[granule_idx] = colormap.get_orange_color(
                 displacement_am,
                 0.0,
                 amp_global_peak_am[None],
             )
-        elif color_palette == 5:  # ironbow (magnitude only: thermal scale)
+        elif wave_menu == 5:  # ironbow (magnitude only: thermal scale)
             granule_var_color[granule_idx] = colormap.get_ironbow_color(
                 amp_local_peak_am[granule_idx],
                 0.0,

--- a/openwave/xperiments/a_granule_motion/xparameters/spacetime_vibration.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/spacetime_vibration.py
@@ -56,7 +56,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 0,  # default (99), granule-type (0), orange (3), ironbow (5)
+        "WAVE_MENU": 0,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/spacetime_vibration.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/spacetime_vibration.py
@@ -56,7 +56,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 0,  # default (99), granule-type (0), orange (3), ironbow (5)
+        "WAVE_MENU": 0,  # default (99), granule-type (0), orange (3), ironbow (5)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/spacetime_vibration.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/spacetime_vibration.py
@@ -56,7 +56,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 0,  # Check _launcher.py display_wave_menu() for wave_menu indexing
+        "WAVE_MENU": 3,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/spherical_wave.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/spherical_wave.py
@@ -45,7 +45,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 3,  # Check _launcher.py display_wave_menu() for wave_menu indexing
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/spherical_wave.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/spherical_wave.py
@@ -45,7 +45,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 3,  # default (99), granule-type (0), orange (3), ironbow (5)
+        "WAVE_MENU": 3,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/spherical_wave.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/spherical_wave.py
@@ -45,7 +45,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 3,  # default (99), granule-type (0), orange (3), ironbow (5)
+        "WAVE_MENU": 3,  # default (99), granule-type (0), orange (3), ironbow (5)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/standing_wave.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/standing_wave.py
@@ -78,7 +78,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 3,  # default (99), granule-type (0), orange (3), ironbow (5)
+        "WAVE_MENU": 3,  # default (99), granule-type (0), orange (3), ironbow (5)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/standing_wave.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/standing_wave.py
@@ -78,7 +78,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 3,  # Check _launcher.py display_wave_menu() for wave_menu indexing
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/standing_wave.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/standing_wave.py
@@ -78,7 +78,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 3,  # default (99), granule-type (0), orange (3), ironbow (5)
+        "WAVE_MENU": 3,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/wave_interference.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/wave_interference.py
@@ -58,7 +58,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 3,  # Check _launcher.py display_wave_menu() for wave_menu indexing
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/wave_interference.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/wave_interference.py
@@ -58,7 +58,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 3,  # default (99), granule-type (0), orange (3), ironbow (5)
+        "WAVE_MENU": 3,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/wave_interference.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/wave_interference.py
@@ -58,7 +58,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 3,  # default (99), granule-type (0), orange (3), ironbow (5)
+        "WAVE_MENU": 3,  # default (99), granule-type (0), orange (3), ironbow (5)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/wc1_attraction.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/wc1_attraction.py
@@ -47,7 +47,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 5,  # Check _launcher.py display_wave_menu() for wave_menu indexing
+        "WAVE_MENU": 2,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/wc1_attraction.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/wc1_attraction.py
@@ -47,7 +47,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 5,  # default (99), granule-type (0), orange (3), ironbow (5)
+        "WAVE_MENU": 5,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/wc1_attraction.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/wc1_attraction.py
@@ -47,7 +47,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 5,  # default (99), granule-type (0), orange (3), ironbow (5)
+        "WAVE_MENU": 5,  # default (99), granule-type (0), orange (3), ironbow (5)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/wc1_attraction.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/wc1_attraction.py
@@ -11,7 +11,7 @@ Z_POSITION = 0.07  # Z-axis position for all sources
 
 XPARAMETERS = {
     "meta": {
-        "X_NAME": "Particle: Attraction",
+        "X_NAME": "Attraction Force",
         "DESCRIPTION": "2 sources in linear pattern demonstrating wave superposition",
     },
     "camera": {

--- a/openwave/xperiments/a_granule_motion/xparameters/wc2_repulsion.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/wc2_repulsion.py
@@ -11,7 +11,7 @@ Z_POSITION = 0.07  # Z-axis position for all sources
 
 XPARAMETERS = {
     "meta": {
-        "X_NAME": "Particle: Repulsion",
+        "X_NAME": "Repulsion Force",
         "DESCRIPTION": "2 sources in linear pattern demonstrating wave superposition",
     },
     "camera": {

--- a/openwave/xperiments/a_granule_motion/xparameters/wc2_repulsion.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/wc2_repulsion.py
@@ -47,7 +47,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 5,  # Check _launcher.py display_wave_menu() for wave_menu indexing
+        "WAVE_MENU": 2,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/wc2_repulsion.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/wc2_repulsion.py
@@ -47,7 +47,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 5,  # default (99), granule-type (0), orange (3), ironbow (5)
+        "WAVE_MENU": 5,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/wc2_repulsion.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/wc2_repulsion.py
@@ -47,7 +47,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 5,  # default (99), granule-type (0), orange (3), ironbow (5)
+        "WAVE_MENU": 5,  # default (99), granule-type (0), orange (3), ironbow (5)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/yin_yang.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/yin_yang.py
@@ -76,7 +76,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 3,  # default (99), granule-type (0), orange (3), ironbow (5)
+        "WAVE_MENU": 3,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/yin_yang.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/yin_yang.py
@@ -76,7 +76,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 3,  # default (99), granule-type (0), orange (3), ironbow (5)
+        "WAVE_MENU": 3,  # default (99), granule-type (0), orange (3), ironbow (5)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/a_granule_motion/xparameters/yin_yang.py
+++ b/openwave/xperiments/a_granule_motion/xparameters/yin_yang.py
@@ -76,7 +76,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 3,  # Check _launcher.py display_wave_menu() for wave_menu indexing
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/b_laplace_propagation/_launcher.py
+++ b/openwave/xperiments/b_laplace_propagation/_launcher.py
@@ -288,12 +288,12 @@ def display_wave_menu(state):
             state.WAVE_MENU = 1
         if sub.checkbox("Displacement (Transverse)", state.WAVE_MENU == 2):
             state.WAVE_MENU = 2
-        if sub.checkbox("Amplitude (Longitudinal)", state.WAVE_MENU == 4):
+        if sub.checkbox("Amplitude (Longitudinal)", state.WAVE_MENU == 3):
+            state.WAVE_MENU = 3
+        if sub.checkbox("Amplitude (Transverse)", state.WAVE_MENU == 4):
             state.WAVE_MENU = 4
-        if sub.checkbox("Amplitude (Transverse)", state.WAVE_MENU == 5):
+        if sub.checkbox("Frequency (L&T)", state.WAVE_MENU == 5):
             state.WAVE_MENU = 5
-        if sub.checkbox("Frequency (L&T)", state.WAVE_MENU == 6):
-            state.WAVE_MENU = 6
         # Display gradient palette with 2× average range for headroom (allows peak visualization)
         if state.WAVE_MENU == 1:  # Display yellowgreen gradient palette
             render.canvas.triangles(yg_palette_vertices, per_vertex_color=yg_palette_colors)
@@ -307,15 +307,15 @@ def display_wave_menu(state):
                 sub.text(
                     f"{-state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}m"
                 )
-        if state.WAVE_MENU == 4:  # Display viridis gradient palette
+        if state.WAVE_MENU == 3:  # Display viridis gradient palette
             render.canvas.triangles(vr_palette_vertices, per_vertex_color=vr_palette_colors)
             with render.gui.sub_window("amplitude", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}m")
-        if state.WAVE_MENU == 5:  # Display ironbow gradient palette
+        if state.WAVE_MENU == 4:  # Display ironbow gradient palette
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window("amplitude", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}m")
-        if state.WAVE_MENU == 6:  # Display blueprint gradient palette
+        if state.WAVE_MENU == 5:  # Display blueprint gradient palette
             render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
             with render.gui.sub_window("frequency", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.freq_global_avg*2*state.wave_field.scale_factor:.0e}Hz")

--- a/openwave/xperiments/b_laplace_propagation/_launcher.py
+++ b/openwave/xperiments/b_laplace_propagation/_launcher.py
@@ -142,7 +142,7 @@ class SimulationState:
 
         # Color control variables
         self.COLOR_THEME = "OCEAN"
-        self.WAVE_MENU = 1  # Color palette index
+        self.WAVE_MENU = 1
 
         # Data Analytics & video export toggles
         self.INSTRUMENTATION = False

--- a/openwave/xperiments/b_laplace_propagation/_launcher.py
+++ b/openwave/xperiments/b_laplace_propagation/_launcher.py
@@ -142,7 +142,7 @@ class SimulationState:
 
         # Color control variables
         self.COLOR_THEME = "OCEAN"
-        self.COLOR_PALETTE = 1  # Color palette index
+        self.WAVE_MENU = 1  # Color palette index
 
         # Data Analytics & video export toggles
         self.INSTRUMENTATION = False
@@ -181,7 +181,7 @@ class SimulationState:
         # Color defaults
         color = params["color_defaults"]
         self.COLOR_THEME = color["COLOR_THEME"]
-        self.COLOR_PALETTE = color["COLOR_PALETTE"]
+        self.WAVE_MENU = color["WAVE_MENU"]
 
         # Data Analytics & video export toggles
         diag = params["analytics"]
@@ -284,38 +284,38 @@ def display_controls(state):
 def display_wave_menu(state):
     """Display wave properties selection menu."""
     with render.gui.sub_window("WAVE MENU", 0.00, 0.70, 0.15, 0.17) as sub:
-        if sub.checkbox("Displacement (Longitudinal)", state.COLOR_PALETTE == 1):
-            state.COLOR_PALETTE = 1
-        if sub.checkbox("Displacement (Transverse)", state.COLOR_PALETTE == 2):
-            state.COLOR_PALETTE = 2
-        if sub.checkbox("Amplitude (Longitudinal)", state.COLOR_PALETTE == 4):
-            state.COLOR_PALETTE = 4
-        if sub.checkbox("Amplitude (Transverse)", state.COLOR_PALETTE == 5):
-            state.COLOR_PALETTE = 5
-        if sub.checkbox("Frequency (L&T)", state.COLOR_PALETTE == 6):
-            state.COLOR_PALETTE = 6
+        if sub.checkbox("Displacement (Longitudinal)", state.WAVE_MENU == 1):
+            state.WAVE_MENU = 1
+        if sub.checkbox("Displacement (Transverse)", state.WAVE_MENU == 2):
+            state.WAVE_MENU = 2
+        if sub.checkbox("Amplitude (Longitudinal)", state.WAVE_MENU == 4):
+            state.WAVE_MENU = 4
+        if sub.checkbox("Amplitude (Transverse)", state.WAVE_MENU == 5):
+            state.WAVE_MENU = 5
+        if sub.checkbox("Frequency (L&T)", state.WAVE_MENU == 6):
+            state.WAVE_MENU = 6
         # Display gradient palette with 2× average range for headroom (allows peak visualization)
-        if state.COLOR_PALETTE == 1:  # Display yellowgreen gradient palette
+        if state.WAVE_MENU == 1:  # Display yellowgreen gradient palette
             render.canvas.triangles(yg_palette_vertices, per_vertex_color=yg_palette_colors)
             with render.gui.sub_window("displacement", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(
                     f"{-state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}m"
                 )
-        if state.COLOR_PALETTE == 2:  # Display redblue gradient palette
+        if state.WAVE_MENU == 2:  # Display redblue gradient palette
             render.canvas.triangles(rb_palette_vertices, per_vertex_color=rb_palette_colors)
             with render.gui.sub_window("displacement", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(
                     f"{-state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}m"
                 )
-        if state.COLOR_PALETTE == 4:  # Display viridis gradient palette
+        if state.WAVE_MENU == 4:  # Display viridis gradient palette
             render.canvas.triangles(vr_palette_vertices, per_vertex_color=vr_palette_colors)
             with render.gui.sub_window("amplitude", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}m")
-        if state.COLOR_PALETTE == 5:  # Display ironbow gradient palette
+        if state.WAVE_MENU == 5:  # Display ironbow gradient palette
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window("amplitude", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}m")
-        if state.COLOR_PALETTE == 6:  # Display blueprint gradient palette
+        if state.WAVE_MENU == 6:  # Display blueprint gradient palette
             render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
             with render.gui.sub_window("frequency", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.freq_global_avg*2*state.wave_field.scale_factor:.0e}Hz")
@@ -542,7 +542,7 @@ def render_elements(state):
         ewave.update_flux_mesh_values(
             state.wave_field,
             state.trackers,
-            state.COLOR_PALETTE,
+            state.WAVE_MENU,
             state.WARP_MESH,
         )
         flux_mesh.render_flux_mesh(render.scene, state.wave_field, state.SHOW_FLUX_MESH)

--- a/openwave/xperiments/b_laplace_propagation/spacetime_ewave.py
+++ b/openwave/xperiments/b_laplace_propagation/spacetime_ewave.py
@@ -1611,7 +1611,7 @@ def sample_avg_trackers(
 def update_flux_mesh_values(
     wave_field: ti.template(),  # type: ignore
     trackers: ti.template(),  # type: ignore
-    color_palette: ti.i32,  # type: ignore
+    wave_menu: ti.i32,  # type: ignore
     warp_mesh: ti.i32,  # type: ignore
 ):
     """
@@ -1623,7 +1623,7 @@ def update_flux_mesh_values(
     Args:
         wave_field: WaveField instance containing flux mesh fields and displacement data
         trackers: WaveTrackers instance with amplitude/frequency data for color scaling
-        color_palette: Color palette selection
+        wave_menu: Selected Wave displayed with color palette
     """
 
     # ================================================================
@@ -1641,7 +1641,7 @@ def update_flux_mesh_values(
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if color_palette == 6:  # blueprint
+        if wave_menu == 6:  # blueprint
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_blueprint_color(
                 freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
             )
@@ -1650,7 +1650,7 @@ def update_flux_mesh_values(
             ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[2] * (
                 wave_field.nz / wave_field.max_grid_size
             )
-        elif color_palette == 5:  # ironbow
+        elif wave_menu == 5:  # ironbow
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_ironbow_color(
                 ampT_value, 0, trackers.ampT_global_rms_am[None] * 2
             )
@@ -1658,7 +1658,7 @@ def update_flux_mesh_values(
                 ampT_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
-        elif color_palette == 4:  # viridis
+        elif wave_menu == 4:  # viridis
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_viridis_color(
                 ampL_value, 0, trackers.ampL_global_rms_am[None] * 2
             )
@@ -1666,7 +1666,7 @@ def update_flux_mesh_values(
                 ampL_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
-        elif color_palette == 2:  # redblue
+        elif wave_menu == 2:  # redblue
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_redblue_color(
                 psiT_value,
                 -trackers.ampT_global_rms_am[None] * 2,
@@ -1701,7 +1701,7 @@ def update_flux_mesh_values(
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if color_palette == 6:  # blueprint
+        if wave_menu == 6:  # blueprint
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_blueprint_color(
                 freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
             )
@@ -1710,7 +1710,7 @@ def update_flux_mesh_values(
             ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[1] * (
                 wave_field.ny / wave_field.max_grid_size
             )
-        elif color_palette == 5:  # ironbow
+        elif wave_menu == 5:  # ironbow
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_ironbow_color(
                 ampT_value, 0, trackers.ampT_global_rms_am[None] * 2
             )
@@ -1718,7 +1718,7 @@ def update_flux_mesh_values(
                 ampT_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
-        elif color_palette == 4:  # viridis
+        elif wave_menu == 4:  # viridis
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_viridis_color(
                 ampL_value, 0, trackers.ampL_global_rms_am[None] * 2
             )
@@ -1726,7 +1726,7 @@ def update_flux_mesh_values(
                 ampL_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
-        elif color_palette == 2:  # redblue
+        elif wave_menu == 2:  # redblue
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_redblue_color(
                 psiT_value,
                 -trackers.ampT_global_rms_am[None] * 2,
@@ -1761,7 +1761,7 @@ def update_flux_mesh_values(
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if color_palette == 6:  # blueprint
+        if wave_menu == 6:  # blueprint
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_blueprint_color(
                 freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
             )
@@ -1770,7 +1770,7 @@ def update_flux_mesh_values(
             ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[0] * (
                 wave_field.nx / wave_field.max_grid_size
             )
-        elif color_palette == 5:  # ironbow
+        elif wave_menu == 5:  # ironbow
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_ironbow_color(
                 ampT_value, 0, trackers.ampT_global_rms_am[None] * 2
             )
@@ -1778,7 +1778,7 @@ def update_flux_mesh_values(
                 ampT_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )
-        elif color_palette == 4:  # viridis
+        elif wave_menu == 4:  # viridis
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_viridis_color(
                 ampL_value, 0, trackers.ampL_global_rms_am[None] * 2
             )
@@ -1786,7 +1786,7 @@ def update_flux_mesh_values(
                 ampL_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )
-        elif color_palette == 2:  # redblue
+        elif wave_menu == 2:  # redblue
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_redblue_color(
                 psiT_value,
                 -trackers.ampT_global_rms_am[None] * 2,

--- a/openwave/xperiments/b_laplace_propagation/spacetime_ewave.py
+++ b/openwave/xperiments/b_laplace_propagation/spacetime_ewave.py
@@ -1641,7 +1641,7 @@ def update_flux_mesh_values(
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if wave_menu == 6:  # blueprint
+        if wave_menu == 5:  # blueprint
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_blueprint_color(
                 freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
             )
@@ -1650,7 +1650,7 @@ def update_flux_mesh_values(
             ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[2] * (
                 wave_field.nz / wave_field.max_grid_size
             )
-        elif wave_menu == 5:  # ironbow
+        elif wave_menu == 4:  # ironbow
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_ironbow_color(
                 ampT_value, 0, trackers.ampT_global_rms_am[None] * 2
             )
@@ -1658,7 +1658,7 @@ def update_flux_mesh_values(
                 ampT_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
-        elif wave_menu == 4:  # viridis
+        elif wave_menu == 3:  # viridis
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_viridis_color(
                 ampL_value, 0, trackers.ampL_global_rms_am[None] * 2
             )
@@ -1676,7 +1676,7 @@ def update_flux_mesh_values(
                 psiT_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
-        else:  # default to yellowgreen (palette 1)
+        else:  # default to yellowgreen (wave_menu == 1)
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_yellowgreen_color(
                 psiL_value,
                 -trackers.ampL_global_rms_am[None] * 2,
@@ -1701,7 +1701,7 @@ def update_flux_mesh_values(
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if wave_menu == 6:  # blueprint
+        if wave_menu == 5:  # blueprint
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_blueprint_color(
                 freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
             )
@@ -1710,7 +1710,7 @@ def update_flux_mesh_values(
             ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[1] * (
                 wave_field.ny / wave_field.max_grid_size
             )
-        elif wave_menu == 5:  # ironbow
+        elif wave_menu == 4:  # ironbow
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_ironbow_color(
                 ampT_value, 0, trackers.ampT_global_rms_am[None] * 2
             )
@@ -1718,7 +1718,7 @@ def update_flux_mesh_values(
                 ampT_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
-        elif wave_menu == 4:  # viridis
+        elif wave_menu == 3:  # viridis
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_viridis_color(
                 ampL_value, 0, trackers.ampL_global_rms_am[None] * 2
             )
@@ -1736,7 +1736,7 @@ def update_flux_mesh_values(
                 psiT_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
-        else:  # default to yellowgreen (palette 1)
+        else:  # default to yellowgreen (wave_menu == 1)
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_yellowgreen_color(
                 psiL_value,
                 -trackers.ampL_global_rms_am[None] * 2,
@@ -1761,7 +1761,7 @@ def update_flux_mesh_values(
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if wave_menu == 6:  # blueprint
+        if wave_menu == 5:  # blueprint
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_blueprint_color(
                 freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
             )
@@ -1770,7 +1770,7 @@ def update_flux_mesh_values(
             ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[0] * (
                 wave_field.nx / wave_field.max_grid_size
             )
-        elif wave_menu == 5:  # ironbow
+        elif wave_menu == 4:  # ironbow
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_ironbow_color(
                 ampT_value, 0, trackers.ampT_global_rms_am[None] * 2
             )
@@ -1778,7 +1778,7 @@ def update_flux_mesh_values(
                 ampT_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )
-        elif wave_menu == 4:  # viridis
+        elif wave_menu == 3:  # viridis
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_viridis_color(
                 ampL_value, 0, trackers.ampL_global_rms_am[None] * 2
             )
@@ -1796,7 +1796,7 @@ def update_flux_mesh_values(
                 psiT_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )
-        else:  # default to yellowgreen (palette 1)
+        else:  # default to yellowgreen (wave_menu == 1)
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_yellowgreen_color(
                 psiL_value,
                 -trackers.ampL_global_rms_am[None] * 2,

--- a/openwave/xperiments/b_laplace_propagation/xparameters/0035_waves.py
+++ b/openwave/xperiments/b_laplace_propagation/xparameters/0035_waves.py
@@ -36,7 +36,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/b_laplace_propagation/xparameters/0035_waves.py
+++ b/openwave/xperiments/b_laplace_propagation/xparameters/0035_waves.py
@@ -36,7 +36,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/b_laplace_propagation/xparameters/2000_waves.py
+++ b/openwave/xperiments/b_laplace_propagation/xparameters/2000_waves.py
@@ -36,7 +36,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/b_laplace_propagation/xparameters/2000_waves.py
+++ b/openwave/xperiments/b_laplace_propagation/xparameters/2000_waves.py
@@ -36,7 +36,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/b_laplace_propagation/xparameters/test_max.py
+++ b/openwave/xperiments/b_laplace_propagation/xparameters/test_max.py
@@ -40,7 +40,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/b_laplace_propagation/xparameters/test_max.py
+++ b/openwave/xperiments/b_laplace_propagation/xparameters/test_max.py
@@ -40,7 +40,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/b_laplace_propagation/xparameters/test_stress.py
+++ b/openwave/xperiments/b_laplace_propagation/xparameters/test_stress.py
@@ -36,7 +36,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/b_laplace_propagation/xparameters/test_stress.py
+++ b/openwave/xperiments/b_laplace_propagation/xparameters/test_stress.py
@@ -36,7 +36,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/b_laplace_propagation/xparameters/the_grid.py
+++ b/openwave/xperiments/b_laplace_propagation/xparameters/the_grid.py
@@ -35,7 +35,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/b_laplace_propagation/xparameters/the_grid.py
+++ b/openwave/xperiments/b_laplace_propagation/xparameters/the_grid.py
@@ -35,7 +35,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/b_laplace_propagation/xparameters/the_king.py
+++ b/openwave/xperiments/b_laplace_propagation/xparameters/the_king.py
@@ -35,7 +35,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 2,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 2,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/b_laplace_propagation/xparameters/the_king.py
+++ b/openwave/xperiments/b_laplace_propagation/xparameters/the_king.py
@@ -35,7 +35,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 2,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 2,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/b_laplace_propagation/xparameters/the_queen.py
+++ b/openwave/xperiments/b_laplace_propagation/xparameters/the_queen.py
@@ -35,7 +35,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/b_laplace_propagation/xparameters/the_queen.py
+++ b/openwave/xperiments/b_laplace_propagation/xparameters/the_queen.py
@@ -35,7 +35,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/_launcher.py
+++ b/openwave/xperiments/c_wolff_lafreniere/_launcher.py
@@ -144,7 +144,7 @@ class SimulationState:
 
         # Color control variables
         self.COLOR_THEME = "OCEAN"
-        self.COLOR_PALETTE = 1  # Color palette index
+        self.WAVE_MENU = 1  # Color palette index
 
         # Data Analytics & video export toggles
         self.INSTRUMENTATION = False
@@ -187,7 +187,7 @@ class SimulationState:
         # Color defaults
         color = params["color_defaults"]
         self.COLOR_THEME = color["COLOR_THEME"]
-        self.COLOR_PALETTE = color["COLOR_PALETTE"]
+        self.WAVE_MENU = color["WAVE_MENU"]
 
         # Data Analytics & video export toggles
         diag = params["analytics"]
@@ -296,38 +296,38 @@ def display_controls(state):
 def display_wave_menu(state):
     """Display wave properties selection menu."""
     with render.gui.sub_window("WAVE MENU", 0.00, 0.70, 0.15, 0.17) as sub:
-        if sub.checkbox("Displacement (Longitudinal)", state.COLOR_PALETTE == 1):
-            state.COLOR_PALETTE = 1
-        if sub.checkbox("Displacement (Transverse)", state.COLOR_PALETTE == 2):
-            state.COLOR_PALETTE = 2
-        if sub.checkbox("Amplitude (Longitudinal)", state.COLOR_PALETTE == 4):
-            state.COLOR_PALETTE = 4
-        if sub.checkbox("Amplitude (Transverse)", state.COLOR_PALETTE == 5):
-            state.COLOR_PALETTE = 5
-        if sub.checkbox("Frequency (L&T)", state.COLOR_PALETTE == 6):
-            state.COLOR_PALETTE = 6
+        if sub.checkbox("Displacement (Longitudinal)", state.WAVE_MENU == 1):
+            state.WAVE_MENU = 1
+        if sub.checkbox("Displacement (Transverse)", state.WAVE_MENU == 2):
+            state.WAVE_MENU = 2
+        if sub.checkbox("Amplitude (Longitudinal)", state.WAVE_MENU == 4):
+            state.WAVE_MENU = 4
+        if sub.checkbox("Amplitude (Transverse)", state.WAVE_MENU == 5):
+            state.WAVE_MENU = 5
+        if sub.checkbox("Frequency (L&T)", state.WAVE_MENU == 6):
+            state.WAVE_MENU = 6
         # Display gradient palette with 2× average range for headroom (allows peak visualization)
-        if state.COLOR_PALETTE == 1:  # Display yellowgreen gradient palette
+        if state.WAVE_MENU == 1:  # Display yellowgreen gradient palette
             render.canvas.triangles(yg_palette_vertices, per_vertex_color=yg_palette_colors)
             with render.gui.sub_window("displacement", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(
                     f"{-state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}m"
                 )
-        if state.COLOR_PALETTE == 2:  # Display redblue gradient palette
+        if state.WAVE_MENU == 2:  # Display redblue gradient palette
             render.canvas.triangles(rb_palette_vertices, per_vertex_color=rb_palette_colors)
             with render.gui.sub_window("displacement", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(
                     f"{-state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}m"
                 )
-        if state.COLOR_PALETTE == 4:  # Display viridis gradient palette
+        if state.WAVE_MENU == 4:  # Display viridis gradient palette
             render.canvas.triangles(vr_palette_vertices, per_vertex_color=vr_palette_colors)
             with render.gui.sub_window("amplitude", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}m")
-        if state.COLOR_PALETTE == 5:  # Display ironbow gradient palette
+        if state.WAVE_MENU == 5:  # Display ironbow gradient palette
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window("amplitude", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}m")
-        if state.COLOR_PALETTE == 6:  # Display blueprint gradient palette
+        if state.WAVE_MENU == 6:  # Display blueprint gradient palette
             render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
             with render.gui.sub_window("frequency", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.freq_global_avg*2*state.wave_field.scale_factor:.0e}Hz")
@@ -555,7 +555,7 @@ def render_elements(state):
         ewave.update_flux_mesh_values(
             state.wave_field,
             state.trackers,
-            state.COLOR_PALETTE,
+            state.WAVE_MENU,
             state.WARP_MESH,
         )
         flux_mesh.render_flux_mesh(render.scene, state.wave_field, state.SHOW_FLUX_MESH)

--- a/openwave/xperiments/c_wolff_lafreniere/_launcher.py
+++ b/openwave/xperiments/c_wolff_lafreniere/_launcher.py
@@ -300,12 +300,12 @@ def display_wave_menu(state):
             state.WAVE_MENU = 1
         if sub.checkbox("Displacement (Transverse)", state.WAVE_MENU == 2):
             state.WAVE_MENU = 2
-        if sub.checkbox("Amplitude (Longitudinal)", state.WAVE_MENU == 4):
+        if sub.checkbox("Amplitude (Longitudinal)", state.WAVE_MENU == 3):
+            state.WAVE_MENU = 3
+        if sub.checkbox("Amplitude (Transverse)", state.WAVE_MENU == 4):
             state.WAVE_MENU = 4
-        if sub.checkbox("Amplitude (Transverse)", state.WAVE_MENU == 5):
+        if sub.checkbox("Frequency (L&T)", state.WAVE_MENU == 5):
             state.WAVE_MENU = 5
-        if sub.checkbox("Frequency (L&T)", state.WAVE_MENU == 6):
-            state.WAVE_MENU = 6
         # Display gradient palette with 2× average range for headroom (allows peak visualization)
         if state.WAVE_MENU == 1:  # Display yellowgreen gradient palette
             render.canvas.triangles(yg_palette_vertices, per_vertex_color=yg_palette_colors)
@@ -319,15 +319,15 @@ def display_wave_menu(state):
                 sub.text(
                     f"{-state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}m"
                 )
-        if state.WAVE_MENU == 4:  # Display viridis gradient palette
+        if state.WAVE_MENU == 3:  # Display viridis gradient palette
             render.canvas.triangles(vr_palette_vertices, per_vertex_color=vr_palette_colors)
             with render.gui.sub_window("amplitude", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}m")
-        if state.WAVE_MENU == 5:  # Display ironbow gradient palette
+        if state.WAVE_MENU == 4:  # Display ironbow gradient palette
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
             with render.gui.sub_window("amplitude", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}m")
-        if state.WAVE_MENU == 6:  # Display blueprint gradient palette
+        if state.WAVE_MENU == 5:  # Display blueprint gradient palette
             render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
             with render.gui.sub_window("frequency", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.freq_global_avg*2*state.wave_field.scale_factor:.0e}Hz")

--- a/openwave/xperiments/c_wolff_lafreniere/_launcher.py
+++ b/openwave/xperiments/c_wolff_lafreniere/_launcher.py
@@ -144,7 +144,7 @@ class SimulationState:
 
         # Color control variables
         self.COLOR_THEME = "OCEAN"
-        self.WAVE_MENU = 1  # Color palette index
+        self.WAVE_MENU = 1
 
         # Data Analytics & video export toggles
         self.INSTRUMENTATION = False

--- a/openwave/xperiments/c_wolff_lafreniere/spacetime_ewave.py
+++ b/openwave/xperiments/c_wolff_lafreniere/spacetime_ewave.py
@@ -554,7 +554,7 @@ def update_flux_mesh_values(
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if wave_menu == 6:  # blueprint
+        if wave_menu == 5:  # blueprint
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_blueprint_color(
                 freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
             )
@@ -563,7 +563,7 @@ def update_flux_mesh_values(
             ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[2] * (
                 wave_field.nz / wave_field.max_grid_size
             )
-        elif wave_menu == 5:  # ironbow
+        elif wave_menu == 4:  # ironbow
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_ironbow_color(
                 ampT_value, 0, trackers.ampT_global_rms_am[None] * 2
             )
@@ -571,7 +571,7 @@ def update_flux_mesh_values(
                 ampT_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
-        elif wave_menu == 4:  # viridis
+        elif wave_menu == 3:  # viridis
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_viridis_color(
                 ampL_value, 0, trackers.ampL_global_rms_am[None] * 2
             )
@@ -589,7 +589,7 @@ def update_flux_mesh_values(
                 psiT_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
-        else:  # default to yellowgreen (palette 1)
+        else:  # default to yellowgreen (wave_menu == 1)
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_yellowgreen_color(
                 psiL_value,
                 -trackers.ampL_global_rms_am[None] * 2,
@@ -614,7 +614,7 @@ def update_flux_mesh_values(
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if wave_menu == 6:  # blueprint
+        if wave_menu == 5:  # blueprint
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_blueprint_color(
                 freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
             )
@@ -623,7 +623,7 @@ def update_flux_mesh_values(
             ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[1] * (
                 wave_field.ny / wave_field.max_grid_size
             )
-        elif wave_menu == 5:  # ironbow
+        elif wave_menu == 4:  # ironbow
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_ironbow_color(
                 ampT_value, 0, trackers.ampT_global_rms_am[None] * 2
             )
@@ -631,7 +631,7 @@ def update_flux_mesh_values(
                 ampT_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
-        elif wave_menu == 4:  # viridis
+        elif wave_menu == 3:  # viridis
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_viridis_color(
                 ampL_value, 0, trackers.ampL_global_rms_am[None] * 2
             )
@@ -649,7 +649,7 @@ def update_flux_mesh_values(
                 psiT_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
-        else:  # default to yellowgreen (palette 1)
+        else:  # default to yellowgreen (wave_menu == 1)
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_yellowgreen_color(
                 psiL_value,
                 -trackers.ampL_global_rms_am[None] * 2,
@@ -674,7 +674,7 @@ def update_flux_mesh_values(
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if wave_menu == 6:  # blueprint
+        if wave_menu == 5:  # blueprint
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_blueprint_color(
                 freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
             )
@@ -683,7 +683,7 @@ def update_flux_mesh_values(
             ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[0] * (
                 wave_field.nx / wave_field.max_grid_size
             )
-        elif wave_menu == 5:  # ironbow
+        elif wave_menu == 4:  # ironbow
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_ironbow_color(
                 ampT_value, 0, trackers.ampT_global_rms_am[None] * 2
             )
@@ -691,7 +691,7 @@ def update_flux_mesh_values(
                 ampT_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )
-        elif wave_menu == 4:  # viridis
+        elif wave_menu == 3:  # viridis
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_viridis_color(
                 ampL_value, 0, trackers.ampL_global_rms_am[None] * 2
             )
@@ -709,7 +709,7 @@ def update_flux_mesh_values(
                 psiT_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )
-        else:  # default to yellowgreen (palette 1)
+        else:  # default to yellowgreen (wave_menu == 1)
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_yellowgreen_color(
                 psiL_value,
                 -trackers.ampL_global_rms_am[None] * 2,

--- a/openwave/xperiments/c_wolff_lafreniere/spacetime_ewave.py
+++ b/openwave/xperiments/c_wolff_lafreniere/spacetime_ewave.py
@@ -524,7 +524,7 @@ def sample_avg_trackers(
 def update_flux_mesh_values(
     wave_field: ti.template(),  # type: ignore
     trackers: ti.template(),  # type: ignore
-    color_palette: ti.i32,  # type: ignore
+    wave_menu: ti.i32,  # type: ignore
     warp_mesh: ti.i32,  # type: ignore
 ):
     """
@@ -536,7 +536,7 @@ def update_flux_mesh_values(
     Args:
         wave_field: WaveField instance containing flux mesh fields and displacement data
         trackers: WaveTrackers instance with amplitude/frequency data for color scaling
-        color_palette: Color palette selection
+        wave_menu: Selected Wave displayed with color palette
     """
 
     # ================================================================
@@ -554,7 +554,7 @@ def update_flux_mesh_values(
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if color_palette == 6:  # blueprint
+        if wave_menu == 6:  # blueprint
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_blueprint_color(
                 freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
             )
@@ -563,7 +563,7 @@ def update_flux_mesh_values(
             ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[2] * (
                 wave_field.nz / wave_field.max_grid_size
             )
-        elif color_palette == 5:  # ironbow
+        elif wave_menu == 5:  # ironbow
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_ironbow_color(
                 ampT_value, 0, trackers.ampT_global_rms_am[None] * 2
             )
@@ -571,7 +571,7 @@ def update_flux_mesh_values(
                 ampT_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
-        elif color_palette == 4:  # viridis
+        elif wave_menu == 4:  # viridis
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_viridis_color(
                 ampL_value, 0, trackers.ampL_global_rms_am[None] * 2
             )
@@ -579,7 +579,7 @@ def update_flux_mesh_values(
                 ampL_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
-        elif color_palette == 2:  # redblue
+        elif wave_menu == 2:  # redblue
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_redblue_color(
                 psiT_value,
                 -trackers.ampT_global_rms_am[None] * 2,
@@ -614,7 +614,7 @@ def update_flux_mesh_values(
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if color_palette == 6:  # blueprint
+        if wave_menu == 6:  # blueprint
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_blueprint_color(
                 freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
             )
@@ -623,7 +623,7 @@ def update_flux_mesh_values(
             ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[1] * (
                 wave_field.ny / wave_field.max_grid_size
             )
-        elif color_palette == 5:  # ironbow
+        elif wave_menu == 5:  # ironbow
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_ironbow_color(
                 ampT_value, 0, trackers.ampT_global_rms_am[None] * 2
             )
@@ -631,7 +631,7 @@ def update_flux_mesh_values(
                 ampT_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
-        elif color_palette == 4:  # viridis
+        elif wave_menu == 4:  # viridis
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_viridis_color(
                 ampL_value, 0, trackers.ampL_global_rms_am[None] * 2
             )
@@ -639,7 +639,7 @@ def update_flux_mesh_values(
                 ampL_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
-        elif color_palette == 2:  # redblue
+        elif wave_menu == 2:  # redblue
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_redblue_color(
                 psiT_value,
                 -trackers.ampT_global_rms_am[None] * 2,
@@ -674,7 +674,7 @@ def update_flux_mesh_values(
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if color_palette == 6:  # blueprint
+        if wave_menu == 6:  # blueprint
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_blueprint_color(
                 freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
             )
@@ -683,7 +683,7 @@ def update_flux_mesh_values(
             ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[0] * (
                 wave_field.nx / wave_field.max_grid_size
             )
-        elif color_palette == 5:  # ironbow
+        elif wave_menu == 5:  # ironbow
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_ironbow_color(
                 ampT_value, 0, trackers.ampT_global_rms_am[None] * 2
             )
@@ -691,7 +691,7 @@ def update_flux_mesh_values(
                 ampT_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )
-        elif color_palette == 4:  # viridis
+        elif wave_menu == 4:  # viridis
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_viridis_color(
                 ampL_value, 0, trackers.ampL_global_rms_am[None] * 2
             )
@@ -699,7 +699,7 @@ def update_flux_mesh_values(
                 ampL_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )
-        elif color_palette == 2:  # redblue
+        elif wave_menu == 2:  # redblue
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_redblue_color(
                 psiT_value,
                 -trackers.ampT_global_rms_am[None] * 2,

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/0007_waves.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/0007_waves.py
@@ -44,7 +44,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/0007_waves.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/0007_waves.py
@@ -44,7 +44,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/2000_waves.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/2000_waves.py
@@ -45,7 +45,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/2000_waves.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/2000_waves.py
@@ -45,7 +45,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction.py
@@ -45,7 +45,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction.py
@@ -45,7 +45,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction2.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction2.py
@@ -45,7 +45,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction2.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction2.py
@@ -45,7 +45,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction3.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction3.py
@@ -45,7 +45,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction3.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_attraction3.py
@@ -45,7 +45,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_repulsion.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_repulsion.py
@@ -45,7 +45,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_repulsion.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_repulsion.py
@@ -45,7 +45,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_repulsion2.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_repulsion2.py
@@ -45,7 +45,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_repulsion2.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/electric_repulsion2.py
@@ -45,7 +45,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/test_max.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/test_max.py
@@ -48,7 +48,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/test_max.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/test_max.py
@@ -48,7 +48,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/test_stress.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/test_stress.py
@@ -44,7 +44,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "COLOR_PALETTE": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics

--- a/openwave/xperiments/c_wolff_lafreniere/xparameters/test_stress.py
+++ b/openwave/xperiments/c_wolff_lafreniere/xparameters/test_stress.py
@@ -44,7 +44,7 @@ XPARAMETERS = {
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 1,  # yellowgreen (1), redblue (2), viridis (4), ironbow (5), blueprint (6)
+        "WAVE_MENU": 1,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data acquisition and analytics


### PR DESCRIPTION
This pull request refactors the color palette selection system throughout the granule motion and Laplace propagation experiment modules. The main change is the replacement of the `COLOR_PALETTE` variable with a more descriptive `WAVE_MENU` variable, updating all related logic, parameter passing, and documentation for clarity and maintainability. Additionally, some experiment metadata has been slightly revised for clarity.

**Refactor and variable renaming:**

* Replaced all instances of `COLOR_PALETTE` with `WAVE_MENU` in the granule motion and Laplace propagation experiment launchers, parameter application, wave menu UI, and rendering logic for more intuitive wave property selection and color mapping. [[1]](diffhunk://#diff-44ec29082236014fa054b5dfaa91d883490c176aaf7bc6cc1b7a9cae365e8766L137-R137) [[2]](diffhunk://#diff-44ec29082236014fa054b5dfaa91d883490c176aaf7bc6cc1b7a9cae365e8766L186-R186) [[3]](diffhunk://#diff-44ec29082236014fa054b5dfaa91d883490c176aaf7bc6cc1b7a9cae365e8766L258-R270) [[4]](diffhunk://#diff-44ec29082236014fa054b5dfaa91d883490c176aaf7bc6cc1b7a9cae365e8766L382-R382) [[5]](diffhunk://#diff-44ec29082236014fa054b5dfaa91d883490c176aaf7bc6cc1b7a9cae365e8766L407-R413) [[6]](diffhunk://#diff-b8d86515f866fa331c7d78ec483c94ad4323ceca5e4fe4b6889a4ba79eca6139L145-R145) [[7]](diffhunk://#diff-b8d86515f866fa331c7d78ec483c94ad4323ceca5e4fe4b6889a4ba79eca6139L184-R184) [[8]](diffhunk://#diff-b8d86515f866fa331c7d78ec483c94ad4323ceca5e4fe4b6889a4ba79eca6139L287-R318)
* Updated the argument and docstring names from `color_palette` to `wave_menu` in the `oscillate_granules` function and its usage, ensuring consistency in function signatures and documentation. [[1]](diffhunk://#diff-a9f23ec349c0671f92f6b7f99d334707b58d93f048f4c8e79ae8962e5b5656fdL149-R149) [[2]](diffhunk://#diff-a9f23ec349c0671f92f6b7f99d334707b58d93f048f4c8e79ae8962e5b5656fdL216-R216) [[3]](diffhunk://#diff-a9f23ec349c0671f92f6b7f99d334707b58d93f048f4c8e79ae8962e5b5656fdL326-R332)

**Parameter and documentation updates:**

* Changed all experiment parameter files to use `WAVE_MENU` instead of `COLOR_PALETTE`, and updated comments to direct users to the correct variable and indexing references. [[1]](diffhunk://#diff-b144a32310d1fa1177d113e6007c16410fd21a54b48aa3ef07b5f1d50b4bff10L119-R119) [[2]](diffhunk://#diff-0501ba6a102e1a55290bf29a83547f7409610974939fdf4bf1bbe5cdcae18b63L59-R59) [[3]](diffhunk://#diff-d4b67096d4aa351e3c659c3ba39f83af15e3ebfe030c4653874eb89c41150b8dL48-R48) [[4]](diffhunk://#diff-27e4bc256479a5883c13d0204fbba4f3ded17750f896f1db977b6e30c55fc624L81-R81) [[5]](diffhunk://#diff-8d347b78d128f759a155bdf3d1bfc321a1be87a86e81238b9c78ad87d0453146L61-R61) [[6]](diffhunk://#diff-2fc558bb61182368b380afda0112fc26f510c7adf96f4feb311160fc1ceb98e3L50-R50) [[7]](diffhunk://#diff-88d6895b03e2444c1b16f266cd4229454f78fba8c40acf2d8c3664abd90887b6L50-R50) [[8]](diffhunk://#diff-2320cbae936f93189ae525344f41840415fed3b3ba5a7c5089bedb03a885f142L79-R79)
* Improved in-line documentation and comments to clarify the meaning of `WAVE_MENU` and its indexing, making the codebase easier to understand for new contributors. [[1]](diffhunk://#diff-0501ba6a102e1a55290bf29a83547f7409610974939fdf4bf1bbe5cdcae18b63L59-R59) [[2]](diffhunk://#diff-d4b67096d4aa351e3c659c3ba39f83af15e3ebfe030c4653874eb89c41150b8dL48-R48) [[3]](diffhunk://#diff-27e4bc256479a5883c13d0204fbba4f3ded17750f896f1db977b6e30c55fc624L81-R81) [[4]](diffhunk://#diff-8d347b78d128f759a155bdf3d1bfc321a1be87a86e81238b9c78ad87d0453146L61-R61) [[5]](diffhunk://#diff-2fc558bb61182368b380afda0112fc26f510c7adf96f4feb311160fc1ceb98e3L50-R50) [[6]](diffhunk://#diff-88d6895b03e2444c1b16f266cd4229454f78fba8c40acf2d8c3664abd90887b6L50-R50) [[7]](diffhunk://#diff-2320cbae936f93189ae525344f41840415fed3b3ba5a7c5089bedb03a885f142L79-R79)

**Minor metadata and style changes:**

* Updated experiment metadata for clarity, such as renaming `"X_NAME"` in attraction and repulsion experiments for better readability. [[1]](diffhunk://#diff-2fc558bb61182368b380afda0112fc26f510c7adf96f4feb311160fc1ceb98e3L14-R14) [[2]](diffhunk://#diff-88d6895b03e2444c1b16f266cd4229454f78fba8c40acf2d8c3664abd90887b6L14-R14)
* Minor style cleanups in colormap palette definitions by removing trailing comments and improving section separation. [[1]](diffhunk://#diff-5cc38f2f8bf917405b5db168f98093b93bf60b53b0ebc21bcd1e8204a5680f7bL82-R82) [[2]](diffhunk://#diff-5cc38f2f8bf917405b5db168f98093b93bf60b53b0ebc21bcd1e8204a5680f7bL93-R93) [[3]](diffhunk://#diff-5cc38f2f8bf917405b5db168f98093b93bf60b53b0ebc21bcd1e8204a5680f7bL104-R104) [[4]](diffhunk://#diff-5cc38f2f8bf917405b5db168f98093b93bf60b53b0ebc21bcd1e8204a5680f7bL115-R115) [[5]](diffhunk://#diff-5cc38f2f8bf917405b5db168f98093b93bf60b53b0ebc21bcd1e8204a5680f7bL126-R126) [[6]](diffhunk://#diff-5cc38f2f8bf917405b5db168f98093b93bf60b53b0ebc21bcd1e8204a5680f7bL137-R137)