### PR TITLE
Add granule_motion xparameters for standing waves

### DIFF
--- a/openwave/xperiments/m1_granule_motion/xparameters/granule_motion.py
+++ b/openwave/xperiments/m1_granule_motion/xparameters/granule_motion.py
@@ -1,0 +1,89 @@
+"""
+XPERIMENT PARAMETERS
+
+Demonstrates standing wave patterns from multiple sources arranged in a circle.
+64 sources generate spherical longitudinal waves that superpose at each granule,
+creating complex standing wave interference patterns.
+
+This XPERIMENT showcases:
+- 64 wave sources arranged in a circular pattern
+- Standing wave formation
+- Complex interference patterns
+- Thin Z dimension for 2.5D visualization
+"""
+
+import numpy as np
+
+from openwave.common import constants
+
+# Generate 64 sources in a circular pattern
+NUM_SOURCES = 1  # Number of wave sources for this xperiment, legacy = 64
+Z_POSITION = 0.01  # Z-axis position for all sources (thin slice)
+
+# Calculate source positions in a circle around center
+UNIVERSE_EDGE = 6 * constants.EWAVE_LENGTH  # m, universe edge length in meters
+SOURCES_RADIUS = 1 * constants.EWAVE_LENGTH  # m, r = n * λ, interference radius, legacy = 2
+NORMALIZED_RADIUS = SOURCES_RADIUS / UNIVERSE_EDGE  # normalized radius
+
+# Positions relative to universe center (0.5, 0.5, Z_POSITION)
+SOURCES_POSITION = [
+    [
+        0.5,
+        0.5,
+        Z_POSITION,
+    ]
+    for i in range(NUM_SOURCES)
+]
+
+# All sources in phase (0°) to create standing wave pattern
+SOURCES_PHASE_DEG = [0] * NUM_SOURCES
+
+XPARAMETERS = {
+    "meta": {
+        "X_NAME": "Granule Motion",
+        "DESCRIPTION": "Detailed simulation of granule motion influenced by standing wave patterns from multiple sources arranged in a circle. Demonstrates complex interference patterns and 2.5D visualization.",
+    },
+    "camera": {
+        "INITIAL_POSITION": [1.00, 0.60, 1.00],  # [x, y, z] in normalized coordinates
+    },
+    "universe": {
+        "SIZE": [
+            UNIVERSE_EDGE,
+            UNIVERSE_EDGE,
+            UNIVERSE_EDGE * Z_POSITION,
+        ],  # m, simulation domain [x, y, z]
+        "TARGET_GRANULES": 1e3,  # Simulation particle count (impacts performance)
+    },
+    "wave_sources": {
+        "COUNT": NUM_SOURCES,  # Number of wave sources for this xperiment
+        # Wave Source positions: normalized coordinates (0-1 range, relative to max universe edge)
+        # Each row represents [x, y, z] coordinates for one source (Z-up coordinate system)
+        "POSITION": SOURCES_POSITION,
+        # Phase offsets for each source (integer degrees, converted to radians internally)
+        # Allows creating constructive/destructive interference patterns
+        # Common patterns: 0° = in phase, 180° = opposite phase, 90° = quarter-cycle offset
+        "PHASE_OFFSETS_DEG": SOURCES_PHASE_DEG,
+        "BASE_WAVE_TOGGLE": 1,  # 1 = enable base_wave, 0 = disable base_wave
+        "IN_WAVE_TOGGLE": 0,  # 1 = enable in_wave, 0 = disable in_wave
+        "OUT_WAVE_TOGGLE": 0,  # 1 = enable out_wave, 0 = disable out_wave
+    },
+    "ui_defaults": {
+        "SHOW_AXIS": False,  # Toggle to show/hide axis lines
+        "TICK_SPACING": 0.25,  # Axis tick marks spacing for position reference
+        "BLOCK_SLICE": False,  # Block-slicing toggle
+        "SHOW_SOURCES": True,  # Toggle to show/hide wave source markers
+        "RADIUS_FACTOR": 0.35,  # Granule radius scaling factor
+        "FREQ_BOOST": 10.0,  # Frequency boost multiplier
+        "AMP_BOOST": 3.0,  # Amplitude boost multiplier, legacy = 0.1
+        "PAUSED": False,  # Pause/Start simulation toggle
+    },
+    "color_defaults": {
+        "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
+        "WAVE_MENU": 2,  # Check _launcher.py display_wave_menu() for wave_menu indexing
+    },
+    "analytics": {
+        "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)
+        "EXPORT_VIDEO": False,  # Toggle frame image export to video directory
+        "VIDEO_FRAMES": 24,  # Target frame number to stop recording and finalize video export
+    },
+}


### PR DESCRIPTION
Introduce a new xparameters configuration for the "Granule Motion" experiment. The file defines wave source positions and phases, universe size (scaled by constants.EWAVE_LENGTH), a thin Z slice for 2.5D visualization, and UI/color/analytics defaults. NUM_SOURCES is currently set to 1 (legacy value noted as 64) and various toggles (base/in/out waves, rendering, export) are provided to control simulation behavior and visualization.