### PR TITLE
Add wave UI options, palettes, force debug, xparams

### DIFF
--- a/openwave/xperiments/m3_wolff_lafreniere/_launcher.py
+++ b/openwave/xperiments/m3_wolff_lafreniere/_launcher.py
@@ -239,7 +239,7 @@ def display_xperiment_launcher(xperiment_mgr, state):
     """
     selected_xperiment = None
 
-    with render.gui.sub_window("XPERIMENT LAUNCHER", 0.00, 0.00, 0.14, 0.32) as sub:
+    with render.gui.sub_window("XPERIMENT LAUNCHER", 0.00, 0.00, 0.14, 0.37) as sub:
         sub.text("(needs window reload)", color=colormap.LIGHT_BLUE[1])
         for xp_name in xperiment_mgr.available_xperiments:
             display_name = xperiment_mgr.get_xperiment_display_name(xp_name)
@@ -256,7 +256,7 @@ def display_xperiment_launcher(xperiment_mgr, state):
 
 def display_controls(state):
     """Display the controls UI overlay."""
-    with render.gui.sub_window("CONTROLS", 0.00, 0.33, 0.16, 0.27) as sub:
+    with render.gui.sub_window("CONTROLS", 0.00, 0.37, 0.16, 0.27) as sub:
         state.SHOW_AXIS = sub.checkbox(f"Axis (ticks: {state.TICK_SPACING})", state.SHOW_AXIS)
         state.SHOW_EDGES = sub.checkbox("Sim Universe Edges", state.SHOW_EDGES)
         state.SHOW_FLUX_MESH = sub.slider_int("Flux Mesh", state.SHOW_FLUX_MESH, 0, 3)
@@ -276,30 +276,44 @@ def display_controls(state):
 
 def display_wave_menu(state):
     """Display wave properties selection menu."""
-    with render.gui.sub_window("WAVE MENU", 0.00, 0.70, 0.15, 0.17) as sub:
+    with render.gui.sub_window("WAVE MENU", 0.00, 0.71, 0.15, 0.17) as sub:
         if sub.checkbox("Displacement (Longitudinal)", state.WAVE_MENU == 1):
             state.WAVE_MENU = 1
+        if sub.checkbox("Displacement (Transverse)", state.WAVE_MENU == 2):
+            state.WAVE_MENU = 2
         if sub.checkbox("Amplitude (Longitudinal)", state.WAVE_MENU == 3):
             state.WAVE_MENU = 3
         if sub.checkbox("Envelope (Longitudinal)", state.WAVE_MENU == 4):
             state.WAVE_MENU = 4
+        if sub.checkbox("Frequency (L&T)", state.WAVE_MENU == 5):
+            state.WAVE_MENU = 5
         # Display gradient palette with 2× average range for headroom (allows peak visualization)
         if state.WAVE_MENU == 1:  # Displacement (Longitudinal) on greenyellow gradient
             render.canvas.triangles(gy_palette_vertices, per_vertex_color=gy_palette_colors)
-            with render.gui.sub_window("displacement", 0.00, 0.64, 0.08, 0.06) as sub:
+            with render.gui.sub_window("displacement", 0.00, 0.65, 0.08, 0.06) as sub:
                 sub.text(
                     f"{-state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}m"
+                )
+        if state.WAVE_MENU == 2:  # Displacement (Transverse) on bluered gradient
+            render.canvas.triangles(br_palette_vertices, per_vertex_color=br_palette_colors)
+            with render.gui.sub_window("displacement", 0.00, 0.65, 0.08, 0.06) as sub:
+                sub.text(
+                    f"{-state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}m"
                 )
         if state.WAVE_MENU == 3:  # Amplitude (Longitudinal) on viridis gradient
             render.canvas.triangles(vr_palette_vertices, per_vertex_color=vr_palette_colors)
-            with render.gui.sub_window("amplitude", 0.00, 0.64, 0.08, 0.06) as sub:
+            with render.gui.sub_window("amplitude", 0.00, 0.65, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}m")
         if state.WAVE_MENU == 4:  # Envelope (Longitudinal) on greenyellow gradient
             render.canvas.triangles(gy_palette_vertices, per_vertex_color=gy_palette_colors)
-            with render.gui.sub_window("envelope", 0.00, 0.64, 0.08, 0.06) as sub:
+            with render.gui.sub_window("envelope", 0.00, 0.65, 0.08, 0.06) as sub:
                 sub.text(
                     f"{-state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}m"
                 )
+        if state.WAVE_MENU == 5:  # Frequency (L&T) on blueprint gradient
+            render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
+            with render.gui.sub_window("frequency", 0.00, 0.65, 0.08, 0.06) as sub:
+                sub.text(f"0       {state.freq_global_avg*2*state.wave_field.scale_factor:.0e}Hz")
 
 
 def display_level_specs(state, level_bar_vertices):
@@ -370,15 +384,27 @@ def initialize_xperiment(state):
         state: SimulationState instance with xperiment parameters
     """
     global gy_palette_vertices, gy_palette_colors
+    global br_palette_vertices, br_palette_colors
     global vr_palette_vertices, vr_palette_colors
