### PR TITLE
Add BASE WAVE on M1

### DIFF
--- a/openwave/xperiments/m1_granule_motion/_launcher.py
+++ b/openwave/xperiments/m1_granule_motion/_launcher.py
@@ -119,6 +119,7 @@ class SimulationState:
         self.NUM_SOURCES = 1
         self.SOURCES_POSITION = []
         self.SOURCES_OFFSET_DEG = []
+        self.BASE_WAVE_TOGGLE = 0
         self.IN_WAVE_TOGGLE = 1
         self.OUT_WAVE_TOGGLE = 1
 
@@ -166,6 +167,7 @@ class SimulationState:
         self.NUM_SOURCES = sources["COUNT"]
         self.SOURCES_POSITION = sources["POSITION"]
         self.SOURCES_OFFSET_DEG = sources["PHASE_OFFSETS_DEG"]
+        self.BASE_WAVE_TOGGLE = sources["BASE_WAVE_TOGGLE"]
         self.IN_WAVE_TOGGLE = sources["IN_WAVE_TOGGLE"]
         self.OUT_WAVE_TOGGLE = sources["OUT_WAVE_TOGGLE"]
 
@@ -235,10 +237,11 @@ def display_xperiment_launcher(xperiment_mgr, state):
 
 def display_controls(state):
     """Display the controls UI overlay."""
-    with render.gui.sub_window("CONTROLS", 0.00, 0.33, 0.16, 0.27) as sub:
+    with render.gui.sub_window("CONTROLS", 0.00, 0.33, 0.16, 0.30) as sub:
         state.SHOW_AXIS = sub.checkbox(f"Axis (ticks: {state.TICK_SPACING})", state.SHOW_AXIS)
         state.BLOCK_SLICE = sub.checkbox("Block Slice", state.BLOCK_SLICE)
         state.SHOW_SOURCES = sub.checkbox("Show Wave Centers (sources)", state.SHOW_SOURCES)
+        state.BASE_WAVE_TOGGLE = sub.checkbox("Base Wave (Full Amp)", state.BASE_WAVE_TOGGLE)
         state.IN_WAVE_TOGGLE = sub.checkbox("Incoming Wave (Full Amp)", state.IN_WAVE_TOGGLE)
         state.OUT_WAVE_TOGGLE = sub.checkbox("Outgoing Wave (Amp Falloff)", state.OUT_WAVE_TOGGLE)
         state.RADIUS_FACTOR = sub.slider_float("Granule", state.RADIUS_FACTOR, 0.1, 2.0)
@@ -381,6 +384,7 @@ def compute_wave_oscillation(state):
         state.AMP_BOOST,
         state.WAVE_MENU,
         state.NUM_SOURCES,
+        state.BASE_WAVE_TOGGLE,
         state.IN_WAVE_TOGGLE,
         state.OUT_WAVE_TOGGLE,
         state.elapsed_t,

--- a/openwave/xperiments/m1_granule_motion/spacetime_ewave.py
+++ b/openwave/xperiments/m1_granule_motion/spacetime_ewave.py
@@ -33,11 +33,13 @@ sources_phase_offset = None  # Phase offset for each wave source (radians)
 amp_global_peak_am = None  # max displacement across all granules
 avg_amplitude_am = None  # RMS amplitude (peak × 0.707)
 last_amp_boost = None  # for detecting amp_boost changes
+last_base_wave_toggle = None  # for detecting base_wave toggle changes
 last_in_wave_toggle = None  # for detecting in_wave toggle changes
 last_out_wave_toggle = None  # for detecting out_wave toggle changes
 
 # Center of sources for signed radial displacement
 sources_center_am = None  # geometric center of all wave sources (attometers)
+universe_vertices_am = None  # 8 corner vertices of the universe bounding box (attometers)
 
 
 # ================================================================
