### PR TITLE
Rename compute_wave_motion to compute_wave_oscillation

### DIFF
--- a/openwave/xperiments/m1_granule_motion/_launcher.py
+++ b/openwave/xperiments/m1_granule_motion/_launcher.py
@@ -364,7 +364,7 @@ def initialize_xperiment(state):
         instrument.print_initial_parameters()
 
 
-def compute_wave_motion(state):
+def compute_wave_oscillation(state):
     """Compute granule oscillations from wave superposition.
 
     Args:
@@ -498,7 +498,7 @@ def main():
             state.elapsed_t += current_time - state.last_time  # Real-time delta accumulation
             state.last_time = current_time
 
-            compute_wave_motion(state)
+            compute_wave_oscillation(state)
             state.frame += 1
         else:
             # Prevent time jump on resume

--- a/openwave/xperiments/m2_laplace_propagation/_launcher.py
+++ b/openwave/xperiments/m2_laplace_propagation/_launcher.py
@@ -457,7 +457,7 @@ def initialize_xperiment(state):
         instrument.plot_static_charge_profile(state.wave_field)
 
 
-def compute_wave_motion(state):
+def compute_wave_oscillation(state):
     """Compute wave propagation, reflection, superposition and update tracker averages.
     The static pulse creates a natural equilibrium via Dirichlet BC reflections.
     """
@@ -615,7 +615,7 @@ def main():
         if not state.PAUSED:
             # Run simulation step and update time
             state.compute_timestep()
-            compute_wave_motion(state)
+            compute_wave_oscillation(state)
             state.elapsed_t_rs += state.dt_rs  # Accumulate simulation time
             state.frame += 1
 

--- a/openwave/xperiments/m2_laplace_propagation/research/stable_waves.md
+++ b/openwave/xperiments/m2_laplace_propagation/research/stable_waves.md
@@ -425,7 +425,7 @@ The smooth envelope provides infinite hysteresis - charging amplitude is a conti
 ### Charging Control Flow
 
 ```python
-def compute_wave_motion(state):
+def compute_wave_oscillation(state):
     """Compute wave propagation with smooth charging and damping."""
 
     # Compute smooth charging envelope (0.0 to 1.0)

--- a/openwave/xperiments/m3_wolff_lafreniere/_launcher.py
+++ b/openwave/xperiments/m3_wolff_lafreniere/_launcher.py
@@ -388,7 +388,7 @@ def initialize_xperiment(state):
         print("=" * 64)
 
 
-def compute_wave_motion(state):
+def compute_wave_oscillation(state):
     """Compute wave propagation, reflection, superposition and update tracker averages."""
 
     ewave.propagate_wave(
@@ -568,7 +568,7 @@ def main():
 
         if not state.PAUSED:
             # Run simulation step and update time
-            compute_wave_motion(state)
+            compute_wave_oscillation(state)
             compute_force_motion(state)
             state.elapsed_t_rs += state.TIMESTEP  # Accumulate simulation time
             state.frame += 1


### PR DESCRIPTION
Refactored function name from compute_wave_motion to compute_wave_oscillation across multiple experiment launchers and documentation for clarity and consistency.