+    global ib_palette_vertices, ib_palette_colors
+    global bp_palette_vertices, bp_palette_colors
     global level_bar_vertices
 
     # Initialize color palette scales for gradient rendering and level indicator
     gy_palette_vertices, gy_palette_colors = colormap.get_palette_scale(
-        colormap.greenyellow, 0.00, 0.63, 0.079, 0.01
+        colormap.greenyellow, 0.00, 0.64, 0.079, 0.01
+    )
+    br_palette_vertices, br_palette_colors = colormap.get_palette_scale(
+        colormap.bluered, 0.00, 0.64, 0.079, 0.01
     )
     vr_palette_vertices, vr_palette_colors = colormap.get_palette_scale(
-        colormap.viridis, 0.00, 0.63, 0.079, 0.01
+        colormap.viridis, 0.00, 0.64, 0.079, 0.01
+    )
+    ib_palette_vertices, ib_palette_colors = colormap.get_palette_scale(
+        colormap.ironbow, 0.00, 0.64, 0.079, 0.01
+    )
+    bp_palette_vertices, bp_palette_colors = colormap.get_palette_scale(
+        colormap.blueprint, 0.00, 0.64, 0.079, 0.01
     )
     level_bar_vertices = colormap.get_level_bar_geometry(0.84, 0.00, 0.159, 0.01)
 
@@ -437,6 +463,13 @@ def compute_force_motion(state):
         state.trackers,
         state.wave_center,
     )