@@ -65,7 +67,8 @@ def build_source_vectors(num_sources, sources_position, sources_offset_deg, latt
     """
     global sources_direction, sources_distance_am, sources_phase_offset, sources_pos_field
     global amp_global_peak_am, avg_amplitude_am, sources_center_am
-    global last_amp_boost, last_in_wave_toggle, last_out_wave_toggle
+    global last_amp_boost, last_base_wave_toggle, last_in_wave_toggle, last_out_wave_toggle
+    global universe_vertices_am
 
     # Convert phase from degrees to radians
     sources_offset_rad = [deg * ti.math.pi / 180 for deg in sources_offset_deg]
@@ -85,6 +88,7 @@ def build_source_vectors(num_sources, sources_position, sources_offset_deg, latt
     amp_global_peak_am = ti.field(dtype=ti.f32, shape=())  # max displacement
     avg_amplitude_am = ti.field(dtype=ti.f32, shape=())  # RMS amplitude
     last_amp_boost = ti.field(dtype=ti.f32, shape=())  # for change detection
+    last_base_wave_toggle = ti.field(dtype=ti.i32, shape=())  # detects base_wave toggle changes
     last_in_wave_toggle = ti.field(dtype=ti.i32, shape=())  # detects in_wave toggle changes
     last_out_wave_toggle = ti.field(dtype=ti.i32, shape=())  # detects out_wave toggle changes
 
@@ -102,6 +106,25 @@ def build_source_vectors(num_sources, sources_position, sources_offset_deg, latt
             center_sum[2] / num_sources * lattice.max_universe_edge_am,
         ]
     )
+
+    # Precompute 8 universe vertices (corners of bounding box) for in-wave computation
+    universe_vertices_am = ti.Vector.field(3, dtype=ti.f32, shape=8)
+    lx = lattice.universe_size_am[0]
+    ly = lattice.universe_size_am[1]
+    lz = lattice.universe_size_am[2]
+    for idx, (cx, cy, cz) in enumerate(
+        [
+            (0, 0, 0),
+            (lx, 0, 0),
+            (0, ly, 0),
+            (0, 0, lz),
+            (lx, ly, 0),
+            (lx, 0, lz),
+            (0, ly, lz),
+            (lx, ly, lz),
+        ]
+    ):
+        universe_vertices_am[idx] = ti.Vector([cx, cy, cz])
 
     # Copy source data to Taichi fields
     for i in range(num_sources):
@@ -148,6 +171,7 @@ def oscillate_granules(
     amp_boost: ti.f32,  # type: ignore
     wave_menu: ti.i32,  # type: ignore
     num_sources: ti.i32,  # type: ignore
+    base_wave_toggle: ti.i32,  # type: ignore
     in_wave_toggle: ti.i32,  # type: ignore
     out_wave_toggle: ti.i32,  # type: ignore
     elapsed_t: ti.f32,  # type: ignore
@@ -215,6 +239,7 @@ def oscillate_granules(
         amp_boost: Amplitude multiplier (for visibility in scaled lattices)
         wave_menu: Selected Wave displayed with color palette
         num_sources: Number of wave sources
+        base_wave_toggle: Toggle for base_wave (1 = enable, 0 = disable)
         in_wave_toggle: Toggle for in_wave (1 = enable, 0 = disable)
         out_wave_toggle: Toggle for out_wave (1 = enable, 0 = disable)
         elapsed_t: Current simulation time (accumulated, seconds)
@@ -232,8 +257,26 @@ def oscillate_granules(
 
     # Process all granules in parallel (outermost loop = GPU parallelization)
     for granule_idx in range(position_am.shape[0]):
+        # Temporal phase: φ = ω·t, oscillatory in time
+        temporal_phase = omega_slo * elapsed_t
+
+        # Accumulate in-wave contributions from all 8 universe vertices
+        base_wave_psi = ti.Vector([0.0, 0.0, 0.0])
+        for v in range(8):  # Loop through each universe vertex
+            # Vector from vertex to granule equilibrium position
+            r_vec = equilibrium_am[granule_idx] - universe_vertices_am[v]
+            r_mag = r_vec.norm()
+            # A·cos(ωt + kr)·direction, positive for inward propagation, full amp
+            base_wave_psi += (
+                base_wave_toggle
+                * base_amplitude_am
+                * amp_boost
+                / 8  # incoming wave do not superpose, split per vertex for energy conservation
+                * ti.cos(temporal_phase + k_am * r_mag)
+            ) * (r_vec / r_mag)
+
         # Initialize accumulation variables for wave superposition
-        total_displacement_am = ti.Vector([0.0, 0.0, 0.0])  # sum of displacements from all sources
+        total_displacement_am = base_wave_psi  # sum of displacements from all sources
         total_velocity_am = ti.Vector([0.0, 0.0, 0.0])  # sum of velocities from all sources
 
         # Sum contributions from all sources (wave superposition)
@@ -243,13 +286,10 @@ def oscillate_granules(
             r_am = sources_distance_am[granule_idx, source_idx]
 
             # Phase shift between in/out waves (at wave-center)
-            phase_shift = ti.math.pi / 2
+            phase_shift = ti.math.pi
 
             # Source phase offset: initial phase of this wave-center
             source_offset = sources_phase_offset[source_idx]
-
-            # Temporal phase: φ = ω·t, oscillatory in time
-            temporal_phase = omega_slo * elapsed_t
 
             # Spatial phase: φ = k·r, creates spherical wave fronts
             spatial_phase = k_am * r_am
@@ -340,6 +380,7 @@ def oscillate_granules(
     # Prevents stale high values when amp_boost is reduced
     if (
         last_amp_boost[None] != amp_boost
+        or last_base_wave_toggle[None] != base_wave_toggle
         or last_in_wave_toggle[None] != in_wave_toggle
         or last_out_wave_toggle[None] != out_wave_toggle
     ):
@@ -347,6 +388,7 @@ def oscillate_granules(
             amp_local_peak_am[i] = 0.0
         amp_global_peak_am[None] = 0.0
         last_amp_boost[None] = amp_boost
+        last_base_wave_toggle[None] = base_wave_toggle
         last_in_wave_toggle[None] = in_wave_toggle
         last_out_wave_toggle[None] = out_wave_toggle
     # Convert peak to RMS amplitude: RMS = peak / √2 ≈ peak × 0.707

--- a/openwave/xperiments/m1_granule_motion/xparameters/spacetime_vibration.py
+++ b/openwave/xperiments/m1_granule_motion/xparameters/spacetime_vibration.py
@@ -41,6 +41,7 @@ XPARAMETERS = {
         # Phase offsets for each source (integer degrees, converted to radians internally)
         # Center source at 180° creates destructive interference with corner sources at 0°
         "PHASE_OFFSETS_DEG": [0, 0, 0, 0, 0, 0, 0, 0, 0],
+        "BASE_WAVE_TOGGLE": 0,  # 1 = enable base_wave, 0 = disable base_wave
         "IN_WAVE_TOGGLE": 0,  # 1 = enable in_wave, 0 = disable in_wave
         "OUT_WAVE_TOGGLE": 1,  # 1 = enable out_wave, 0 = disable out_wave
     },

--- a/openwave/xperiments/m1_granule_motion/xparameters/spherical_wave.py
+++ b/openwave/xperiments/m1_granule_motion/xparameters/spherical_wave.py
@@ -30,6 +30,7 @@ XPARAMETERS = {
         "POSITION": [[0.5, 0.5, 0.5]],  # Wave Source position - Center
         # Phase offset in degrees (0° = in phase with base frequency)
         "PHASE_OFFSETS_DEG": [0],
+        "BASE_WAVE_TOGGLE": 0,  # 1 = enable base_wave, 0 = disable base_wave
         "IN_WAVE_TOGGLE": 0,  # 1 = enable in_wave, 0 = disable in_wave
         "OUT_WAVE_TOGGLE": 1,  # 1 = enable out_wave, 0 = disable out_wave
     },

--- a/openwave/xperiments/m1_granule_motion/xparameters/standing_wave.py
+++ b/openwave/xperiments/m1_granule_motion/xparameters/standing_wave.py
@@ -28,8 +28,8 @@ NORMALIZED_RADIUS = SOURCES_RADIUS / UNIVERSE_EDGE  # normalized radius
 # Positions relative to universe center (0.5, 0.5, Z_POSITION)
 SOURCES_POSITION = [
     [
-        np.cos(i * 2 * np.pi / NUM_SOURCES) * NORMALIZED_RADIUS + 0.5,
-        np.sin(i * 2 * np.pi / NUM_SOURCES) * NORMALIZED_RADIUS + 0.5,
+        0.5,
+        0.5,
         Z_POSITION,
     ]
     for i in range(NUM_SOURCES)
@@ -63,6 +63,7 @@ XPARAMETERS = {
         # Allows creating constructive/destructive interference patterns
         # Common patterns: 0° = in phase, 180° = opposite phase, 90° = quarter-cycle offset
         "PHASE_OFFSETS_DEG": SOURCES_PHASE_DEG,
+        "BASE_WAVE_TOGGLE": 0,  # 1 = enable base_wave, 0 = disable base_wave
         "IN_WAVE_TOGGLE": 1,  # 1 = enable in_wave, 0 = disable in_wave
         "OUT_WAVE_TOGGLE": 1,  # 1 = enable out_wave, 0 = disable out_wave
     },

--- a/openwave/xperiments/m1_granule_motion/xparameters/wave_interference.py
+++ b/openwave/xperiments/m1_granule_motion/xparameters/wave_interference.py
@@ -43,6 +43,7 @@ XPARAMETERS = {
         # Phase offsets for each source (integer degrees, converted to radians internally)
         # All sources in phase (0°) to create symmetric interference
         "PHASE_OFFSETS_DEG": [0, 0, 0],
+        "BASE_WAVE_TOGGLE": 0,  # 1 = enable base_wave, 0 = disable base_wave
         "IN_WAVE_TOGGLE": 0,  # 1 = enable in_wave, 0 = disable in_wave
         "OUT_WAVE_TOGGLE": 1,  # 1 = enable out_wave, 0 = disable out_wave
     },

--- a/openwave/xperiments/m1_granule_motion/xparameters/wc1_attraction.py
+++ b/openwave/xperiments/m1_granule_motion/xparameters/wc1_attraction.py
@@ -32,6 +32,7 @@ XPARAMETERS = {
         # Phase offsets for each source (integer degrees, converted to radians internally)
         # All sources in phase (0°) to create symmetric interference
         "PHASE_OFFSETS_DEG": [0, 180],
+        "BASE_WAVE_TOGGLE": 0,  # 1 = enable base_wave, 0 = disable base_wave
         "IN_WAVE_TOGGLE": 1,  # 1 = enable in_wave, 0 = disable in_wave
         "OUT_WAVE_TOGGLE": 1,  # 1 = enable out_wave, 0 = disable out_wave
     },

--- a/openwave/xperiments/m1_granule_motion/xparameters/wc2_repulsion.py
+++ b/openwave/xperiments/m1_granule_motion/xparameters/wc2_repulsion.py
@@ -32,6 +32,7 @@ XPARAMETERS = {
         # Phase offsets for each source (integer degrees, converted to radians internally)
         # All sources in phase (0°) to create symmetric interference
         "PHASE_OFFSETS_DEG": [0, 0],
+        "BASE_WAVE_TOGGLE": 0,  # 1 = enable base_wave, 0 = disable base_wave
         "IN_WAVE_TOGGLE": 1,  # 1 = enable in_wave, 0 = disable in_wave
         "OUT_WAVE_TOGGLE": 1,  # 1 = enable out_wave, 0 = disable out_wave
     },

--- a/openwave/xperiments/m1_granule_motion/xparameters/yin_yang.py
+++ b/openwave/xperiments/m1_granule_motion/xparameters/yin_yang.py
@@ -61,6 +61,7 @@ XPARAMETERS = {
         # Phase offsets for each source (integer degrees, converted to radians internally)
         # Progressive 30° increments create spiral wave interference pattern
         "PHASE_OFFSETS_DEG": SOURCES_PHASE_DEG,
+        "BASE_WAVE_TOGGLE": 0,  # 1 = enable base_wave, 0 = disable base_wave
         "IN_WAVE_TOGGLE": 0,  # 1 = enable in_wave, 0 = disable in_wave
         "OUT_WAVE_TOGGLE": 1,  # 1 = enable out_wave, 0 = disable out_wave
     },

--- a/openwave/xperiments/m3_wolff_lafreniere/particle.py
+++ b/openwave/xperiments/m3_wolff_lafreniere/particle.py
@@ -70,15 +70,14 @@ class WaveCenter:
         # ================================================================
         # Phase offset in radians (charge analog: 0 = electron, pi = positron)
         self.offset = ti.field(dtype=ti.f32, shape=num_sources)
+        # Convert phase from degrees to radians
+        sources_offset_rad = [deg * ti.math.pi / 180 for deg in sources_offset_deg]
 
         # ================================================================
         # Activity state
         # ================================================================
         # Per-WC flag (1 = active, 0 = inactive/annihilated)
         self.active = ti.field(dtype=ti.i32, shape=num_sources)
-
-        # Convert phase from degrees to radians
-        sources_offset_rad = [deg * ti.math.pi / 180 for deg in sources_offset_deg]
 
         # Copy source data to Taichi fields
         for i in range(num_sources):

--- a/openwave/xperiments/m4_vector_wave/particle.py
+++ b/openwave/xperiments/m4_vector_wave/particle.py
@@ -70,15 +70,14 @@ class WaveCenter:
         # ================================================================
         # Phase offset in radians (charge analog: 0 = electron, pi = positron)
         self.offset = ti.field(dtype=ti.f32, shape=num_sources)
+        # Convert phase from degrees to radians
+        sources_offset_rad = [deg * ti.math.pi / 180 for deg in sources_offset_deg]
 
         # ================================================================
         # Activity state
         # ================================================================
         # Per-WC flag (1 = active, 0 = inactive/annihilated)
         self.active = ti.field(dtype=ti.i32, shape=num_sources)
-
-        # Convert phase from degrees to radians
-        sources_offset_rad = [deg * ti.math.pi / 180 for deg in sources_offset_deg]
 
         # Copy source data to Taichi fields
         for i in range(num_sources):

--- a/openwave/xperiments/m4_vector_wave/research/wave1D_plot.py
+++ b/openwave/xperiments/m4_vector_wave/research/wave1D_plot.py
@@ -46,7 +46,7 @@ PERIOD_RS = 2 * np.pi / omega_rs  # one full wave period in rontoseconds
 # Displacement Functions
 # ================================================================
 
-wc_spacing = 40 * base_wavelength_am  # am, spacing between wave centers
+wc_spacing = 10 * base_wavelength_am  # am, spacing between wave centers
 
 x_am = np.linspace(-1.5 * wc_spacing, +1.5 * wc_spacing, 1000)
 
@@ -121,6 +121,7 @@ def compute_wave_standing(
     source_offset = get_source_offset(source)
     psi_am = (
         base_amplitude_am
+        / 2
         * np.cos(omega_rs * t_rs + source_offset)  # temporal phases (rad)
         * np.cos(k_am * radius_am)  # spatial phase, φ = k·r (rad)
     )
@@ -143,7 +144,7 @@ def compute_wave_fullamp(
     source_offset = get_source_offset(source)
     psi_am = (
         base_amplitude_am
-        / 1
+        / 2
         * np.cos(  # full amplitude (am)  # oscillator cosine function
             omega_rs * t_rs  # temporal phase (rad)
             + direction * k_am * radius_am  # spatial phase, spherical wave fronts, φ = ±kr (rad)
@@ -550,6 +551,34 @@ PLOT_CONFIGS = [  # 1 WC: standing + ampfalloff
         "label": "TOTAL Psi (am)",
     },
 ]
+
+PLOT_CONFIGS = [  # 2 WC: standing + ampfalloff
+    {
+        "func": ["standing", "standing"],  # sum of both sources
+        "direction": [1, 1],
+        "source": [1, 2],  # WC1 + WC2
+        "ylim": (-1.5, 1.5),
+        "height_ratio": 1,
+        "label": "INCOMING Psi (am)",
+    },
+    {
+        "func": ["ampfalloff", "ampfalloff"],  # sum of both sources
+        "direction": [-1, -1],
+        "source": [1, 2],  # WC1 + WC2
+        "ylim": (-1.5, 1.5),
+        "height_ratio": 1,
+        "label": "OUTGOING Psi (am)",
+    },
+    {
+        "func": ["standing", "ampfalloff", "standing", "ampfalloff"],  # sum of both sources
+        "direction": [1, -1, 1, -1],
+        "source": [1, 1, 2, 2],  # WC1 + WC2
+        "ylim": (-2.5, 2.5),
+        "height_ratio": 1,
+        "label": "TOTAL Psi (am)",
+    },
+]
+
 
 PLOT_CONFIGS = [  # 1 WC: fullamp + ampfalloff
     {

--- a/openwave/xperiments/m4_vector_wave/research/wave1D_plot.py
+++ b/openwave/xperiments/m4_vector_wave/research/wave1D_plot.py
@@ -46,7 +46,7 @@ PERIOD_RS = 2 * np.pi / omega_rs  # one full wave period in rontoseconds
 # Displacement Functions
 # ================================================================
 
-wc_spacing = 10 * base_wavelength_am  # am, spacing between wave centers
+wc_spacing = 4 * base_wavelength_am  # am, spacing between wave centers
 
 x_am = np.linspace(-1.5 * wc_spacing, +1.5 * wc_spacing, 1000)
 
@@ -144,7 +144,7 @@ def compute_wave_fullamp(
     source_offset = get_source_offset(source)
     psi_am = (
         base_amplitude_am
-        / 2
+        / 1
         * np.cos(  # full amplitude (am)  # oscillator cosine function
             omega_rs * t_rs  # temporal phase (rad)
             + direction * k_am * radius_am  # spatial phase, spherical wave fronts, φ = ±kr (rad)
@@ -634,6 +634,60 @@ PLOT_CONFIGS = [  # 2 WC: fullamp + ampfalloff
     },
 ]
 
+PLOT_CONFIGS = [  # 2 WC: ampfalloff + ampfalloff
+    {
+        "func": ["ampfalloff"],  # sum of both sources
+        "direction": [-1],
+        "source": [1],  # WC1 + WC2
+        "ylim": (-1.5, 1.5),
+        "height_ratio": 1,
+        "label": "OUTGOING Psi (am)",
+    },
+    {
+        "func": ["ampfalloff"],  # sum of both sources
+        "direction": [-1],
+        "source": [2],  # WC1 + WC2
+        "ylim": (-1.5, 1.5),
+        "height_ratio": 1,
+        "label": "OUTGOING Psi (am)",
+    },
+    {
+        "func": ["ampfalloff", "ampfalloff"],  # sum of both sources
+        "direction": [-1, -1],
+        "source": [1, 2],  # WC1 + WC2
+        "ylim": (-1.5, 1.5),
+        "height_ratio": 1,
+        "label": "TOTAL Psi (am)",
+    },
+]
+
+PLOT_CONFIGS0 = [  # 2 WC: fullamp + fullamp
+    {
+        "func": ["fullamp"],  # sum of both sources
+        "direction": [-1],
+        "source": [1],  # WC1 + WC2
+        "ylim": (-1.5, 1.5),
+        "height_ratio": 1,
+        "label": "OUTGOING Psi (am)",
+    },
+    {
+        "func": ["fullamp"],  # sum of both sources
+        "direction": [-1],
+        "source": [2],  # WC1 + WC2
+        "ylim": (-1.5, 1.5),
+        "height_ratio": 1,
+        "label": "OUTGOING Psi (am)",
+    },
+    {
+        "func": ["fullamp", "fullamp"],  # sum of both sources
+        "direction": [-1, -1],
+        "source": [1, 2],  # WC1 + WC2
+        "ylim": (-1.5, 1.5),
+        "height_ratio": 1,
+        "label": "TOTAL Psi (am)",
+    },
+]
+
 PLOT_CONFIGS0 = [  # 1 WC: wolff & lafreniere
     {
         "func": "lafreniere",
@@ -1019,47 +1073,33 @@ def plot_waves(start_paused: bool = False, start_frame: int = 0, save_gif: bool 
         ax.axhline(y=0, color="w", linestyle="--", alpha=0.3)
         # WC1 markers (only if WC1 is used)
         if use_wc1:
-            ax.axvline(x=wc1_x_am, color="orange", linestyle="--", alpha=0.5, label="WC1")
+            ax.axvline(x=wc1_x_am, color="#FF0000", linestyle="--", alpha=0.5, label="WC1 ± λ")
             ax.axvline(
                 x=wc1_x_am + base_wavelength_am,
-                color="yellow",
+                color="#FF0000",
                 linestyle="--",
-                alpha=0.3,
-                label="WC1 ± λ",
+                alpha=0.2,
             )
             ax.axvline(
                 x=wc1_x_am - base_wavelength_am,
-                color="yellow",
+                color="#FF0000",
                 linestyle="--",
-                alpha=0.3,
-            )
-            ax.axvline(
-                x=wc1_x_am + 2 * base_wavelength_am,
-                color="yellow",
-                linestyle="--",
-                alpha=0.3,
-            )
-            ax.axvline(
-                x=wc1_x_am - 2 * base_wavelength_am,
-                color="yellow",
-                linestyle="--",
-                alpha=0.3,
+                alpha=0.2,
             )
         # WC2 markers (only if WC2 is used)
         if use_wc2:
-            ax.axvline(x=wc2_x_am, color="cyan", linestyle="--", alpha=0.5, label="WC2")
+            ax.axvline(x=wc2_x_am, color="#1A99E6", linestyle="--", alpha=0.5, label="WC2 ± λ")
             ax.axvline(
                 x=wc2_x_am + base_wavelength_am,
-                color="magenta",
+                color="#1A99E6",
                 linestyle="--",
-                alpha=0.3,
-                label="WC2 ± λ",
+                alpha=0.2,
             )
             ax.axvline(
                 x=wc2_x_am - base_wavelength_am,
-                color="magenta",
+                color="#1A99E6",
                 linestyle="--",
-                alpha=0.3,
+                alpha=0.2,
             )
         ax.set_xlabel("X (am)", family="Monospace")
         ax.set_ylabel("Displacement (am)", family="Monospace")


### PR DESCRIPTION
This pull request introduces a new "base wave" feature to the granule motion experiments, allowing users to toggle a uniform base wave originating from the universe's bounding box corners. The changes update the simulation logic, user interface, and configuration files to support this new wave type, as well as make minor improvements and bug fixes in related modules.

**Base Wave Feature Implementation:**

* Added `BASE_WAVE_TOGGLE` to experiment state, configuration files, and UI controls, enabling users to activate or deactivate the base wave in all relevant experiment modes. [[1]](diffhunk://#diff-4e68fdac2d422dfc4dd822c9031efb1234c0f2f45f790b91e97b74e84ac8389bR122) [[2]](diffhunk://#diff-4e68fdac2d422dfc4dd822c9031efb1234c0f2f45f790b91e97b74e84ac8389bR170) [[3]](diffhunk://#diff-deb9f5725e58fae12d0832bcc878046660aee998406375561d3c4d0f19c70f59R44) [[4]](diffhunk://#diff-4346d020c8b97f76668f375b026882060a5ef90ad8761931563bf23ebb37d868R33) [[5]](diffhunk://#diff-03d808050abb33578fd78f45ad4296efddb463d53864d1c2695f64440fcea50bR66) [[6]](diffhunk://#diff-9766c7d30495339f6fb2903e2413ccbd691ef5a3c642de389daa01fd2acb3364R46) [[7]](diffhunk://#diff-df0fab49c75557177627e87c99547d71d7fe3394dab6b642906cfd5601782559R35) [[8]](diffhunk://#diff-ddf01d6fd51cb44960abd7a6526e9b19045ed6c035b63612039ddf03862a2e01R35) [[9]](diffhunk://#diff-ad6fa57cbec260d78aa1b1751d09301a5288554ee28b444f8b74bd911d203a30R64) [[10]](diffhunk://#diff-4e68fdac2d422dfc4dd822c9031efb1234c0f2f45f790b91e97b74e84ac8389bL238-R244)
* Updated simulation logic in `spacetime_ewave.py` to compute and superpose the base wave from the eight universe bounding box corners, integrating its contribution into granule displacement calculations. [[1]](diffhunk://#diff-9fcd63255bcf5d720ec5f92d6a18707dbd5c7862811c56e7080c718f5bcadda2R110-R128) [[2]](diffhunk://#diff-9fcd63255bcf5d720ec5f92d6a18707dbd5c7862811c56e7080c718f5bcadda2R260-R279)
* Ensured correct change detection and amplitude peak reset when toggling the base wave, preventing stale simulation states. [[1]](diffhunk://#diff-9fcd63255bcf5d720ec5f92d6a18707dbd5c7862811c56e7080c718f5bcadda2R91) [[2]](diffhunk://#diff-9fcd63255bcf5d720ec5f92d6a18707dbd5c7862811c56e7080c718f5bcadda2R383-R391)

**Simulation Logic and Physics Adjustments:**

* Changed the phase shift for source waves to π (from π/2) for more accurate wave interference modeling.
* Added precomputation of universe bounding box vertices for use in base wave calculations.

**Configuration and UI Updates:**

* Updated all experiment parameter files to include the `BASE_WAVE_TOGGLE` option, ensuring consistent configuration across modes. [[1]](diffhunk://#diff-deb9f5725e58fae12d0832bcc878046660aee998406375561d3c4d0f19c70f59R44) [[2]](diffhunk://#diff-4346d020c8b97f76668f375b026882060a5ef90ad8761931563bf23ebb37d868R33) [[3]](diffhunk://#diff-03d808050abb33578fd78f45ad4296efddb463d53864d1c2695f64440fcea50bR66) [[4]](diffhunk://#diff-9766c7d30495339f6fb2903e2413ccbd691ef5a3c642de389daa01fd2acb3364R46) [[5]](diffhunk://#diff-df0fab49c75557177627e87c99547d71d7fe3394dab6b642906cfd5601782559R35) [[6]](diffhunk://#diff-ddf01d6fd51cb44960abd7a6526e9b19045ed6c035b63612039ddf03862a2e01R35) [[7]](diffhunk://#diff-ad6fa57cbec260d78aa1b1751d09301a5288554ee28b444f8b74bd911d203a30R64)
* Added a checkbox for the base wave toggle to the controls UI overlay, allowing interactive control during experiments.

**Minor Fixes and Code Quality Improvements:**

* Moved phase offset conversion in particle initializers to before field assignment for clarity and correctness.
* Adjusted wave center spacing and amplitude scaling in 1D wave plotting for improved visualization. [[1]](diffhunk://#diff-cb9756fc41bec76393b3b7ca2dc300786c9227dace6edbdb5166173f8a9be14aL49-R49) [[2]](diffhunk://#diff-cb9756fc41bec76393b3b7ca2dc300786c9227dace6edbdb5166173f8a9be14aR124)
* Added new plot configurations for 2-wave-center scenarios in 1D wave research module.
* Fixed source position initialization in standing wave configuration for proper centering.