### PR TITLE
Adjust wavecenter radius and frequency

### DIFF
--- a/openwave/xperiments/m2_laplace_propagation/spacetime_ewave.py
+++ b/openwave/xperiments/m2_laplace_propagation/spacetime_ewave.py
@@ -786,13 +786,13 @@ def interact_wc1_pulse(wave_field: ti.template(), elapsed_t_rs):  # type: ignore
         wave_field: WaveField instance containing displacement arrays and grid info
     """
     wc1x, wc1y, wc1z = wave_field.nx * 2 // 3, wave_field.ny * 2 // 3, wave_field.nz // 2
-    wc_radius = 0  # radius in voxels
+    wc_radius = 12  # radius in voxels
     wc_radius_sq = wc_radius**2  # radius² = 8² voxels (≈ λ/4 for λ=30dx)
     boost = 1  # amplitude boost factor
 
     # Compute angular frequency (ω = 2πf) for temporal phase variation
     omega_rs = (
-        2.0 * ti.math.pi * base_frequency_rHz / wave_field.scale_factor
+        4.0 * ti.math.pi * base_frequency_rHz / wave_field.scale_factor
     )  # angular frequency (rad/rs)
 
     for i, j, k in ti.ndrange(
@@ -826,13 +826,13 @@ def interact_wc2_pulse(wave_field: ti.template(), elapsed_t_rs):  # type: ignore
         wave_field: WaveField instance containing displacement arrays and grid info
     """
     wc2x, wc2y, wc2z = wave_field.nx * 3 // 4, wave_field.ny * 3 // 4, wave_field.nz // 2
-    wc_radius = 0  # radius in voxels
+    wc_radius = 12  # radius in voxels
     wc_radius_sq = wc_radius**2  # radius² = 8² voxels (≈ λ/4 for λ=30dx)
     boost = 1  # amplitude boost factor
 
     # Compute angular frequency (ω = 2πf) for temporal phase variation
     omega_rs = (
-        2.0 * ti.math.pi * base_frequency_rHz / wave_field.scale_factor
+        4.0 * ti.math.pi * base_frequency_rHz / wave_field.scale_factor
     )  # angular frequency (rad/rs)
 
     for i, j, k in ti.ndrange(


### PR DESCRIPTION
This pull request modifies the pulse interaction functions in `spacetime_ewave.py` to enable and expand the spatial extent of the pulses, as well as to increase their temporal frequency. These changes will make the pulses more visible and dynamic in the simulation.

Pulse spatial and frequency adjustments:

* Increased the `wc_radius` from 0 to 12 in both `interact_wc1_pulse` and `interact_wc2_pulse`, enabling and expanding the spatial region affected by the pulse. [[1]](diffhunk://#diff-f9132e4320e80307a126f3ed8c5f93ba5ef2cf902a5d7032846c4b58b6feb72fL789-R795) [[2]](diffhunk://#diff-f9132e4320e80307a126f3ed8c5f93ba5ef2cf902a5d7032846c4b58b6feb72fL829-R835)
* Doubled the angular frequency calculation (`omega_rs`) from `2π` to `4π` in both functions, resulting in faster temporal variation of the pulses. [[1]](diffhunk://#diff-f9132e4320e80307a126f3ed8c5f93ba5ef2cf902a5d7032846c4b58b6feb72fL789-R795) [[2]](diffhunk://#diff-f9132e4320e80307a126f3ed8c5f93ba5ef2cf902a5d7032846c4b58b6feb72fL829-R835)