+    # # DEBUG: Print force analysis every 100 frames
+    # force_motion.debug_force_analysis(
+    #     state.wave_field,
+    #     state.trackers,
+    #     state.wave_center,
+    #     state.frame,
+    # )
     if state.APPLY_MOTION:
         force_motion.integrate_motion_euler(
             state.wave_field,

--- a/openwave/xperiments/m3_wolff_lafreniere/force_motion.py
+++ b/openwave/xperiments/m3_wolff_lafreniere/force_motion.py
@@ -214,6 +214,11 @@ def compute_force_vector(
             A_zm_am = trackers.ampL_local_envelope_am[i, j, k - sample_radius]
             dA_dz = (A_zp_am - A_zm_am) / sample_dist_am
 
+            # DEBUG: Store intermediate values
+            wave_center.debug_A_center[wc_idx] = A_center_am * ATTOMETER
+            wave_center.debug_dA_dx[wc_idx] = dA_dx
+            wave_center.debug_force_scale[wc_idx] = force_scale_qgrs * 1e21  # qg/rs² to kg/s²
+
             # Force: F = -2 * rho * V * f^2 * A * grad(A), in N, converted from qg/rs² * am
             F_x = -force_scale_qgrs * A_center_am * dA_dx * 1000  # qg·am/rs² to N (kg·m/s²)
             F_y = -force_scale_qgrs * A_center_am * dA_dy * 1000  # qg·am/rs² to N (kg·m/s²)
@@ -276,6 +281,20 @@ def integrate_motion_euler(
         wave_center.velocity_amrs[wc_idx][0] += a_x_amrs * dt_rs
         wave_center.velocity_amrs[wc_idx][1] += a_y_amrs * dt_rs
         wave_center.velocity_amrs[wc_idx][2] += a_z_amrs * dt_rs
+
+        # # Clamp velocity to speed of light (c = 0.3 am/rs)
+        # # velocity clamp to prevent superluminal speeds
+        # c_amrs = ti.cast(0.3, ti.f32)
+        # v_mag = ti.sqrt(
+        #     wave_center.velocity_amrs[wc_idx][0] ** 2
+        #     + wave_center.velocity_amrs[wc_idx][1] ** 2
+        #     + wave_center.velocity_amrs[wc_idx][2] ** 2
+        # )
+        # if v_mag > c_amrs:
+        #     scale = c_amrs / v_mag
+        #     wave_center.velocity_amrs[wc_idx][0] *= scale
+        #     wave_center.velocity_amrs[wc_idx][1] *= scale
+        #     wave_center.velocity_amrs[wc_idx][2] *= scale
 
         # Position change in attometers
         dx_am_step = wave_center.velocity_amrs[wc_idx][0] * dt_rs
@@ -411,3 +430,228 @@ def detect_annihilation(
                 # Mark both WCs as inactive (annihilated)
                 wave_center.active[i] = 0
                 wave_center.active[j] = 0
+
+
+# ================================================================
+# DEBUG: Force Analysis
+# ================================================================
+
+
+def debug_force_analysis(wave_field, trackers, wave_center, frame: int = 0):
+    """
+    Debug function to analyze force calculation values.
+
+    Prints amplitude, gradient, and force values for each wave center.
+    Includes Coulomb force comparison for model calibration.
+    Call periodically (e.g., every 100 frames) to monitor force evolution.
+    """
+    if frame % 100 != 0:
+        return
+
+    print(f"\n{'='*60}")
+    print(f"FORCE ANALYSIS - Frame {frame}")
+    print(f"{'='*60}")
+
+    # ================================================================
+    # EWT FORCE COMPARISON (Primary validation)
+    # ================================================================
+    # EWT Electric Force: F_e = (4πρ K^7 A^6 c² Oe / 3λ²) × gλ × (1/r²)
+    #
+    # This is the CORRECT comparison for OpenWave validation:
+    # - Derived from wave physics (same as our simulation)
+    # - Uses K (wave center count) as parameter
+    # - For K=1: Oe=1.0, gλ=1.0 (no outer shell complexity)
+    # - For K=10 (electron): Oe=2.14, gλ=0.99
+    #
+    # If simulated force matches EWT force, OpenWave is validated!
+    # ================================================================
+    positions_grid = wave_center.position_grid.to_numpy()
+    dx = wave_field.dx  # voxel size in meters
+
+    if wave_center.num_sources == 2:
+        # Calculate separation distance in meters
+        pos0 = positions_grid[0] * dx
+        pos1 = positions_grid[1] * dx
+        separation = np.linalg.norm(pos1 - pos0)
+
+        if separation > 0:
+            # EWT force for K=1 (fundamental particle)
+            F_ewt_k1 = compute_ewt_electric_force(separation, K=1, Oe=1.0, glambda=1.0)
+
+            # EWT force for K=10 (electron) - should match Coulomb
+            F_ewt_k10 = compute_ewt_electric_force(
+                separation, K=10, Oe=ELECTRON_OUTER_SHELL, glambda=ELECTRON_ORBITAL_G
+            )
+
+            # Coulomb force for reference
+            F_coulomb = COULOMB_CONSTANT * ELEMENTARY_CHARGE**2 / separation**2
+
+            # Direction vector (from 0 to 1)
+            direction = (pos1 - pos0) / separation
+
+            print(f"\n{'─'*60}")
+            print("EWT FORCE PREDICTIONS (Target for validation)")
+            print(f"{'─'*60}")
+            print(f"  Separation: {separation:.3e} m ({separation/ATTOMETER:.3f} am)")
+            print(f"  F_ewt (K=1):  {F_ewt_k1:.3e} N  ← TARGET for simulation")
+            print(f"  F_ewt (K=10): {F_ewt_k10:.3e} N  (electron)")
+            print(f"  F_coulomb:    {F_coulomb:.3e} N  (reference)")
+            print(f"  EWT K=10 / Coulomb ratio: {F_ewt_k10/F_coulomb:.6f}")
+            print(
+                f"  Direction (WC0→WC1): [{direction[0]:.3f}, {direction[1]:.3f}, {direction[2]:.3f}]"
+            )
+            print(f"{'─'*60}")
+
+    # Get numpy arrays from taichi fields
+    # Using envelope field (smooth 1/r) for force calculation instead of RMS
+    envelope = trackers.ampL_local_envelope_am.to_numpy()
+    positions = wave_center.position_grid.to_numpy()
+    forces = wave_center.force.to_numpy()
+    velocities = wave_center.velocity_amrs.to_numpy()
+
+    dx = wave_field.dx
+    dx_am = wave_field.dx / ATTOMETER
+
+    print(f"Voxel size: {dx:.3e} m ({dx_am:.3f} am)")
+    # Compute force_scale same way as kernel (avoid overflow)
+    rhoV = MEDIUM_DENSITY * dx**3
+    force_scale = 2.0 * rhoV * EWAVE_FREQUENCY * EWAVE_FREQUENCY
+    # Scale factor correction
+    S = wave_field.scale_factor
+    S4 = S * S * S * S
+    force_scale_corrected = force_scale / S4
+
+    print(f"Force scale (raw): 2*rho*V*f² = {force_scale:.3e}")
+    print(f"  (rho*V = {rhoV:.3e}, f = {EWAVE_FREQUENCY:.3e})")
+    print(f"Scale factor: {S:.1f}x (S⁴ = {S4:.3e})")
+    print(f"Force scale (corrected): {force_scale_corrected:.3e}")
+
+    # Show module constants
+    sample_radius = GRADIENT_SAMPLE_RADIUS
+    print(f"Gradient sampling radius: {sample_radius} voxels (GRADIENT_SAMPLE_RADIUS)")
+
+    # Read kernel debug values
+    kernel_A_center = wave_center.debug_A_center.to_numpy()
+    kernel_dA_dx = wave_center.debug_dA_dx.to_numpy()
+    kernel_force_scale = wave_center.debug_force_scale.to_numpy()
+    masses = wave_center.mass_qg.to_numpy()
+
+    for wc_idx in range(wave_center.num_sources):
+        i, j, k = positions[wc_idx]
+        print(f"\n--- Wave Center {wc_idx} at grid [{i}, {j}, {k}] ---")
+        print(f"  KERNEL DEBUG VALUES:")
+        print(f"    A_center (kernel): {kernel_A_center[wc_idx]:.3e}")
+        print(f"    dA_dx (kernel): {kernel_dA_dx[wc_idx]:.3e}")
+        print(f"    force_scale (kernel): {kernel_force_scale[wc_idx]:.3e}")
+        if kernel_force_scale[wc_idx] != 0:
+            expected_Fx = (
+                -kernel_force_scale[wc_idx] * kernel_A_center[wc_idx] * kernel_dA_dx[wc_idx]
+            )
+            print(f"    Expected F_x: {expected_Fx:.3e}")
+
+        # Boundary check (sample_radius defined above from GRADIENT_SAMPLE_RADIUS)
+        if i <= sample_radius or i >= wave_field.nx - sample_radius:
+            print(f"  WARNING: Near x boundary!")
+            continue
+        if j <= sample_radius or j >= wave_field.ny - sample_radius:
+            print(f"  WARNING: Near y boundary!")
+            continue
+        if k <= sample_radius or k >= wave_field.nz - sample_radius:
+            print(f"  WARNING: Near z boundary!")
+            continue
+
+        # Envelope values at sampling radius distance (smooth 1/r field)
+        A_center = envelope[i, j, k] * ATTOMETER
+        A_xp = envelope[i + sample_radius, j, k] * ATTOMETER
+        A_xm = envelope[i - sample_radius, j, k] * ATTOMETER
+        A_yp = envelope[i, j + sample_radius, k] * ATTOMETER
+        A_ym = envelope[i, j - sample_radius, k] * ATTOMETER
+        A_zp = envelope[i, j, k + sample_radius] * ATTOMETER
+        A_zm = envelope[i, j, k - sample_radius] * ATTOMETER
+
+        print(f"  Envelope at center: {A_center:.3e} m ({envelope[i,j,k]:.3f} am)")
+        print(f"  Amplitude x±{sample_radius}: [{A_xm:.3e}, {A_xp:.3e}] m")
+
+        # Gradients with larger sampling distance
+        sample_dist = 2.0 * sample_radius * dx
+        dA_dx = (A_xp - A_xm) / sample_dist
+        dA_dy = (A_yp - A_ym) / sample_dist
+        dA_dz = (A_zp - A_zm) / sample_dist
+
+        print(f"  Gradient dA/dx: {dA_dx:.3e}")
+        print(f"  Gradient dA/dy: {dA_dy:.3e}")
+        print(f"  Gradient dA/dz: {dA_dz:.3e}")
+
+        # Force
+        F = forces[wc_idx]
+        print(f"  Force: [{F[0]:.3e}, {F[1]:.3e}, {F[2]:.3e}] N")
+
+        # Expected acceleration (using actual mass from wave_center in qg)
+        m_qg = masses[wc_idx]  # mass in quectograms
+        m_kg = m_qg * QUECTOGRAM  # convert to kg for display
+        # Acceleration using qg conversion: (F/m_qg) * 1e-3 -> am/rs²
+        a_amrs2 = (F[0] / m_qg) * 1e-3 if m_qg > 0 else 0
+        a_ms2 = F[0] / m_kg if m_kg > 0 else 0  # for display
+        print(f"  Mass: {m_qg:.3e} qg ({m_kg:.3e} kg)")
+        print(f"  Acceleration: {a_ms2:.3e} m/s² ({a_amrs2:.3e} am/rs²)")
+
+        # Velocity
+        v = velocities[wc_idx]
+        print(f"  Velocity: [{v[0]:.6e}, {v[1]:.6e}, {v[2]:.6e}] am/rs")
+
+    # ================================================================
+    # VALIDATION SUMMARY: Simulated vs EWT Prediction
+    # ================================================================
+    if wave_center.num_sources == 2:
+        pos0 = positions_grid[0] * dx
+        pos1 = positions_grid[1] * dx
+        separation = np.linalg.norm(pos1 - pos0)
+
+        if separation > 0:
+            # EWT predicted force for K=1
+            F_ewt_k1 = compute_ewt_electric_force(separation, K=1, Oe=1.0, glambda=1.0)
+
+            # Get simulated force magnitudes
+            forces = wave_center.force.to_numpy()
+            F_sim_0 = np.linalg.norm(forces[0])
+            F_sim_1 = np.linalg.norm(forces[1])
+            F_sim_avg = (F_sim_0 + F_sim_1) / 2
+
+            # Calculate ratio to EWT K=1 prediction (THIS IS THE KEY METRIC)
+            ratio_ewt = F_sim_avg / F_ewt_k1 if F_ewt_k1 > 0 else 0
+
+            # Also show Coulomb comparison for reference
+            F_coulomb = COULOMB_CONSTANT * ELEMENTARY_CHARGE**2 / separation**2
+            ratio_coulomb = F_sim_avg / F_coulomb if F_coulomb > 0 else 0
+
+            print(f"\n{'─'*60}")
+            print("VALIDATION: Simulated vs EWT Prediction")
+            print(f"{'─'*60}")
+            print(f"  EWT F (K=1 target):     {F_ewt_k1:.3e} N")
+            print(f"  Simulated F (WC0):      {F_sim_0:.3e} N")
+            print(f"  Simulated F (WC1):      {F_sim_1:.3e} N")
+            print(f"  Simulated F (average):  {F_sim_avg:.3e} N")
+            print(f"{'─'*60}")
+            print(f"  RATIO (sim/EWT K=1):    {ratio_ewt:.6f}")
+            if ratio_ewt > 0:
+                print(f"  Scale needed:           {1/ratio_ewt:.3e}x")
+            print(f"{'─'*60}")
+            if ratio_ewt > 0.9 and ratio_ewt < 1.1:
+                print("  ✓ VALIDATED: Within 10% of EWT prediction!")
+            elif ratio_ewt > 0.5 and ratio_ewt < 2.0:
+                print("  ~ CLOSE: Within 2x of EWT prediction")
+            else:
+                print("  ✗ Calibration needed")
+            print(f"{'─'*60}")
+            print(f"  (Coulomb ref: {F_coulomb:.3e} N, ratio: {ratio_coulomb:.3e})")
+            print(f"{'─'*60}")
+
+            # Direction check
+            direction = (pos1 - pos0) / separation
+            F0_dir = forces[0] / F_sim_0 if F_sim_0 > 0 else np.zeros(3)
+            dot_product = np.dot(F0_dir, direction)
+            force_type = "ATTRACTION" if dot_product > 0 else "REPULSION"
+            print(f"  Force direction: {force_type} (dot={dot_product:.3f})")
+            print(f"{'─'*60}")
+
+    print(f"{'='*60}\n")

--- a/openwave/xperiments/m3_wolff_lafreniere/particle.py
+++ b/openwave/xperiments/m3_wolff_lafreniere/particle.py
@@ -57,7 +57,7 @@ class WaveCenter:
         # Force in Newtons (SI) - kept in SI for physics accuracy
         self.force = ti.Vector.field(3, dtype=ti.f32, shape=num_sources)
 
-        # DEBUG: Intermediate values for force calculation inspection
+        # DEBUG: Intermediate values for force calculation inspection, to be stored per source
         self.debug_A_center = ti.field(dtype=ti.f32, shape=num_sources)
         self.debug_dA_dx = ti.field(dtype=ti.f32, shape=num_sources)
         self.debug_force_scale = ti.field(dtype=ti.f32, shape=num_sources)

--- a/openwave/xperiments/m3_wolff_lafreniere/spacetime_ewave.py
+++ b/openwave/xperiments/m3_wolff_lafreniere/spacetime_ewave.py
@@ -179,13 +179,13 @@ def propagate_wave(
             #     / ti.sqrt((k_grid * r_grid) ** 2 + 1)
             # )  # smoothed 1/r decay
 
-            # DAMPED SMOOTHED 1/r ==================================
-            trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-                base_amplitude_am
-                * wave_field.scale_factor
-                * k_grid
-                / ti.sqrt((k_grid * r_grid) ** 2 + (2 * ti.math.pi) ** 2)
-            )  # smoothed 1/r decay
+            # # DAMPED SMOOTHED 1/r ==================================
+            # trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
+            #     base_amplitude_am
+            #     * wave_field.scale_factor
+            #     * k_grid
+            #     / ti.sqrt((k_grid * r_grid) ** 2 + (2 * ti.math.pi) ** 2)
+            # )  # smoothed 1/r decay
 
             # # WOLFF-ORIGINAL ENVELOPE ==================================
             # if r_grid < 0.5:  # CENTER VOXEL only, avoids singularity
@@ -205,7 +205,7 @@ def propagate_wave(
             # else:
             #     if r_grid <= (2.5 * ti.math.pi / k_grid):  # NEAR-FIELD: time-dilated-1.25λ
             #         trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-            #             base_amplitude_amq
+            #             base_amplitude_am
             #             * wave_field.scale_factor
             #             * ti.sin(k_grid * r_grid)
             #             / r_grid
@@ -273,25 +273,25 @@ def propagate_wave(
             #             base_amplitude_am * wave_field.scale_factor * 1.0 / r_grid
             #         )  # smooth 1/r decay
 
-            # # DAMPED + WOLFF ==================================
-            # if r_grid < 0.5:  # CENTER VOXEL only, avoids singularity
-            #     trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-            #         base_amplitude_am * wave_field.scale_factor * (k_grid / (2 * ti.math.pi))
-            #     )  # finite value at center, k_grid / constant
-            # else:
-            #     if r_grid <= (2.5 * ti.math.pi / k_grid):  # NEAR-FIELD: time-dilated-1.25λ
-            #         trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-            #             base_amplitude_am
-            #             * wave_field.scale_factor
-            #             * (
-            #                 k_grid / ti.sqrt((k_grid * r_grid) ** 2 + (48))
-            #                 + ti.sin(k_grid * r_grid) / (r_grid * 4)
-            #             )
-            #         )  # smoothed 1/r decay
-            #     else:  # FAR-FIELD: smooth 1/r decay
-            #         trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-            #             base_amplitude_am * wave_field.scale_factor * 1.0 / r_grid
-            #         )  # smooth 1/r decay
+            # DAMPED + WOLFF ==================================
+            if r_grid < 0.5:  # CENTER VOXEL only, avoids singularity
+                trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
+                    base_amplitude_am * wave_field.scale_factor * (k_grid / (2 * ti.math.pi))
+                )  # finite value at center, k_grid / constant
+            else:
+                if r_grid <= (1.25 * 2 * ti.math.pi / k_grid):  # NEAR-FIELD: time-dilated-1.25λ
+                    trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
+                        base_amplitude_am
+                        * wave_field.scale_factor
+                        * (
+                            k_grid / ti.sqrt((k_grid * r_grid) ** 2 + (48))
+                            + ti.sin(k_grid * r_grid) / (r_grid * 4)
+                        )
+                    )  # smoothed 1/r decay
+                else:  # FAR-FIELD: smooth 1/r decay
+                    trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
+                        base_amplitude_am * wave_field.scale_factor * 1.0 / r_grid
+                    )  # smooth 1/r decay
 
             # # FLAT NEAR-FIELD ==================================
             # if r_grid < 0.5:  # CENTER VOXEL only, avoids singularity
@@ -542,13 +542,25 @@ def update_flux_mesh_values(
     for i, j in ti.ndrange(wave_field.nx, wave_field.ny):
         # Sample longitudinal displacement at this voxel
         psiL_value = wave_field.psiL_am[i, j, wave_field.fm_plane_z_idx]
+        psiT_value = wave_field.psiT_am[i, j, wave_field.fm_plane_z_idx]
         ampLr_value = trackers.ampL_local_rms_am[i, j, wave_field.fm_plane_z_idx]
         ampLe_value = trackers.ampL_local_envelope_am[i, j, wave_field.fm_plane_z_idx]
+        ampT_value = trackers.ampT_local_rms_am[i, j, wave_field.fm_plane_z_idx]
+        freq_value = trackers.freq_local_cross_rHz[i, j, wave_field.fm_plane_z_idx]
         univ_edge_z = wave_field.universe_size_am[2]
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if wave_menu == 4:  # greenyellow
+        if wave_menu == 5:  # blueprint
+            wave_field.fluxmesh_xy_colors[i, j] = colormap.get_blueprint_color(
+                freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
+            )
+            wave_field.fluxmesh_xy_vertices[i, j][2] = freq_value / trackers.freq_global_avg_rHz[
+                None
+            ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[2] * (
+                wave_field.nz / wave_field.max_grid_size
+            )
+        elif wave_menu == 4:  # greenyellow
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_greenyellow_color(
                 ampLe_value,
                 -trackers.ampL_global_rms_am[None] * 2,
@@ -564,6 +576,16 @@ def update_flux_mesh_values(
             )
             wave_field.fluxmesh_xy_vertices[i, j][2] = (
                 ampLr_value / univ_edge_z * warp_mesh
+                + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
+            )
+        elif wave_menu == 2:  # bluered
+            wave_field.fluxmesh_xy_colors[i, j] = colormap.get_bluered_color(
+                psiT_value,
+                -trackers.ampT_global_rms_am[None] * 2,
+                trackers.ampT_global_rms_am[None] * 2,
+            )
+            wave_field.fluxmesh_xy_vertices[i, j][2] = (
+                psiT_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
         else:  # default to greenyellow (wave_menu == 1)
@@ -583,13 +605,25 @@ def update_flux_mesh_values(
     for i, k in ti.ndrange(wave_field.nx, wave_field.nz):
         # Sample longitudinal displacement at this voxel
         psiL_value = wave_field.psiL_am[i, wave_field.fm_plane_y_idx, k]
+        psiT_value = wave_field.psiT_am[i, wave_field.fm_plane_y_idx, k]
         ampLr_value = trackers.ampL_local_rms_am[i, wave_field.fm_plane_y_idx, k]
         ampLe_value = trackers.ampL_local_envelope_am[i, wave_field.fm_plane_y_idx, k]
+        ampT_value = trackers.ampT_local_rms_am[i, wave_field.fm_plane_y_idx, k]
+        freq_value = trackers.freq_local_cross_rHz[i, wave_field.fm_plane_y_idx, k]
         univ_edge_y = wave_field.universe_size_am[1]
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if wave_menu == 4:  # greenyellow
+        if wave_menu == 5:  # blueprint
+            wave_field.fluxmesh_xz_colors[i, k] = colormap.get_blueprint_color(
+                freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
+            )
+            wave_field.fluxmesh_xz_vertices[i, k][1] = freq_value / trackers.freq_global_avg_rHz[
+                None
+            ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[1] * (
+                wave_field.ny / wave_field.max_grid_size
+            )
+        elif wave_menu == 4:  # greenyellow
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_greenyellow_color(
                 ampLe_value,
                 -trackers.ampL_global_rms_am[None] * 2,
@@ -605,6 +639,16 @@ def update_flux_mesh_values(
             )
             wave_field.fluxmesh_xz_vertices[i, k][1] = (
                 ampLr_value / univ_edge_y * warp_mesh
+                + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
+            )
+        elif wave_menu == 2:  # bluered
+            wave_field.fluxmesh_xz_colors[i, k] = colormap.get_bluered_color(
+                psiT_value,
+                -trackers.ampT_global_rms_am[None] * 2,
+                trackers.ampT_global_rms_am[None] * 2,
+            )
+            wave_field.fluxmesh_xz_vertices[i, k][1] = (
+                psiT_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
         else:  # default to greenyellow (wave_menu == 1)
@@ -624,13 +668,25 @@ def update_flux_mesh_values(
     for j, k in ti.ndrange(wave_field.ny, wave_field.nz):
         # Sample longitudinal displacement at this voxel
         psiL_value = wave_field.psiL_am[wave_field.fm_plane_x_idx, j, k]
+        psiT_value = wave_field.psiT_am[wave_field.fm_plane_x_idx, j, k]
         ampLr_value = trackers.ampL_local_rms_am[wave_field.fm_plane_x_idx, j, k]
         ampLe_value = trackers.ampL_local_envelope_am[wave_field.fm_plane_x_idx, j, k]
+        ampT_value = trackers.ampT_local_rms_am[wave_field.fm_plane_x_idx, j, k]
+        freq_value = trackers.freq_local_cross_rHz[wave_field.fm_plane_x_idx, j, k]
         univ_edge_x = wave_field.universe_size_am[0]
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if wave_menu == 4:  # greenyellow
+        if wave_menu == 5:  # blueprint
+            wave_field.fluxmesh_yz_colors[j, k] = colormap.get_blueprint_color(
+                freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
+            )
+            wave_field.fluxmesh_yz_vertices[j, k][0] = freq_value / trackers.freq_global_avg_rHz[
+                None
+            ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[0] * (
+                wave_field.nx / wave_field.max_grid_size
+            )
+        elif wave_menu == 4:  # greenyellow
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_greenyellow_color(
                 ampLe_value,
                 -trackers.ampL_global_rms_am[None] * 2,
@@ -646,6 +702,16 @@ def update_flux_mesh_values(
             )
             wave_field.fluxmesh_yz_vertices[j, k][0] = (
                 ampLr_value / univ_edge_x * warp_mesh
+                + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
+            )
+        elif wave_menu == 2:  # bluered
+            wave_field.fluxmesh_yz_colors[j, k] = colormap.get_bluered_color(
+                psiT_value,
+                -trackers.ampT_global_rms_am[None] * 2,
+                trackers.ampT_global_rms_am[None] * 2,
+            )
+            wave_field.fluxmesh_yz_vertices[j, k][0] = (
+                psiT_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )
         else:  # default to greenyellow (wave_menu == 1)

--- a/openwave/xperiments/m3_wolff_lafreniere/xparameters/electric_repulsion3.py
+++ b/openwave/xperiments/m3_wolff_lafreniere/xparameters/electric_repulsion3.py
@@ -1,0 +1,55 @@
+"""
+XPERIMENT PARAMETERS
+
+This XPERIMENT showcases:
+-
+"""
+
+UNIVERSE_EDGE = 1e-15  # m, universe edge length in meters
+TARGET_VOXELS = 100_000_000  # Target voxel count (impacts performance)
+
+XPARAMETERS = {
+    "meta": {
+        "X_NAME": f"  /Lock Test",
+        "DESCRIPTION": "Energy Wave Charging, Propagation and Interaction",
+    },
+    "camera": {
+        "INITIAL_POSITION": [0.27, 1.62, 0.90],  # [x, y, z] in normalized coordinates
+    },
+    "universe": {
+        "SIZE": [UNIVERSE_EDGE, UNIVERSE_EDGE, UNIVERSE_EDGE],  # m, simulation domain [x, y, z]
+        "TARGET_VOXELS": TARGET_VOXELS,  # Simulation voxel count (impacts performance)
+    },
+    "wave_centers": {
+        "COUNT": 2,  # Number of wave-centers for this xperiment
+        # Wave-Center positions: normalized coordinates (0-1 range, relative to max universe edge)
+        "POSITION": [
+            [0.58, 0.50, 0.50],
+            [0.60, 0.50, 0.50],
+        ],
+        # Phase offsets for each wave-center (integer degrees, converted to radians internally)
+        "PHASE_OFFSETS_DEG": [180, 180],
+        "APPLY_MOTION": True,  # Toggle to apply motion at wave-centers, from force at each iteration
+    },
+    "ui_defaults": {
+        "SHOW_AXIS": False,  # Toggle to show/hide axis lines
+        "TICK_SPACING": 0.25,  # Axis tick marks spacing for position reference
+        "SHOW_GRID": False,  # Toggle to show/hide the voxel data-grid
+        "SHOW_EDGES": False,  # Toggle to show/hide universe edges
+        "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
+        "SHOW_FLUX_MESH": 1,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
+        "WARP_MESH": 500,  # Visual warp mesh effect intensity
+        "PARTICLE_SHELL": True,  # Toggle to enable/disable particle shell rendering
+        "TIMESTEP": 5.0,  # Simulation timestep in rontoseconds (10-27s)
+        "PAUSED": False,  # Pause/Start simulation toggle
+    },
+    "color_defaults": {
+        "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
+        "WAVE_MENU": 4,  # Check _launcher.py display_wave_menu() for wave_menu indexing
+    },
+    "analytics": {
+        "INSTRUMENTATION": False,  # Toggle data acquisition and analytics
+        "EXPORT_VIDEO": False,  # Toggle frame image export to video directory
+        "VIDEO_FRAMES": 24,  # Target frame number to stop recording and finalize video export
+    },
+}

--- a/openwave/xperiments/m3_wolff_lafreniere/xparameters/electric_repulsion4.py
+++ b/openwave/xperiments/m3_wolff_lafreniere/xparameters/electric_repulsion4.py
@@ -1,0 +1,57 @@
+"""
+XPERIMENT PARAMETERS
+
+This XPERIMENT showcases:
+-
+"""
+
+UNIVERSE_EDGE = 1e-15  # m, universe edge length in meters
+TARGET_VOXELS = 100_000_000  # Target voxel count (impacts performance)
+
+XPARAMETERS = {
+    "meta": {
+        "X_NAME": f"  /NO-Charge Test",
+        "DESCRIPTION": "Energy Wave Charging, Propagation and Interaction",
+    },
+    "camera": {
+        "INITIAL_POSITION": [0.27, 1.62, 0.90],  # [x, y, z] in normalized coordinates
+    },
+    "universe": {
+        "SIZE": [UNIVERSE_EDGE, UNIVERSE_EDGE, UNIVERSE_EDGE],  # m, simulation domain [x, y, z]
+        "TARGET_VOXELS": TARGET_VOXELS,  # Simulation voxel count (impacts performance)
+    },
+    "wave_centers": {
+        "COUNT": 4,  # Number of wave-centers for this xperiment
+        # Wave-Center positions: normalized coordinates (0-1 range, relative to max universe edge)
+        "POSITION": [
+            [0.57, 0.75, 0.50],
+            [0.60, 0.75, 0.50],
+            [0.57, 0.25, 0.50],
+            [0.60, 0.25, 0.50],
+        ],
+        # Phase offsets for each wave-center (integer degrees, converted to radians internally)
+        "PHASE_OFFSETS_DEG": [180, 180, 180, 180],
+        "APPLY_MOTION": True,  # Toggle to apply motion at wave-centers, from force at each iteration
+    },
+    "ui_defaults": {
+        "SHOW_AXIS": False,  # Toggle to show/hide axis lines
+        "TICK_SPACING": 0.25,  # Axis tick marks spacing for position reference
+        "SHOW_GRID": False,  # Toggle to show/hide the voxel data-grid
+        "SHOW_EDGES": False,  # Toggle to show/hide universe edges
+        "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
+        "SHOW_FLUX_MESH": 2,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
+        "WARP_MESH": 500,  # Visual warp mesh effect intensity
+        "PARTICLE_SHELL": True,  # Toggle to enable/disable particle shell rendering
+        "TIMESTEP": 5.0,  # Simulation timestep in rontoseconds (10-27s)
+        "PAUSED": False,  # Pause/Start simulation toggle
+    },
+    "color_defaults": {
+        "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
+        "WAVE_MENU": 4,  # Check _launcher.py display_wave_menu() for wave_menu indexing
+    },
+    "analytics": {
+        "INSTRUMENTATION": False,  # Toggle data acquisition and analytics
+        "EXPORT_VIDEO": False,  # Toggle frame image export to video directory
+        "VIDEO_FRAMES": 24,  # Target frame number to stop recording and finalize video export
+    },
+}

--- a/openwave/xperiments/m3_wolff_lafreniere/xparameters/electric_repulsion5.py
+++ b/openwave/xperiments/m3_wolff_lafreniere/xparameters/electric_repulsion5.py
@@ -1,0 +1,78 @@
+"""
+XPERIMENT PARAMETERS
+
+This XPERIMENT showcases:
+-
+"""
+
+import numpy as np
+
+UNIVERSE_EDGE = 1e-15  # m, universe edge length in meters
+TARGET_VOXELS = 100_000_000  # Target voxel count (impacts performance)
+LOCK_SPACING = 0.02  # center-to-center separation between adjacent elements
+
+
+def tetrahedral_10(center=(0.5, 0.5, 0.5)):
+    """Generate 10 positions in 1-3-6 tetrahedral arrangement."""
+    layer_h = LOCK_SPACING * np.sqrt(2 / 3)  # tetrahedral layer spacing
+    cx, cy, cz = center  # Reference center position
+
+    Rb = LOCK_SPACING * 2 / np.sqrt(3)  # base vertex radius
+    Rm = LOCK_SPACING / np.sqrt(3)  # midpoint/middle layer radius
+
+    angles_v = np.radians([90, 210, 330])  # vertex angles
+    angles_m = np.radians([30, 150, 270])  # midpoint angles
+
+    return [
+        # Base: 3 vertices + 3 midpoints
+        *[[cx + Rb * np.cos(a), cy + Rb * np.sin(a), cz] for a in angles_v],
+        *[[cx + Rm * np.cos(a), cy + Rm * np.sin(a), cz] for a in angles_m],
+        # Middle: 3 elements
+        *[[cx + Rm * np.cos(a), cy + Rm * np.sin(a), cz + layer_h] for a in angles_v],
+        # Apex: 1 element
+        [cx, cy, cz + 2 * layer_h],
+    ]
+
+
+XPARAMETERS = {
+    "meta": {
+        "X_NAME": f"  /Electron Test",
+        "DESCRIPTION": "Energy Wave Charging, Propagation and Interaction",
+    },
+    "camera": {
+        "INITIAL_POSITION": [0.27, 1.62, 0.90],  # [x, y, z] in normalized coordinates
+    },
+    "universe": {
+        "SIZE": [UNIVERSE_EDGE, UNIVERSE_EDGE, UNIVERSE_EDGE],  # m, simulation domain [x, y, z]
+        "TARGET_VOXELS": TARGET_VOXELS,  # Simulation voxel count (impacts performance)
+    },
+    "wave_centers": {
+        "COUNT": 10,  # Number of wave-centers for this xperiment
+        # Wave-Center positions: normalized coordinates (0-1 range, relative to max universe edge)
+        "POSITION": tetrahedral_10(center=(0.60, 0.73, 0.50)),
+        # Phase offsets for each wave-center (integer degrees, converted to radians internally)
+        "PHASE_OFFSETS_DEG": [180, 180, 180, 180, 180, 180, 180, 180, 180, 180],
+        "APPLY_MOTION": True,  # Toggle to apply motion at wave-centers, from force at each iteration
+    },
+    "ui_defaults": {
+        "SHOW_AXIS": False,  # Toggle to show/hide axis lines
+        "TICK_SPACING": 0.25,  # Axis tick marks spacing for position reference
+        "SHOW_GRID": False,  # Toggle to show/hide the voxel data-grid
+        "SHOW_EDGES": False,  # Toggle to show/hide universe edges
+        "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],  # [x, y, z] positions relative to universe size
+        "SHOW_FLUX_MESH": 2,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
+        "WARP_MESH": 500,  # Visual warp mesh effect intensity
+        "PARTICLE_SHELL": True,  # Toggle to enable/disable particle shell rendering
+        "TIMESTEP": 5.0,  # Simulation timestep in rontoseconds (10-27s)
+        "PAUSED": False,  # Pause/Start simulation toggle
+    },
+    "color_defaults": {
+        "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
+        "WAVE_MENU": 4,  # Check _launcher.py display_wave_menu() for wave_menu indexing
+    },
+    "analytics": {
+        "INSTRUMENTATION": False,  # Toggle data acquisition and analytics
+        "EXPORT_VIDEO": False,  # Toggle frame image export to video directory
+        "VIDEO_FRAMES": 24,  # Target frame number to stop recording and finalize video export
+    },
+}


### PR DESCRIPTION
UI/layout: enlarge launcher/controls windows and add new WAVE_MENU options (Transverse displacement, Frequency). Add new color palettes (bluered, ironbow, blueprint) and show corresponding palette ticks/labels. Force/debug: add per-source debug fields to WaveCenter, record intermediate values in compute_force_vector, add debug_force_analysis() to print detailed force/EWT/Coulomb comparisons and diagnostics (called optionally), and include a commented velocity clamp. Physics: adjust envelope/near-field propagation logic in propagate_wave. Visualization: extend update_flux_mesh_values to support transverse (psiT) and frequency visualizations (wave_menu==2 and ==5) and map their colors/vertex heights. Add three new experiment xparameter files (electric_repulsion3/4/5) including a tetrahedral electron-config helper in repulsion5.