### PR TITLE
Rename color gradients to greenyellow and bluered

### DIFF
--- a/openwave/common/colormap.py
+++ b/openwave/common/colormap.py
@@ -71,25 +71,25 @@ FOREST = {
 # Performance-critical code > DRY principle in this case.
 
 # ================================================================
-# Yellowgreen Gradient: PALETTE [used in get_yellowgreen_color()]
+# Greenyellow Gradient: PALETTE [used in get_greenyellow_color()]
 # ================================================================
-yellowgreen_palette = [
-    ["#FFFF00", (1.0, 1.0, 0.0)],  # yellow
-    ["#C79B17", (0.78, 0.61, 0.09)],  # dark yellow
-    ["#000000", (0.0, 0.0, 0.0)],  # black
-    ["#1E7A1E", (0.118, 0.478, 0.118)],  # dark green
+greenyellow_palette = [
     ["#35B779", (0.208, 0.718, 0.475)],  # green
+    ["#1E7A1E", (0.118, 0.478, 0.118)],  # dark green
+    ["#000000", (0.0, 0.0, 0.0)],  # black
+    ["#C79B17", (0.78, 0.61, 0.09)],  # dark yellow
+    ["#FFFF00", (1.0, 1.0, 0.0)],  # yellow
 ]
 
 # ================================================================
-# Redblue Gradient: PALETTE [used in get_redblue_color()]
+# Bluered Gradient: PALETTE [used in get_bluered_color()]
 # ================================================================
-redblue_palette = [
-    ["#FF6347", (1.0, 0.388, 0.278)],  # red-orange
-    ["#8B0000", (0.545, 0.0, 0.0)],  # dark red
-    ["#000000", (0.0, 0.0, 0.0)],  # black
-    ["#00008B", (0.0, 0.0, 0.545)],  # dark blue
+bluered_palette = [
     ["#4169E1", (0.255, 0.412, 0.882)],  # bright blue
+    ["#00008B", (0.0, 0.0, 0.545)],  # dark blue
+    ["#000000", (0.0, 0.0, 0.0)],  # black
+    ["#8B0000", (0.545, 0.0, 0.0)],  # dark red
+    ["#FF6347", (1.0, 0.388, 0.278)],  # red-orange
 ]
 
 # ================================================================
@@ -138,24 +138,24 @@ blueprint_palette = [
 
 
 # ================================================================
-# Yellowgreen Gradient: FUNCTION
+# Greenyellow Gradient: FUNCTION
 # ================================================================
 
 # Taichi-compatible constants for use inside @ti.func
 # Extracts RGB tuples from palette for use in both Python and Taichi scopes
-yellowgreen = [color[1] for color in yellowgreen_palette]
-YELLOWGREEN_0 = ti.Vector([yellowgreen[0][0], yellowgreen[0][1], yellowgreen[0][2]])
-YELLOWGREEN_1 = ti.Vector([yellowgreen[1][0], yellowgreen[1][1], yellowgreen[1][2]])
-YELLOWGREEN_2 = ti.Vector([yellowgreen[2][0], yellowgreen[2][1], yellowgreen[2][2]])
-YELLOWGREEN_3 = ti.Vector([yellowgreen[3][0], yellowgreen[3][1], yellowgreen[3][2]])
-YELLOWGREEN_4 = ti.Vector([yellowgreen[4][0], yellowgreen[4][1], yellowgreen[4][2]])
+greenyellow = [color[1] for color in greenyellow_palette]
+GREENYELLOW_0 = ti.Vector([greenyellow[0][0], greenyellow[0][1], greenyellow[0][2]])
+GREENYELLOW_1 = ti.Vector([greenyellow[1][0], greenyellow[1][1], greenyellow[1][2]])
+GREENYELLOW_2 = ti.Vector([greenyellow[2][0], greenyellow[2][1], greenyellow[2][2]])
+GREENYELLOW_3 = ti.Vector([greenyellow[3][0], greenyellow[3][1], greenyellow[3][2]])
+GREENYELLOW_4 = ti.Vector([greenyellow[4][0], greenyellow[4][1], greenyellow[4][2]])
 
 
 @ti.func
-def get_yellowgreen_color(value, min_value, max_value):
-    """Maps a signed numerical value to a YELLOWGREEN gradient color.
+def get_greenyellow_color(value, min_value, max_value):
+    """Maps a signed numerical value to a GREENYELLOW gradient color.
 
-    YELLOWGREEN gradient: yellow → dark yellow → black → dark green → green
+    GREENYELLOW gradient: yellow → dark yellow → black → dark green → green
     Used for displacement visualization where negative = yellow, zero = black, positive = green.
 
     Optimized for maximum performance with millions of voxels.
@@ -170,7 +170,7 @@ def get_yellowgreen_color(value, min_value, max_value):
         ti.Vector([r, g, b]): RGB color in range [0.0, 1.0] for each component
 
     Example:
-        color = get_yellowgreen_color(value=50, min_value=0, max_value=100)
+        color = get_greenyellow_color(value=50, min_value=0, max_value=100)
         # Returns green-ish color since 50/100 = 0.5 is in the positive range
     """
 
@@ -185,48 +185,48 @@ def get_yellowgreen_color(value, min_value, max_value):
 
     if norm_color < 0.25:
         blend = norm_color / 0.25
-        r = YELLOWGREEN_0[0] * (1.0 - blend) + YELLOWGREEN_1[0] * blend
-        g = YELLOWGREEN_0[1] * (1.0 - blend) + YELLOWGREEN_1[1] * blend
-        b = YELLOWGREEN_0[2] * (1.0 - blend) + YELLOWGREEN_1[2] * blend
+        r = GREENYELLOW_0[0] * (1.0 - blend) + GREENYELLOW_1[0] * blend
+        g = GREENYELLOW_0[1] * (1.0 - blend) + GREENYELLOW_1[1] * blend
+        b = GREENYELLOW_0[2] * (1.0 - blend) + GREENYELLOW_1[2] * blend
     elif norm_color < 0.5:
         blend = (norm_color - 0.25) / 0.25
-        r = YELLOWGREEN_1[0] * (1.0 - blend) + YELLOWGREEN_2[0] * blend
-        g = YELLOWGREEN_1[1] * (1.0 - blend) + YELLOWGREEN_2[1] * blend
-        b = YELLOWGREEN_1[2] * (1.0 - blend) + YELLOWGREEN_2[2] * blend
+        r = GREENYELLOW_1[0] * (1.0 - blend) + GREENYELLOW_2[0] * blend
+        g = GREENYELLOW_1[1] * (1.0 - blend) + GREENYELLOW_2[1] * blend
+        b = GREENYELLOW_1[2] * (1.0 - blend) + GREENYELLOW_2[2] * blend
     elif norm_color < 0.75:
         blend = (norm_color - 0.5) / 0.25
-        r = YELLOWGREEN_2[0] * (1.0 - blend) + YELLOWGREEN_3[0] * blend
-        g = YELLOWGREEN_2[1] * (1.0 - blend) + YELLOWGREEN_3[1] * blend
-        b = YELLOWGREEN_2[2] * (1.0 - blend) + YELLOWGREEN_3[2] * blend
+        r = GREENYELLOW_2[0] * (1.0 - blend) + GREENYELLOW_3[0] * blend
+        g = GREENYELLOW_2[1] * (1.0 - blend) + GREENYELLOW_3[1] * blend
+        b = GREENYELLOW_2[2] * (1.0 - blend) + GREENYELLOW_3[2] * blend
     else:
         blend = (norm_color - 0.75) / 0.25
-        r = YELLOWGREEN_3[0] * (1.0 - blend) + YELLOWGREEN_4[0] * blend
-        g = YELLOWGREEN_3[1] * (1.0 - blend) + YELLOWGREEN_4[1] * blend
-        b = YELLOWGREEN_3[2] * (1.0 - blend) + YELLOWGREEN_4[2] * blend
+        r = GREENYELLOW_3[0] * (1.0 - blend) + GREENYELLOW_4[0] * blend
+        g = GREENYELLOW_3[1] * (1.0 - blend) + GREENYELLOW_4[1] * blend
+        b = GREENYELLOW_3[2] * (1.0 - blend) + GREENYELLOW_4[2] * blend
 
-    yellowgreen_color = ti.Vector([r, g, b])
-    return yellowgreen_color
+    greenyellow_color = ti.Vector([r, g, b])
+    return greenyellow_color
 
 
 # ================================================================
-# Redblue Gradient: FUNCTION
+# Bluered Gradient: FUNCTION
 # ================================================================
 
 # Taichi-compatible constants for use inside @ti.func
 # Extracts RGB tuples from palette for use in both Python and Taichi scopes
-redblue = [color[1] for color in redblue_palette]
-REDBLUE_0 = ti.Vector([redblue[0][0], redblue[0][1], redblue[0][2]])
-REDBLUE_1 = ti.Vector([redblue[1][0], redblue[1][1], redblue[1][2]])
-REDBLUE_2 = ti.Vector([redblue[2][0], redblue[2][1], redblue[2][2]])
-REDBLUE_3 = ti.Vector([redblue[3][0], redblue[3][1], redblue[3][2]])
-REDBLUE_4 = ti.Vector([redblue[4][0], redblue[4][1], redblue[4][2]])
+bluered = [color[1] for color in bluered_palette]
+BLUERED_0 = ti.Vector([bluered[0][0], bluered[0][1], bluered[0][2]])
+BLUERED_1 = ti.Vector([bluered[1][0], bluered[1][1], bluered[1][2]])
+BLUERED_2 = ti.Vector([bluered[2][0], bluered[2][1], bluered[2][2]])
+BLUERED_3 = ti.Vector([bluered[3][0], bluered[3][1], bluered[3][2]])
+BLUERED_4 = ti.Vector([bluered[4][0], bluered[4][1], bluered[4][2]])
 
 
 @ti.func
-def get_redblue_color(value, min_value, max_value):
-    """Maps a signed numerical value to a REDBLUE gradient color.
+def get_bluered_color(value, min_value, max_value):
+    """Maps a signed numerical value to a BLUERED gradient color.
 
-    REDBLUE gradient: red-orange → dark red → gray → dark blue → bright blue
+    BLUERED gradient: red-orange → dark red → gray → dark blue → bright blue
     Used for displacement visualization where negative = red, zero = gray, positive = blue.
 
     Optimized for maximum performance with millions of voxels.
@@ -241,7 +241,7 @@ def get_redblue_color(value, min_value, max_value):
         ti.Vector([r, g, b]): RGB color in range [0.0, 1.0] for each component
 
     Example:
-        color = get_redblue_color(value=-50, min_value=-100, max_value=100)
+        color = get_bluered_color(value=-50, min_value=-100, max_value=100)
         # Returns red-ish color since -50 is in the negative range
     """
 
@@ -256,28 +256,28 @@ def get_redblue_color(value, min_value, max_value):
 
     if norm_color < 0.25:
         blend = norm_color / 0.25
-        r = REDBLUE_0[0] * (1.0 - blend) + REDBLUE_1[0] * blend
-        g = REDBLUE_0[1] * (1.0 - blend) + REDBLUE_1[1] * blend
-        b = REDBLUE_0[2] * (1.0 - blend) + REDBLUE_1[2] * blend
+        r = BLUERED_0[0] * (1.0 - blend) + BLUERED_1[0] * blend
+        g = BLUERED_0[1] * (1.0 - blend) + BLUERED_1[1] * blend
+        b = BLUERED_0[2] * (1.0 - blend) + BLUERED_1[2] * blend
     elif norm_color < 0.5:
         blend = (norm_color - 0.25) / 0.25
-        r = REDBLUE_1[0] * (1.0 - blend) + REDBLUE_2[0] * blend
-        g = REDBLUE_1[1] * (1.0 - blend) + REDBLUE_2[1] * blend
-        b = REDBLUE_1[2] * (1.0 - blend) + REDBLUE_2[2] * blend
+        r = BLUERED_1[0] * (1.0 - blend) + BLUERED_2[0] * blend
+        g = BLUERED_1[1] * (1.0 - blend) + BLUERED_2[1] * blend
+        b = BLUERED_1[2] * (1.0 - blend) + BLUERED_2[2] * blend
     elif norm_color < 0.75:
         blend = (norm_color - 0.5) / 0.25
-        r = REDBLUE_2[0] * (1.0 - blend) + REDBLUE_3[0] * blend
-        g = REDBLUE_2[1] * (1.0 - blend) + REDBLUE_3[1] * blend
-        b = REDBLUE_2[2] * (1.0 - blend) + REDBLUE_3[2] * blend
+        r = BLUERED_2[0] * (1.0 - blend) + BLUERED_3[0] * blend
+        g = BLUERED_2[1] * (1.0 - blend) + BLUERED_3[1] * blend
+        b = BLUERED_2[2] * (1.0 - blend) + BLUERED_3[2] * blend
     else:
         blend = (norm_color - 0.75) / 0.25
-        r = REDBLUE_3[0] * (1.0 - blend) + REDBLUE_4[0] * blend
-        g = REDBLUE_3[1] * (1.0 - blend) + REDBLUE_4[1] * blend
-        b = REDBLUE_3[2] * (1.0 - blend) + REDBLUE_4[2] * blend
+        r = BLUERED_3[0] * (1.0 - blend) + BLUERED_4[0] * blend
+        g = BLUERED_3[1] * (1.0 - blend) + BLUERED_4[1] * blend
+        b = BLUERED_3[2] * (1.0 - blend) + BLUERED_4[2] * blend
 
-    redblue_color = ti.Vector([r, g, b])
+    bluered_color = ti.Vector([r, g, b])
 
-    return redblue_color
+    return bluered_color
 
 
 # ================================================================
@@ -580,7 +580,7 @@ def get_palette_scale(color_palette, x, y, width, height):
     """Generate palette scale indicator with geometry and colors as horizontal gradient.
 
     Generic function for creating palette display. Works with any color palette
-    (ironbow, blueprint, redblue, viridis, etc.).
+    (ironbow, blueprint, bluered, viridis, etc.).
 
     Creates a horizontal color bar with gradient transitions between colors.
     Each color band is made of 2 triangles forming a rectangle.

--- a/openwave/xperiments/b_laplace_propagation/_launcher.py
+++ b/openwave/xperiments/b_laplace_propagation/_launcher.py
@@ -295,14 +295,14 @@ def display_wave_menu(state):
         if sub.checkbox("Frequency (L&T)", state.WAVE_MENU == 5):
             state.WAVE_MENU = 5
         # Display gradient palette with 2× average range for headroom (allows peak visualization)
-        if state.WAVE_MENU == 1:  # Display yellowgreen gradient palette
-            render.canvas.triangles(yg_palette_vertices, per_vertex_color=yg_palette_colors)
+        if state.WAVE_MENU == 1:  # Display greenyellow gradient palette
+            render.canvas.triangles(gy_palette_vertices, per_vertex_color=gy_palette_colors)
             with render.gui.sub_window("displacement", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(
                     f"{-state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}m"
                 )
-        if state.WAVE_MENU == 2:  # Display redblue gradient palette
-            render.canvas.triangles(rb_palette_vertices, per_vertex_color=rb_palette_colors)
+        if state.WAVE_MENU == 2:  # Display bluered gradient palette
+            render.canvas.triangles(br_palette_vertices, per_vertex_color=br_palette_colors)
             with render.gui.sub_window("displacement", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(
                     f"{-state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}m"
@@ -414,19 +414,19 @@ def initialize_xperiment(state):
     Args:
         state: SimulationState instance with xperiment parameters
     """
-    global yg_palette_vertices, yg_palette_colors
-    global rb_palette_vertices, rb_palette_colors
+    global gy_palette_vertices, gy_palette_colors
+    global br_palette_vertices, br_palette_colors
     global vr_palette_vertices, vr_palette_colors
     global ib_palette_vertices, ib_palette_colors
     global bp_palette_vertices, bp_palette_colors
     global level_bar_vertices
 
     # Initialize color palette scales for gradient rendering and level indicator
-    yg_palette_vertices, yg_palette_colors = colormap.get_palette_scale(
-        colormap.yellowgreen, 0.00, 0.63, 0.079, 0.01
+    gy_palette_vertices, gy_palette_colors = colormap.get_palette_scale(
+        colormap.greenyellow, 0.00, 0.63, 0.079, 0.01
     )
-    rb_palette_vertices, rb_palette_colors = colormap.get_palette_scale(
-        colormap.redblue, 0.00, 0.63, 0.079, 0.01
+    br_palette_vertices, br_palette_colors = colormap.get_palette_scale(
+        colormap.bluered, 0.00, 0.63, 0.079, 0.01
     )
     vr_palette_vertices, vr_palette_colors = colormap.get_palette_scale(
         colormap.viridis, 0.00, 0.63, 0.079, 0.01

--- a/openwave/xperiments/b_laplace_propagation/research/11_flux_mesh.md
+++ b/openwave/xperiments/b_laplace_propagation/research/11_flux_mesh.md
@@ -19,7 +19,7 @@
    - [Supported Properties](#supported-properties)
 1. [Color Palettes](#color-palettes)
    - [Amplitude Visualization (Ironbow)](#amplitude-visualization-ironbow)
-   - [Displacement Visualization (Redblue)](#displacement-visualization-redblue)
+   - [Displacement Visualization (Bluered)](#displacement-visualization-bluered)
    - [Blueprint Palette](#blueprint-palette)
 1. [User Interface Controls](#user-interface-controls)
    - [Toggle Controls](#toggle-controls)
@@ -62,7 +62,7 @@
 - 🔄 **In Progress**: Core mesh rendering and wave property visualization
   - Mesh generation functions (to be implemented)
   - Property sampling kernels (to be implemented)
-  - Color gradient mapping (redblue gradient needed)
+  - Color gradient mapping (bluered gradient needed)
   - Integration with render loop (to be wired up)
 
 ## Concept and Terminology
@@ -314,7 +314,7 @@ def property_to_color(value: ti.f32,
         value: Property value to visualize
         min_val: Minimum expected value
         max_val: Maximum expected value
-        gradient_type: 0=ironbow, 1=redblue, 2=blueprint
+        gradient_type: 0=ironbow, 1=bluered, 2=blueprint
 
     Returns:
         RGB color vector [0,1]³
@@ -327,8 +327,8 @@ def property_to_color(value: ti.f32,
 
     if gradient_type == 0:  # Ironbow
         color = ironbow_gradient(norm_value)
-    elif gradient_type == 1:  # Redblue
-        color = redblue_gradient(norm_value)
+    elif gradient_type == 1:  # Bluered
+        color = bluered_gradient(norm_value)
     elif gradient_type == 2:  # Blueprint
         color = blueprint_gradient(norm_value)
 
@@ -341,7 +341,7 @@ def property_to_color(value: ti.f32,
 
 1. **Displacement** (primary)
    - Signed value (positive/negative)
-   - Use redblue gradient (red=positive, blue=negative)
+   - Use bluered gradient (red=positive, blue=negative)
    - Shows wave fronts and interference
 
 2. **Amplitude** (primary)
@@ -397,7 +397,7 @@ ironbow = [
 - **Orange/Yellow**: High amplitude
 - **White**: Maximum amplitude (saturation)
 
-### Displacement Visualization (Redblue)
+### Displacement Visualization (Bluered)
 
 **Use Case**: Visualizing signed properties (displacement, velocity)
 
@@ -406,10 +406,10 @@ ironbow = [
 **New Gradient Definition** (to be added to `config.py`):
 
 ```python
-# Redblue Doppler-Inspired Palette
+# Bluered Doppler-Inspired Palette
 # ================================================================
 # 5-color gradient for signed wave displacement
-redblue = [
+bluered = [
     ["#8B0000", (0.545, 0.0, 0.0)],     # dark red (maximum negative)
     ["#FF6347", (1.0, 0.39, 0.28)],     # red-orange (negative)
     ["#1C1C1C", (0.11, 0.11, 0.11)],    # dark gray (zero)
@@ -418,11 +418,11 @@ redblue = [
 ]
 
 @ti.func
-def get_redblue_color(value, min_value, max_value, saturation=1.0):
-    """Maps signed value to redblue gradient (red-blue).
+def get_bluered_color(value, min_value, max_value, saturation=1.0):
+    """Maps signed value to bluered gradient (red-blue).
 
     Gradient: dark red → red → gray → blue → dark blue
-    Red = negative displacement (redblue)
+    Red = negative displacement (bluered)
     Blue = positive displacement (blueshift)
     Gray = zero displacement
 
@@ -473,7 +473,7 @@ def get_redblue_color(value, min_value, max_value, saturation=1.0):
 
 **Physical Interpretation**:
 
-- **Red**: Wave compressed (moving away, redblue)
+- **Red**: Wave compressed (moving away, bluered)
 - **Blue**: Wave expanded (moving toward, blueshift)
 - **Gray**: Equilibrium position (no displacement)
 
@@ -546,7 +546,7 @@ state.show_film_yz = True   # YZ plane at x=0.5
 state.property_mode = 0  # 0=displacement, 1=amplitude, 2=energy
 
 # Color gradient selection (future)
-state.gradient_mode = 0  # 0=ironbow, 1=redblue, 2=blueprint
+state.gradient_mode = 0  # 0=ironbow, 1=bluered, 2=blueprint
 ```
 
 ### Camera Interaction
@@ -720,7 +720,7 @@ for wall in wall_films:
   - Default: `flux_mesh = False`
 
 - ⏳ **Remaining Tasks**:
-  1. Implement `get_redblue_color()` function in `config.py`
+  1. Implement `get_bluered_color()` function in `config.py`
   2. Create flux mesh generation functions in `config.py`
   3. Implement property sampling and color mapping kernels
   4. Wire up `state.flux_mesh` toggle to mesh rendering
@@ -749,7 +749,7 @@ All flux mesh functionality will be implemented in existing modules (no new file
 openwave/
 └── common/
     └── config.py  (ADD flux mesh functions)
-        ├── get_redblue_color()         # NEW: Redblue gradient for signed values
+        ├── get_bluered_color()         # NEW: Bluered gradient for signed values
         ├── create_flux_mesh()          # NEW: Initialize 3 flux meshes
         ├── update_flux_mesh_values()    # NEW: Sample wave properties and apply colors
         └── render_flux_mesh()          # NEW: Render meshes to scene

--- a/openwave/xperiments/b_laplace_propagation/research/13_wave_center.md
+++ b/openwave/xperiments/b_laplace_propagation/research/13_wave_center.md
@@ -50,7 +50,7 @@ Where:
 
 **Approach**: Invert displacement at single voxel after propagation
 
-**Result**: Red-to-blue hue under redblue color, tiny black sphere (1 voxel radius).
+**Result**: Red-to-blue hue under bluered color, tiny black sphere (1 voxel radius).
 
 **Issue**: Same size problem. Also, inverting after propagation creates discontinuities.
 

--- a/openwave/xperiments/b_laplace_propagation/spacetime_ewave.py
+++ b/openwave/xperiments/b_laplace_propagation/spacetime_ewave.py
@@ -1666,8 +1666,8 @@ def update_flux_mesh_values(
                 ampL_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
-        elif wave_menu == 2:  # redblue
-            wave_field.fluxmesh_xy_colors[i, j] = colormap.get_redblue_color(
+        elif wave_menu == 2:  # bluered
+            wave_field.fluxmesh_xy_colors[i, j] = colormap.get_bluered_color(
                 psiT_value,
                 -trackers.ampT_global_rms_am[None] * 2,
                 trackers.ampT_global_rms_am[None] * 2,
@@ -1676,8 +1676,8 @@ def update_flux_mesh_values(
                 psiT_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
-        else:  # default to yellowgreen (wave_menu == 1)
-            wave_field.fluxmesh_xy_colors[i, j] = colormap.get_yellowgreen_color(
+        else:  # default to greenyellow (wave_menu == 1)
+            wave_field.fluxmesh_xy_colors[i, j] = colormap.get_greenyellow_color(
                 psiL_value,
                 -trackers.ampL_global_rms_am[None] * 2,
                 trackers.ampL_global_rms_am[None] * 2,
@@ -1726,8 +1726,8 @@ def update_flux_mesh_values(
                 ampL_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
-        elif wave_menu == 2:  # redblue
-            wave_field.fluxmesh_xz_colors[i, k] = colormap.get_redblue_color(
+        elif wave_menu == 2:  # bluered
+            wave_field.fluxmesh_xz_colors[i, k] = colormap.get_bluered_color(
                 psiT_value,
                 -trackers.ampT_global_rms_am[None] * 2,
                 trackers.ampT_global_rms_am[None] * 2,
@@ -1736,8 +1736,8 @@ def update_flux_mesh_values(
                 psiT_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
-        else:  # default to yellowgreen (wave_menu == 1)
-            wave_field.fluxmesh_xz_colors[i, k] = colormap.get_yellowgreen_color(
+        else:  # default to greenyellow (wave_menu == 1)
+            wave_field.fluxmesh_xz_colors[i, k] = colormap.get_greenyellow_color(
                 psiL_value,
                 -trackers.ampL_global_rms_am[None] * 2,
                 trackers.ampL_global_rms_am[None] * 2,
@@ -1786,8 +1786,8 @@ def update_flux_mesh_values(
                 ampL_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )
-        elif wave_menu == 2:  # redblue
-            wave_field.fluxmesh_yz_colors[j, k] = colormap.get_redblue_color(
+        elif wave_menu == 2:  # bluered
+            wave_field.fluxmesh_yz_colors[j, k] = colormap.get_bluered_color(
                 psiT_value,
                 -trackers.ampT_global_rms_am[None] * 2,
                 trackers.ampT_global_rms_am[None] * 2,
@@ -1796,8 +1796,8 @@ def update_flux_mesh_values(
                 psiT_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )
-        else:  # default to yellowgreen (wave_menu == 1)
-            wave_field.fluxmesh_yz_colors[j, k] = colormap.get_yellowgreen_color(
+        else:  # default to greenyellow (wave_menu == 1)
+            wave_field.fluxmesh_yz_colors[j, k] = colormap.get_greenyellow_color(
                 psiL_value,
                 -trackers.ampL_global_rms_am[None] * 2,
                 trackers.ampL_global_rms_am[None] * 2,

--- a/openwave/xperiments/c_wolff_lafreniere/_launcher.py
+++ b/openwave/xperiments/c_wolff_lafreniere/_launcher.py
@@ -307,14 +307,14 @@ def display_wave_menu(state):
         if sub.checkbox("Frequency (L&T)", state.WAVE_MENU == 5):
             state.WAVE_MENU = 5
         # Display gradient palette with 2× average range for headroom (allows peak visualization)
-        if state.WAVE_MENU == 1:  # Display yellowgreen gradient palette
-            render.canvas.triangles(yg_palette_vertices, per_vertex_color=yg_palette_colors)
+        if state.WAVE_MENU == 1:  # Display greenyellow gradient palette
+            render.canvas.triangles(gy_palette_vertices, per_vertex_color=gy_palette_colors)
             with render.gui.sub_window("displacement", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(
                     f"{-state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}m"
                 )
-        if state.WAVE_MENU == 2:  # Display redblue gradient palette
-            render.canvas.triangles(rb_palette_vertices, per_vertex_color=rb_palette_colors)
+        if state.WAVE_MENU == 2:  # Display bluered gradient palette
+            render.canvas.triangles(br_palette_vertices, per_vertex_color=br_palette_colors)
             with render.gui.sub_window("displacement", 0.00, 0.64, 0.08, 0.06) as sub:
                 sub.text(
                     f"{-state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}m"
@@ -410,19 +410,19 @@ def initialize_xperiment(state):
     Args:
         state: SimulationState instance with xperiment parameters
     """
-    global yg_palette_vertices, yg_palette_colors
-    global rb_palette_vertices, rb_palette_colors
+    global gy_palette_vertices, gy_palette_colors
+    global br_palette_vertices, br_palette_colors
     global vr_palette_vertices, vr_palette_colors
     global ib_palette_vertices, ib_palette_colors
     global bp_palette_vertices, bp_palette_colors
     global level_bar_vertices
 
     # Initialize color palette scales for gradient rendering and level indicator
-    yg_palette_vertices, yg_palette_colors = colormap.get_palette_scale(
-        colormap.yellowgreen, 0.00, 0.63, 0.079, 0.01
+    gy_palette_vertices, gy_palette_colors = colormap.get_palette_scale(
+        colormap.greenyellow, 0.00, 0.63, 0.079, 0.01
     )
-    rb_palette_vertices, rb_palette_colors = colormap.get_palette_scale(
-        colormap.redblue, 0.00, 0.63, 0.079, 0.01
+    br_palette_vertices, br_palette_colors = colormap.get_palette_scale(
+        colormap.bluered, 0.00, 0.63, 0.079, 0.01
     )
     vr_palette_vertices, vr_palette_colors = colormap.get_palette_scale(
         colormap.viridis, 0.00, 0.63, 0.079, 0.01

--- a/openwave/xperiments/c_wolff_lafreniere/spacetime_ewave.py
+++ b/openwave/xperiments/c_wolff_lafreniere/spacetime_ewave.py
@@ -579,8 +579,8 @@ def update_flux_mesh_values(
                 ampL_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
-        elif wave_menu == 2:  # redblue
-            wave_field.fluxmesh_xy_colors[i, j] = colormap.get_redblue_color(
+        elif wave_menu == 2:  # bluered
+            wave_field.fluxmesh_xy_colors[i, j] = colormap.get_bluered_color(
                 psiT_value,
                 -trackers.ampT_global_rms_am[None] * 2,
                 trackers.ampT_global_rms_am[None] * 2,
@@ -589,8 +589,8 @@ def update_flux_mesh_values(
                 psiT_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
-        else:  # default to yellowgreen (wave_menu == 1)
-            wave_field.fluxmesh_xy_colors[i, j] = colormap.get_yellowgreen_color(
+        else:  # default to greenyellow (wave_menu == 1)
+            wave_field.fluxmesh_xy_colors[i, j] = colormap.get_greenyellow_color(
                 psiL_value,
                 -trackers.ampL_global_rms_am[None] * 2,
                 trackers.ampL_global_rms_am[None] * 2,
@@ -639,8 +639,8 @@ def update_flux_mesh_values(
                 ampL_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
-        elif wave_menu == 2:  # redblue
-            wave_field.fluxmesh_xz_colors[i, k] = colormap.get_redblue_color(
+        elif wave_menu == 2:  # bluered
+            wave_field.fluxmesh_xz_colors[i, k] = colormap.get_bluered_color(
                 psiT_value,
                 -trackers.ampT_global_rms_am[None] * 2,
                 trackers.ampT_global_rms_am[None] * 2,
@@ -649,8 +649,8 @@ def update_flux_mesh_values(
                 psiT_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
-        else:  # default to yellowgreen (wave_menu == 1)
-            wave_field.fluxmesh_xz_colors[i, k] = colormap.get_yellowgreen_color(
+        else:  # default to greenyellow (wave_menu == 1)
+            wave_field.fluxmesh_xz_colors[i, k] = colormap.get_greenyellow_color(
                 psiL_value,
                 -trackers.ampL_global_rms_am[None] * 2,
                 trackers.ampL_global_rms_am[None] * 2,
@@ -699,8 +699,8 @@ def update_flux_mesh_values(
                 ampL_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )
-        elif wave_menu == 2:  # redblue
-            wave_field.fluxmesh_yz_colors[j, k] = colormap.get_redblue_color(
+        elif wave_menu == 2:  # bluered
+            wave_field.fluxmesh_yz_colors[j, k] = colormap.get_bluered_color(
                 psiT_value,
                 -trackers.ampT_global_rms_am[None] * 2,
                 trackers.ampT_global_rms_am[None] * 2,
@@ -709,8 +709,8 @@ def update_flux_mesh_values(
                 psiT_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )
-        else:  # default to yellowgreen (wave_menu == 1)
-            wave_field.fluxmesh_yz_colors[j, k] = colormap.get_yellowgreen_color(
+        else:  # default to greenyellow (wave_menu == 1)
+            wave_field.fluxmesh_yz_colors[j, k] = colormap.get_greenyellow_color(
                 psiL_value,
                 -trackers.ampL_global_rms_am[None] * 2,
                 trackers.ampL_global_rms_am[None] * 2,


### PR DESCRIPTION
Renamed 'yellowgreen' gradient and related functions to 'greenyellow', and 'redblue' gradient and related functions to 'bluered' across code, documentation, and UI. Updated variable names, function calls, and comments for consistency and clarity in color palette usage.