### PR TITLE
Implemented Vector Wave, wave scalar fields converted to vector fields

### DIFF
--- a/openwave/xperiments/_archives/radial_wave/wave_engine.py
+++ b/openwave/xperiments/_archives/radial_wave/wave_engine.py
@@ -16,7 +16,7 @@ from openwave.common import constants
 # ================================================================
 # Energy-Wave Oscillation Parameters
 # ================================================================
-amp_local_peak_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETER  # am, oscillation amplitude
+amplitude_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETER  # am, oscillation amplitude
 wavelength_am = constants.EWAVE_LENGTH / constants.ATTOMETER  # in attometers
 frequency = constants.EWAVE_SPEED / constants.EWAVE_LENGTH  # Hz, energy-wave frequency
 
@@ -115,7 +115,7 @@ def oscillate_granules_tocenter(
 
         # Total amplitude at distance r from wave source
         # Step 1: Apply energy conservation (1/r falloff) and visualization scaling
-        amplitude_uncapped = amp_local_peak_am * amplitude_falloff * amp_boost
+        amplitude_uncapped = amplitude_am * amplitude_falloff * amp_boost
 
         # Step 2: Cap amplitude to distance from source (A ≤ r)
         # Prevents non-physical behavior: granules crossing through wave source

--- a/openwave/xperiments/_archives/spring_mass/wave_engine_euler.py
+++ b/openwave/xperiments/_archives/spring_mass/wave_engine_euler.py
@@ -12,7 +12,7 @@ from openwave.common import constants
 # ================================================================
 # Energy-Wave Oscillation Parameters
 # ================================================================
-amp_local_peak_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETER  # am, oscillation amplitude
+amplitude_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETER  # am, oscillation amplitude
 frequency = constants.EWAVE_SPEED / constants.EWAVE_LENGTH  # Hz, energy-wave frequency
 
 
@@ -58,11 +58,11 @@ def oscillate_vertex(
         phase = float(v) * ti.math.pi / 4.0
 
         # Position: x(t) = x_eq + A·cos(ωt + φ)·direction
-        displacement = amp_local_peak_am * ti.cos(omega_slo * t + phase)
+        displacement = amplitude_am * ti.cos(omega_slo * t + phase)
         position[idx] = vertex_equilibrium[v] + displacement * direction
 
         # Velocity: v(t) = -A·ω·sin(ωt + φ)·direction (derivative of position)
-        velocity_magnitude = -amp_local_peak_am * omega_slo * ti.sin(omega_slo * t + phase)
+        velocity_magnitude = -amplitude_am * omega_slo * ti.sin(omega_slo * t + phase)
         velocity[idx] = velocity_magnitude * direction
 
 

--- a/openwave/xperiments/_archives/spring_mass/wave_engine_leapfrog.py
+++ b/openwave/xperiments/_archives/spring_mass/wave_engine_leapfrog.py
@@ -12,7 +12,7 @@ from openwave.common import constants
 # ================================================================
 # Energy-Wave Oscillation Parameters
 # ================================================================
-amp_local_peak_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETER  # am, oscillation amplitude
+amplitude_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETER  # am, oscillation amplitude
 frequency = constants.EWAVE_SPEED / constants.EWAVE_LENGTH  # Hz, energy-wave frequency
 
 
@@ -58,11 +58,11 @@ def oscillate_vertex(
         phase = float(v) * ti.math.pi / 4.0
 
         # Position: x(t) = x_eq + A·cos(ωt + φ)·direction
-        displacement = amp_local_peak_am * ti.cos(omega_slo * t + phase)
+        displacement = amplitude_am * ti.cos(omega_slo * t + phase)
         position[idx] = vertex_equilibrium[v] + displacement * direction
 
         # Velocity: v(t) = -A·ω·sin(ωt + φ)·direction (derivative of position)
-        velocity_magnitude = -amp_local_peak_am * omega_slo * ti.sin(omega_slo * t + phase)
+        velocity_magnitude = -amplitude_am * omega_slo * ti.sin(omega_slo * t + phase)
         velocity[idx] = velocity_magnitude * direction
 
 

--- a/openwave/xperiments/_archives/spring_mass/wave_engine_xpbd.py
+++ b/openwave/xperiments/_archives/spring_mass/wave_engine_xpbd.py
@@ -23,7 +23,7 @@ from openwave.common import constants
 # ================================================================
 # Energy-Wave Oscillation Parameters
 # ================================================================
-amp_local_peak_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETER  # am, oscillation amplitude
+amplitude_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETER  # am, oscillation amplitude
 frequency = constants.EWAVE_SPEED / constants.EWAVE_LENGTH  # Hz, energy-wave frequency
 
 
@@ -74,13 +74,11 @@ def oscillate_vertex(
 
         # Position: x(t) = x_eq + A·cos(ωt + φ)·direction
         # Apply amp_boost for visibility in scaled-up lattices
-        displacement = amp_local_peak_am * amp_boost * ti.cos(omega_slo * t + phase)
+        displacement = amplitude_am * amp_boost * ti.cos(omega_slo * t + phase)
         position[idx] = vertex_equilibrium[v] + displacement * direction
 
         # Velocity: v(t) = -A·ω·sin(ωt + φ)·direction (derivative of position)
-        velocity_magnitude = (
-            -amp_local_peak_am * amp_boost * omega_slo * ti.sin(omega_slo * t + phase)
-        )
+        velocity_magnitude = -amplitude_am * amp_boost * omega_slo * ti.sin(omega_slo * t + phase)
         velocity[idx] = velocity_magnitude * direction
 
 
@@ -570,7 +568,7 @@ def measure_wave_speed(
         slo_mo: Slow motion factor (to convert simulation time to real time)
 
     Returns:
-        dict with 'max_distance_am', 'amp_local_peak_am', 'threshold_am'
+        dict with 'max_distance_am', 'amplitude_am', 'threshold_am'
     """
     # Allocate displacement field if needed
     if not hasattr(lattice, "displacement_mag_am"):
@@ -610,7 +608,7 @@ def measure_wave_speed(
 
     return {
         "max_distance_am": max_distance,
-        "amp_local_peak_am": max_displacement,
+        "amplitude_am": max_displacement,
         "threshold_am": threshold,
     }
 

--- a/openwave/xperiments/m1_granule_motion/spacetime_medium.py
+++ b/openwave/xperiments/m1_granule_motion/spacetime_medium.py
@@ -156,8 +156,8 @@ class BCCLattice:
         self.position_am = ti.Vector.field(3, dtype=ti.f32, shape=self.granule_count)
         self.position_screen = ti.Vector.field(3, dtype=ti.f32, shape=self.granule_count)
         self.equilibrium_am = ti.Vector.field(3, dtype=ti.f32, shape=self.granule_count)  # rest
-        self.amp_local_peak_am = ti.field(dtype=ti.f32, shape=self.granule_count)  # wave amplitude
         self.velocity_am = ti.Vector.field(3, dtype=ti.f32, shape=self.granule_count)
+        self.amp_local_peak_am = ti.field(dtype=ti.f32, shape=self.granule_count)  # wave amplitude
         self.granule_type = ti.field(dtype=ti.i32, shape=self.granule_count)
         self.front_octant = ti.field(dtype=ti.i32, shape=self.granule_count)
         self.granule_type_color = ti.Vector.field(3, dtype=ti.f32, shape=self.granule_count)
@@ -652,8 +652,8 @@ class SCLattice:
         self.position_am = ti.Vector.field(3, dtype=ti.f32, shape=self.granule_count)
         self.position_screen = ti.Vector.field(3, dtype=ti.f32, shape=self.granule_count)
         self.equilibrium_am = ti.Vector.field(3, dtype=ti.f32, shape=self.granule_count)  # rest
-        self.amp_local_peak_am = ti.field(dtype=ti.f32, shape=self.granule_count)  # wave amplitude
         self.velocity_am = ti.Vector.field(3, dtype=ti.f32, shape=self.granule_count)
+        self.amp_local_peak_am = ti.field(dtype=ti.f32, shape=self.granule_count)  # wave amplitude
         self.granule_type = ti.field(dtype=ti.i32, shape=self.granule_count)
         self.front_octant = ti.field(dtype=ti.i32, shape=self.granule_count)
         self.granule_type_color = ti.Vector.field(3, dtype=ti.f32, shape=self.granule_count)

--- a/openwave/xperiments/m1_granule_motion/wave_engine.py
+++ b/openwave/xperiments/m1_granule_motion/wave_engine.py
@@ -18,7 +18,7 @@ from openwave.common import colormap, constants, equations, utils
 # ================================================================
 base_amplitude_am = constants.EWAVE_AMPLITUDE / constants.ATTOMETER  # in am
 base_frequency = constants.EWAVE_SPEED / constants.EWAVE_LENGTH  # in Hz
-wavelength_am = constants.EWAVE_LENGTH / constants.ATTOMETER  # in am
+base_wavelength_am = constants.EWAVE_LENGTH / constants.ATTOMETER  # in am
 
 # ================================================================
 # Energy-Wave Source Data (Global Fields)
@@ -107,7 +107,7 @@ def build_source_vectors(num_sources, sources_position, sources_offset_deg, latt
         ]
     )
 
-    # Precompute 8 universe vertices (corners of bounding box) for in-wave computation
+    # Precompute 8 universe vertices (corners of bounding box) for base-wave computation
     universe_vertices_am = ti.Vector.field(3, dtype=ti.f32, shape=8)
     lx = lattice.universe_size_am[0]
     ly = lattice.universe_size_am[1]
@@ -249,18 +249,18 @@ def oscillate_granules(
     omega_slo = 2.0 * ti.math.pi * frequency_slo  # angular frequency (rad/s)
 
     # Compute angular wave number (k = 2π/λ) for spatial phase variation
-    k_am = 2.0 * ti.math.pi / wavelength_am  # radians per attometer
+    k_am = 2.0 * ti.math.pi / base_wavelength_am  # radians per attometer
 
     # Reference radius for amplitude normalization (r₀ = 1λ)
     # Prevents singularity at r=0 and sets 1/r falloff reference point
-    r_reference_am = wavelength_am
+    r_reference_am = base_wavelength_am
 
     # Process all granules in parallel (outermost loop = GPU parallelization)
     for granule_idx in range(position_am.shape[0]):
         # Temporal phase: φ = ω·t, oscillatory in time
         temporal_phase = omega_slo * elapsed_t
 
-        # Accumulate in-wave contributions from all 8 universe vertices
+        # Accumulate base-wave contributions from all 8 universe vertices
         base_wave_psi = ti.Vector([0.0, 0.0, 0.0])
         for v in range(8):  # Loop through each universe vertex
             # Vector from vertex to granule equilibrium position
@@ -271,7 +271,7 @@ def oscillate_granules(
                 base_wave_toggle
                 * base_amplitude_am
                 * amp_boost
-                / 8  # incoming wave do not superpose, split per vertex for energy conservation
+                / 8  # base-wave do not superpose, split per vertex for energy conservation
                 * ti.cos(temporal_phase - k_am * r_mag)
             ) * (r_vec / r_mag)
 

--- a/openwave/xperiments/m1_granule_motion/wave_engine.py
+++ b/openwave/xperiments/m1_granule_motion/wave_engine.py
@@ -266,13 +266,13 @@ def oscillate_granules(
             # Vector from vertex to granule equilibrium position
             r_vec = equilibrium_am[granule_idx] - universe_vertices_am[v]
             r_mag = r_vec.norm()
-            # A·cos(ωt + kr)·direction, positive for inward propagation, full amp
+            # A·cos(ωt - kr)·direction, negative for outward propagation, full amp
             base_wave_psi += (
                 base_wave_toggle
                 * base_amplitude_am
                 * amp_boost
                 / 8  # incoming wave do not superpose, split per vertex for energy conservation
-                * ti.cos(temporal_phase + k_am * r_mag)
+                * ti.cos(temporal_phase - k_am * r_mag)
             ) * (r_vec / r_mag)
 
         # Initialize accumulation variables for wave superposition

--- a/openwave/xperiments/m1_granule_motion/xparameters/medium_disturbance.py
+++ b/openwave/xperiments/m1_granule_motion/xparameters/medium_disturbance.py
@@ -40,7 +40,7 @@ SOURCES_PHASE_DEG = [0] * NUM_SOURCES
 
 XPARAMETERS = {
     "meta": {
-        "X_NAME": "Granule Motion",
+        "X_NAME": "Medium Disturbance",
         "DESCRIPTION": "Detailed simulation of granule motion influenced by standing wave patterns from multiple sources arranged in a circle. Demonstrates complex interference patterns and 2.5D visualization.",
     },
     "camera": {
@@ -73,13 +73,13 @@ XPARAMETERS = {
         "BLOCK_SLICE": False,  # Block-slicing toggle
         "SHOW_SOURCES": True,  # Toggle to show/hide wave source markers
         "RADIUS_FACTOR": 0.35,  # Granule radius scaling factor
-        "FREQ_BOOST": 10.0,  # Frequency boost multiplier
+        "FREQ_BOOST": 2.0,  # Frequency boost multiplier
         "AMP_BOOST": 3.0,  # Amplitude boost multiplier, legacy = 0.1
         "PAUSED": False,  # Pause/Start simulation toggle
     },
     "color_defaults": {
         "COLOR_THEME": "OCEAN",  # Choose color theme for rendering (OCEAN, DESERT, FOREST)
-        "WAVE_MENU": 2,  # Check _launcher.py display_wave_menu() for wave_menu indexing
+        "WAVE_MENU": 4,  # Check _launcher.py display_wave_menu() for wave_menu indexing
     },
     "analytics": {
         "INSTRUMENTATION": False,  # Toggle data collection (speed & wavelength measurements)

--- a/openwave/xperiments/m3_wolff_lafreniere/wave_engine.py
+++ b/openwave/xperiments/m3_wolff_lafreniere/wave_engine.py
@@ -99,7 +99,7 @@ def propagate_wave(
             if wave_center.active[wc_idx] == 0:
                 continue
 
-            # Compute radial distance from wave source (in grid indices)
+            # Compute radial distance from wave center (in grid indices)
             r_grid = ti.sqrt(
                 (i - wave_center.position_grid[wc_idx][0]) ** 2
                 + (j - wave_center.position_grid[wc_idx][1]) ** 2

--- a/openwave/xperiments/m4_vector_wave/_launcher.py
+++ b/openwave/xperiments/m4_vector_wave/_launcher.py
@@ -275,40 +275,22 @@ def display_controls(state):
 def display_wave_menu(state):
     """Display wave properties selection menu."""
     with render.gui.sub_window("WAVE MENU", 0.00, 0.71, 0.15, 0.17) as sub:
-        if sub.checkbox("Displacement (Longitudinal)", state.WAVE_MENU == 1):
+        if sub.checkbox("Displacement", state.WAVE_MENU == 1):
             state.WAVE_MENU = 1
-        if sub.checkbox("Displacement (Transverse)", state.WAVE_MENU == 2):
+        if sub.checkbox("Amplitude (RMS)", state.WAVE_MENU == 2):
             state.WAVE_MENU = 2
-        if sub.checkbox("Amplitude (Longitudinal)", state.WAVE_MENU == 3):
+        if sub.checkbox("Frequency (L&T)", state.WAVE_MENU == 3):
             state.WAVE_MENU = 3
-        if sub.checkbox("Envelope (Longitudinal)", state.WAVE_MENU == 4):
-            state.WAVE_MENU = 4
-        if sub.checkbox("Frequency (L&T)", state.WAVE_MENU == 5):
-            state.WAVE_MENU = 5
         # Display gradient palette with 2× average range for headroom (allows peak visualization)
-        if state.WAVE_MENU == 1:  # Displacement (Longitudinal) on greenyellow gradient
-            render.canvas.triangles(gy_palette_vertices, per_vertex_color=gy_palette_colors)
+        if state.WAVE_MENU == 1:  # Displacement on orange gradient
+            render.canvas.triangles(og_palette_vertices, per_vertex_color=og_palette_colors)
             with render.gui.sub_window("displacement", 0.00, 0.65, 0.08, 0.06) as sub:
-                sub.text(
-                    f"{-state.amp_global_rms*2/state.wave_field.scale_factor:.0e}  {state.amp_global_rms*2/state.wave_field.scale_factor:.0e}m"
-                )
-        if state.WAVE_MENU == 2:  # Displacement (Transverse) on bluered gradient
-            render.canvas.triangles(br_palette_vertices, per_vertex_color=br_palette_colors)
-            with render.gui.sub_window("displacement", 0.00, 0.65, 0.08, 0.06) as sub:
-                sub.text(
-                    f"{-state.amp_global_rms*2/state.wave_field.scale_factor:.0e}  {state.amp_global_rms*2/state.wave_field.scale_factor:.0e}m"
-                )
-        if state.WAVE_MENU == 3:  # Amplitude (Longitudinal) on viridis gradient
-            render.canvas.triangles(vr_palette_vertices, per_vertex_color=vr_palette_colors)
-            with render.gui.sub_window("amplitude", 0.00, 0.65, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.amp_global_rms*2/state.wave_field.scale_factor:.0e}m")
-        if state.WAVE_MENU == 4:  # Envelope (Longitudinal) on greenyellow gradient
-            render.canvas.triangles(gy_palette_vertices, per_vertex_color=gy_palette_colors)
-            with render.gui.sub_window("envelope", 0.00, 0.65, 0.08, 0.06) as sub:
-                sub.text(
-                    f"{-state.amp_global_rms*2/state.wave_field.scale_factor:.0e}  {state.amp_global_rms*2/state.wave_field.scale_factor:.0e}m"
-                )
-        if state.WAVE_MENU == 5:  # Frequency (L&T) on blueprint gradient
+        if state.WAVE_MENU == 2:  # Amplitude (RMS) on ironbow gradient
+            render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
+            with render.gui.sub_window("displacement", 0.00, 0.65, 0.08, 0.06) as sub:
+                sub.text(f"0       {state.amp_global_rms*2/state.wave_field.scale_factor:.0e}m")
+        if state.WAVE_MENU == 3:  # Frequency (L&T) on blueprint gradient
             render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
             with render.gui.sub_window("frequency", 0.00, 0.65, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.freq_global_avg*2*state.wave_field.scale_factor:.0e}Hz")
@@ -380,22 +362,14 @@ def initialize_xperiment(state):
     Args:
         state: SimulationState instance with xperiment parameters
     """
-    global gy_palette_vertices, gy_palette_colors
-    global br_palette_vertices, br_palette_colors
-    global vr_palette_vertices, vr_palette_colors
+    global og_palette_vertices, og_palette_colors
     global ib_palette_vertices, ib_palette_colors
     global bp_palette_vertices, bp_palette_colors
     global level_bar_vertices
 
     # Initialize color palette scales for gradient rendering and level indicator
-    gy_palette_vertices, gy_palette_colors = colormap.get_palette_scale(
-        colormap.greenyellow, 0.00, 0.64, 0.079, 0.01
-    )
-    br_palette_vertices, br_palette_colors = colormap.get_palette_scale(
-        colormap.bluered, 0.00, 0.64, 0.079, 0.01
-    )
-    vr_palette_vertices, vr_palette_colors = colormap.get_palette_scale(
-        colormap.viridis, 0.00, 0.64, 0.079, 0.01
+    og_palette_vertices, og_palette_colors = colormap.get_palette_scale(
+        colormap.orange, 0.00, 0.64, 0.079, 0.01
     )
     ib_palette_vertices, ib_palette_colors = colormap.get_palette_scale(
         colormap.ironbow, 0.00, 0.64, 0.079, 0.01

--- a/openwave/xperiments/m4_vector_wave/_launcher.py
+++ b/openwave/xperiments/m4_vector_wave/_launcher.py
@@ -112,8 +112,7 @@ class SimulationState:
         self.elapsed_t_rs = 0.0
         self.clock_start_time = time.time()
         self.frame = 1
-        self.ampL_global_rms = constants.EWAVE_AMPLITUDE
-        self.ampT_global_rms = 0.0
+        self.amp_global_rms = constants.EWAVE_AMPLITUDE
         self.freq_global_avg = constants.EWAVE_FREQUENCY
         self.wavelength_global_avg = constants.EWAVE_LENGTH
 
@@ -214,8 +213,7 @@ class SimulationState:
         self.elapsed_t_rs = 0.0
         self.clock_start_time = time.time()
         self.frame = 1
-        self.ampL_global_rms = constants.EWAVE_AMPLITUDE
-        self.ampT_global_rms = 0.0
+        self.amp_global_rms = constants.EWAVE_AMPLITUDE
         self.freq_global_avg = constants.EWAVE_FREQUENCY
         self.wavelength_global_avg = constants.EWAVE_LENGTH
         self.initialize_grid()
@@ -292,23 +290,23 @@ def display_wave_menu(state):
             render.canvas.triangles(gy_palette_vertices, per_vertex_color=gy_palette_colors)
             with render.gui.sub_window("displacement", 0.00, 0.65, 0.08, 0.06) as sub:
                 sub.text(
-                    f"{-state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}m"
+                    f"{-state.amp_global_rms*2/state.wave_field.scale_factor:.0e}  {state.amp_global_rms*2/state.wave_field.scale_factor:.0e}m"
                 )
         if state.WAVE_MENU == 2:  # Displacement (Transverse) on bluered gradient
             render.canvas.triangles(br_palette_vertices, per_vertex_color=br_palette_colors)
             with render.gui.sub_window("displacement", 0.00, 0.65, 0.08, 0.06) as sub:
                 sub.text(
-                    f"{-state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}m"
+                    f"{-state.amp_global_rms*2/state.wave_field.scale_factor:.0e}  {state.amp_global_rms*2/state.wave_field.scale_factor:.0e}m"
                 )
         if state.WAVE_MENU == 3:  # Amplitude (Longitudinal) on viridis gradient
             render.canvas.triangles(vr_palette_vertices, per_vertex_color=vr_palette_colors)
             with render.gui.sub_window("amplitude", 0.00, 0.65, 0.08, 0.06) as sub:
-                sub.text(f"0       {state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}m")
+                sub.text(f"0       {state.amp_global_rms*2/state.wave_field.scale_factor:.0e}m")
         if state.WAVE_MENU == 4:  # Envelope (Longitudinal) on greenyellow gradient
             render.canvas.triangles(gy_palette_vertices, per_vertex_color=gy_palette_colors)
             with render.gui.sub_window("envelope", 0.00, 0.65, 0.08, 0.06) as sub:
                 sub.text(
-                    f"{-state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}m"
+                    f"{-state.amp_global_rms*2/state.wave_field.scale_factor:.0e}  {state.amp_global_rms*2/state.wave_field.scale_factor:.0e}m"
                 )
         if state.WAVE_MENU == 5:  # Frequency (L&T) on blueprint gradient
             render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
@@ -359,8 +357,7 @@ def display_data_dashboard(state):
             sub.text(f"*** WARNING: Undersampling! ***", color=(1.0, 0.0, 0.0))
 
         sub.text("\n--- ENERGY-WAVE ---", color=colormap.LIGHT_BLUE[1])
-        sub.text(f"Amp Longitudinal: {state.ampL_global_rms/state.wave_field.scale_factor:.1e} m")
-        sub.text(f"Amp Transverse: {state.ampT_global_rms/state.wave_field.scale_factor:.1e} m")
+        sub.text(f"Amplitude: {state.amp_global_rms/state.wave_field.scale_factor:.1e} m")
         sub.text(f"Frequency: {state.freq_global_avg*state.wave_field.scale_factor:.1e} Hz")
         sub.text(f"Wavelength: {state.wavelength_global_avg/state.wave_field.scale_factor:.1e} m")
 
@@ -443,8 +440,7 @@ def compute_wave_oscillation(state):
     # Frame skip reduces GPU->CPU transfer overhead
     if state.frame % 60 == 0 or state.frame == 10:
         ewave.sample_avg_trackers(state.wave_field, state.trackers)
-    state.ampL_global_rms = state.trackers.ampL_global_rms_am[None] * constants.ATTOMETER  # in m
-    state.ampT_global_rms = state.trackers.ampT_global_rms_am[None] * constants.ATTOMETER  # in m
+    state.amp_global_rms = state.trackers.amp_global_rms_am[None] * constants.ATTOMETER  # in m
     state.freq_global_avg = state.trackers.freq_global_avg_rHz[None] / constants.RONTOSECOND
     state.wavelength_global_avg = constants.EWAVE_SPEED / (
         state.freq_global_avg or 1

--- a/openwave/xperiments/m4_vector_wave/force_motion.py
+++ b/openwave/xperiments/m4_vector_wave/force_motion.py
@@ -187,31 +187,29 @@ def compute_force_vector(
             and k < nz - sample_radius
         ):
             # ================================================================
-            # Use ENVELOPE field for force calculation (smooth 1/r, no oscillations)
-            # Envelope = sum of (charge_sign * A₀/r) from each source
-            # Gives EWT-predicted 1/r² force law
+            # Use AMPLITUDE field for force calculation
             # ================================================================
-            # Sample envelope at center
-            A_center_am = trackers.ampL_local_envelope_am[i, j, k]
+            # Sample amplitude at center
+            A_center_am = trackers.amp_local_rms_am[i, j, k]
 
             # Central difference gradient with larger sampling radius:
             # grad(A) = (A[+R] - A[-R]) / (2*R*dx)
             # This averages the gradient over a larger region
             sample_dist_am = 2.0 * sample_radius * dx_am
 
-            # X gradient from envelope field
-            A_xp_am = trackers.ampL_local_envelope_am[i + sample_radius, j, k]
-            A_xm_am = trackers.ampL_local_envelope_am[i - sample_radius, j, k]
+            # X gradient from amplitude field
+            A_xp_am = trackers.amp_local_rms_am[i + sample_radius, j, k]
+            A_xm_am = trackers.amp_local_rms_am[i - sample_radius, j, k]
             dA_dx = (A_xp_am - A_xm_am) / sample_dist_am
 
-            # Y gradient from envelope field
-            A_yp_am = trackers.ampL_local_envelope_am[i, j + sample_radius, k]
-            A_ym_am = trackers.ampL_local_envelope_am[i, j - sample_radius, k]
+            # Y gradient from amplitude field
+            A_yp_am = trackers.amp_local_rms_am[i, j + sample_radius, k]
+            A_ym_am = trackers.amp_local_rms_am[i, j - sample_radius, k]
             dA_dy = (A_yp_am - A_ym_am) / sample_dist_am
 
-            # Z gradient from envelope field
-            A_zp_am = trackers.ampL_local_envelope_am[i, j, k + sample_radius]
-            A_zm_am = trackers.ampL_local_envelope_am[i, j, k - sample_radius]
+            # Z gradient from amplitude field
+            A_zp_am = trackers.amp_local_rms_am[i, j, k + sample_radius]
+            A_zm_am = trackers.amp_local_rms_am[i, j, k - sample_radius]
             dA_dz = (A_zp_am - A_zm_am) / sample_dist_am
 
             # DEBUG: Store intermediate values
@@ -503,8 +501,7 @@ def debug_force_analysis(wave_field, trackers, wave_center, frame: int = 0):
             print(f"{'─'*60}")
 
     # Get numpy arrays from taichi fields
-    # Using envelope field (smooth 1/r) for force calculation instead of RMS
-    envelope = trackers.ampL_local_envelope_am.to_numpy()
+    amplitude = trackers.amp_local_rms_am.to_numpy()
     positions = wave_center.position_grid.to_numpy()
     forces = wave_center.force.to_numpy()
     velocities = wave_center.velocity_amrs.to_numpy()
@@ -560,16 +557,16 @@ def debug_force_analysis(wave_field, trackers, wave_center, frame: int = 0):
             print(f"  WARNING: Near z boundary!")
             continue
 
-        # Envelope values at sampling radius distance (smooth 1/r field)
-        A_center = envelope[i, j, k] * ATTOMETER
-        A_xp = envelope[i + sample_radius, j, k] * ATTOMETER
-        A_xm = envelope[i - sample_radius, j, k] * ATTOMETER
-        A_yp = envelope[i, j + sample_radius, k] * ATTOMETER
-        A_ym = envelope[i, j - sample_radius, k] * ATTOMETER
-        A_zp = envelope[i, j, k + sample_radius] * ATTOMETER
-        A_zm = envelope[i, j, k - sample_radius] * ATTOMETER
+        # Amplitude values at sampling radius distance
+        A_center = amplitude[i, j, k] * ATTOMETER
+        A_xp = amplitude[i + sample_radius, j, k] * ATTOMETER
+        A_xm = amplitude[i - sample_radius, j, k] * ATTOMETER
+        A_yp = amplitude[i, j + sample_radius, k] * ATTOMETER
+        A_ym = amplitude[i, j - sample_radius, k] * ATTOMETER
+        A_zp = amplitude[i, j, k + sample_radius] * ATTOMETER
+        A_zm = amplitude[i, j, k - sample_radius] * ATTOMETER
 
-        print(f"  Envelope at center: {A_center:.3e} m ({envelope[i,j,k]:.3f} am)")
+        print(f"  Amplitude at center: {A_center:.3e} m ({amplitude[i,j,k]:.3f} am)")
         print(f"  Amplitude x±{sample_radius}: [{A_xm:.3e}, {A_xp:.3e}] m")
 
         # Gradients with larger sampling distance

--- a/openwave/xperiments/m4_vector_wave/instrumentation.py
+++ b/openwave/xperiments/m4_vector_wave/instrumentation.py
@@ -120,9 +120,7 @@ def log_timestep_data(timestep: int, wave_field, trackers) -> None:
 
     # Capture probe values
     displacement_am = wave_field.displacement_am[px, py, pz] / wave_field.scale_factor
-    velocity_am = wave_field.velocity_am[px, py, pz] / wave_field.scale_factor
     amp_local_rms_am = trackers.amp_local_rms_am[px, py, pz] / wave_field.scale_factor
-    amp_local_peak_am = trackers.amp_local_peak_am[px, py, pz] / wave_field.scale_factor
     freq_local_cross_rHz = trackers.freq_local_cross_rHz[px, py, pz] * wave_field.scale_factor
 
     # Add to buffer
@@ -130,9 +128,7 @@ def log_timestep_data(timestep: int, wave_field, trackers) -> None:
         [
             timestep,
             displacement_am,
-            velocity_am,
             amp_local_rms_am,
-            amp_local_peak_am,
             freq_local_cross_rHz,
         ]
     )
@@ -160,9 +156,7 @@ def _flush_timestep_buffer() -> None:
                 [
                     "timestep",
                     "displacement_am",
-                    "velocity_am",
                     "amp_local_rms_am",
-                    "amp_local_peak_am",
                     "freq_local_cross_rHz",
                 ]
             )
@@ -178,8 +172,6 @@ def _flush_timestep_buffer() -> None:
                     f"{row[1]:.6f}",
                     f"{row[2]:.6f}",
                     f"{row[3]:.6f}",
-                    f"{row[4]:.6f}",
-                    f"{row[5]:.6f}",
                 ]
             )
 
@@ -200,9 +192,7 @@ def _read_timestep_data():
     data = {
         "timesteps": [],
         "displacements": [],
-        "displacements_T": [],
-        "amplitudes_L": [],
-        "amplitudes_T": [],
+        "amplitudes": [],
         "frequencies": [],
     }
 
@@ -211,9 +201,7 @@ def _read_timestep_data():
         for row in reader:
             data["timesteps"].append(int(row["timestep"]))
             data["displacements"].append(float(row["displacement_am"]))
-            data["displacements_T"].append(float(row["velocity_am"]))
-            data["amplitudes_L"].append(float(row["amp_local_rms_am"]))
-            data["amplitudes_T"].append(float(row["amp_local_peak_am"]))
+            data["amplitudes"].append(float(row["amp_local_rms_am"]))
             data["frequencies"].append(float(row["freq_local_cross_rHz"]))
 
     return data
@@ -241,7 +229,7 @@ def plot_probe_values():
     )
     plt.plot(
         data["timesteps"],
-        data["amplitudes_L"],
+        data["amplitudes"],
         color=colormap.viridis_palette[3][1],
         linewidth=2,
         label="RMS AMPLITUDE (am)",
@@ -271,7 +259,7 @@ def plot_probe_values():
     )
     plt.plot(
         data["timesteps"],
-        data["amplitudes_T"],
+        data["amplitudes"],
         color=colormap.ironbow_palette[3][1],
         linewidth=2,
         label="RMS AMPLITUDE (am)",

--- a/openwave/xperiments/m4_vector_wave/instrumentation.py
+++ b/openwave/xperiments/m4_vector_wave/instrumentation.py
@@ -44,13 +44,13 @@ def plot_probe_wave_profile(wave_field):
 
     # Extract displacement along x-axis at center (y, z)
     x_indices = np.arange(wave_field.nx)
-    displacements_L = np.zeros(wave_field.nx)
+    displacements = np.zeros(wave_field.nx)
     displacements_T = np.zeros(wave_field.nx)
 
     # Sample longitudinal displacement values
     for i in range(wave_field.nx):
-        displacements_L[i] = wave_field.psiL_am[i, py, pz]
-        displacements_T[i] = wave_field.psiT_am[i, py, pz]
+        displacements[i] = wave_field.displacement_am[i, py, pz]
+        displacements_T[i] = wave_field.velocity_am[i, py, pz]
 
     # Calculate distance from center in grid indices
     distances = x_indices - px
@@ -64,7 +64,7 @@ def plot_probe_wave_profile(wave_field):
     plt.subplot(1, 2, 1)
     plt.plot(
         distances,
-        displacements_L,
+        displacements,
         color=colormap.viridis_palette[2][1],
         linewidth=4,
         label="LONGITUDINAL",
@@ -119,15 +119,22 @@ def log_timestep_data(timestep: int, wave_field, trackers) -> None:
     px, py, pz = wave_field.nx // 2, wave_field.ny // 2, wave_field.nz // 2
 
     # Capture probe values
-    psiL_am = wave_field.psiL_am[px, py, pz] / wave_field.scale_factor
-    psiT_am = wave_field.psiT_am[px, py, pz] / wave_field.scale_factor
-    ampL_local_rms_am = trackers.ampL_local_rms_am[px, py, pz] / wave_field.scale_factor
-    ampT_local_rms_am = trackers.ampT_local_rms_am[px, py, pz] / wave_field.scale_factor
+    displacement_am = wave_field.displacement_am[px, py, pz] / wave_field.scale_factor
+    velocity_am = wave_field.velocity_am[px, py, pz] / wave_field.scale_factor
+    amp_local_rms_am = trackers.amp_local_rms_am[px, py, pz] / wave_field.scale_factor
+    amp_local_peak_am = trackers.amp_local_peak_am[px, py, pz] / wave_field.scale_factor
     freq_local_cross_rHz = trackers.freq_local_cross_rHz[px, py, pz] * wave_field.scale_factor
 
     # Add to buffer
     _timestep_buffer.append(
-        [timestep, psiL_am, psiT_am, ampL_local_rms_am, ampT_local_rms_am, freq_local_cross_rHz]
+        [
+            timestep,
+            displacement_am,
+            velocity_am,
+            amp_local_rms_am,
+            amp_local_peak_am,
+            freq_local_cross_rHz,
+        ]
     )
 
     # Flush buffer periodically
@@ -152,10 +159,10 @@ def _flush_timestep_buffer() -> None:
             writer.writerow(
                 [
                     "timestep",
-                    "psiL_am",
-                    "psiT_am",
-                    "ampL_local_rms_am",
-                    "ampT_local_rms_am",
+                    "displacement_am",
+                    "velocity_am",
+                    "amp_local_rms_am",
+                    "amp_local_peak_am",
                     "freq_local_cross_rHz",
                 ]
             )
@@ -192,7 +199,7 @@ def _read_timestep_data():
 
     data = {
         "timesteps": [],
-        "displacements_L": [],
+        "displacements": [],
         "displacements_T": [],
         "amplitudes_L": [],
         "amplitudes_T": [],
@@ -203,10 +210,10 @@ def _read_timestep_data():
         reader = csv.DictReader(f)
         for row in reader:
             data["timesteps"].append(int(row["timestep"]))
-            data["displacements_L"].append(float(row["psiL_am"]))
-            data["displacements_T"].append(float(row["psiT_am"]))
-            data["amplitudes_L"].append(float(row["ampL_local_rms_am"]))
-            data["amplitudes_T"].append(float(row["ampT_local_rms_am"]))
+            data["displacements"].append(float(row["displacement_am"]))
+            data["displacements_T"].append(float(row["velocity_am"]))
+            data["amplitudes_L"].append(float(row["amp_local_rms_am"]))
+            data["amplitudes_T"].append(float(row["amp_local_peak_am"]))
             data["frequencies"].append(float(row["freq_local_cross_rHz"]))
 
     return data
@@ -227,7 +234,7 @@ def plot_probe_values():
     plt.subplot(3, 1, 1)
     plt.plot(
         data["timesteps"],
-        data["displacements_L"],
+        data["displacements"],
         color=colormap.viridis_palette[2][1],
         linewidth=2,
         label="DISPLACEMENT (am)",

--- a/openwave/xperiments/m4_vector_wave/spacetime_medium.py
+++ b/openwave/xperiments/m4_vector_wave/spacetime_medium.py
@@ -108,16 +108,16 @@ class WaveField:
         # ================================================================
         # DATA STRUCTURE & INITIALIZATION
         # ================================================================
-        # PROPAGATED SCALAR FIELDS (values in attometers for f32 precision)
+        # PROPAGATED VECTOR FIELDS (values in attometers for f32 precision)
         # This avoids catastrophic cancellation in difference calculations
         # Scales 1e-17 m values to ~10 am, well within f32 range
-        # Longitudinal wave scalar field (ψl)
-        self.psiL_am = ti.field(dtype=ti.f32, shape=self.grid_size)  # am, ψl at t
-        # Transverse wave scalar field (ψt)
-        self.psiT_am = ti.field(dtype=ti.f32, shape=self.grid_size)  # am, ψt at t
+        # Wave displacement vector field (ψ)
+        self.displacement_am = ti.Vector.field(3, dtype=ti.f32, shape=self.grid_size)  # am, ψ
+        # Wave velocity vector field (v = dψ/dt)
+        self.velocity_am = ti.Vector.field(3, dtype=ti.f32, shape=self.grid_size)  # am/s
 
         # TODO: Implement DERIVED SCALAR FIELDS
-        # wavelength, period, phase, energy, momentum
+        # WAVELENGTH, PERIOD, phase, energy, momentum
 
         # TODO: Implement DERIVED VECTOR FIELDS (directions normalized to unit vectors)
         # energy_flux, wave_direction, displacement_direction, wave_mode, wave_type
@@ -442,32 +442,21 @@ class Trackers:
             grid_size: Grid dimensions [nx, ny, nz] matching WaveField.
         """
         # TRACKED FIELDS ==================================================
-        # 2 polarities to track: longitudinal & transverse
         # LOCAL FIELDS per voxel
         # Amplitude tracks A via EMA of |ψ| and RMS calculation
         # Frequency tracks local oscillation rate via zero-crossing detection
-        self.ampL_local_rms_am = ti.field(dtype=ti.f32, shape=grid_size)  # am, longitudinal amp
-        # self.ampL_local_peak_am = ti.field(dtype=ti.f32, shape=grid_size)  # am, longitudinal peak
-        self.ampT_local_rms_am = ti.field(dtype=ti.f32, shape=grid_size)  # am, transverse amp
+        self.amp_local_rms_am = ti.field(dtype=ti.f32, shape=grid_size)  # am, rms amp
+        self.amp_local_peak_am = ti.field(dtype=ti.f32, shape=grid_size)  # am, peak amp
         self.last_crossing = ti.field(dtype=ti.f32, shape=grid_size)  # rs, last zero crossing
         self.freq_local_cross_rHz = ti.field(dtype=ti.f32, shape=grid_size)  # rHz, local frequency
 
-        # ENVELOPE FIELD for force calculation (smooth 1/r, no oscillations)
-        # Tracks signed amplitude envelope: sum of (charge_sign * A₀/r) from each source
-        # This gives smooth 1/r² force law matching EWT predictions
-        self.ampL_local_envelope_am = ti.field(dtype=ti.f32, shape=grid_size)  # am, signed
-
         # GLOBAL AVERAGES for visualization scaling & energy calculations
-        self.ampL_global_rms_am = ti.field(dtype=ti.f32, shape=())  # RMS all voxels
-        self.ampT_global_rms_am = ti.field(dtype=ti.f32, shape=())  # RMS all voxels
+        self.amp_global_rms_am = ti.field(dtype=ti.f32, shape=())  # RMS all voxels
         self.freq_global_avg_rHz = ti.field(dtype=ti.f32, shape=())  # avg frequency all voxels
 
         # Assign default values for visualization scaling
         # baseline to allow wave peaks to rise without color saturation
-        self.ampL_global_rms_am[None] = (
-            constants.EWAVE_AMPLITUDE / constants.ATTOMETER * scale_factor
-        )
-        self.ampT_global_rms_am[None] = (
+        self.amp_global_rms_am[None] = (
             constants.EWAVE_AMPLITUDE / constants.ATTOMETER * scale_factor
         )
         self.freq_global_avg_rHz[None] = (

--- a/openwave/xperiments/m4_vector_wave/spacetime_medium.py
+++ b/openwave/xperiments/m4_vector_wave/spacetime_medium.py
@@ -113,8 +113,9 @@ class WaveField:
         # Scales 1e-17 m values to ~10 am, well within f32 range
         # Wave displacement vector field (ψ)
         self.displacement_am = ti.Vector.field(3, dtype=ti.f32, shape=self.grid_size)  # am, ψ
+        # TODO: check need for velocity field = pressure / density
         # Wave velocity vector field (v = dψ/dt)
-        self.velocity_am = ti.Vector.field(3, dtype=ti.f32, shape=self.grid_size)  # am/s
+        # self.velocity_am = ti.Vector.field(3, dtype=ti.f32, shape=self.grid_size)  # am/s
 
         # TODO: Implement DERIVED SCALAR FIELDS
         # WAVELENGTH, PERIOD, phase, energy, momentum
@@ -446,7 +447,6 @@ class Trackers:
         # Amplitude tracks A via EMA of |ψ| and RMS calculation
         # Frequency tracks local oscillation rate via zero-crossing detection
         self.amp_local_rms_am = ti.field(dtype=ti.f32, shape=grid_size)  # am, rms amp
-        self.amp_local_peak_am = ti.field(dtype=ti.f32, shape=grid_size)  # am, peak amp
         self.last_crossing = ti.field(dtype=ti.f32, shape=grid_size)  # rs, last zero crossing
         self.freq_local_cross_rHz = ti.field(dtype=ti.f32, shape=grid_size)  # rHz, local frequency
 

--- a/openwave/xperiments/m4_vector_wave/wave_engine.py
+++ b/openwave/xperiments/m4_vector_wave/wave_engine.py
@@ -166,7 +166,7 @@ def compute_voxel_wave(
         if wave_center.active[wc_idx] == 0:
             continue
 
-        # Compute radial distance from wave source (in grid indices)
+        # Compute radial distance from wave center (in grid indices)
         r_grid = ti.sqrt(
             (i - wave_center.position_grid[wc_idx][0]) ** 2
             + (j - wave_center.position_grid[wc_idx][1]) ** 2

--- a/openwave/xperiments/m4_vector_wave/wave_engine.py
+++ b/openwave/xperiments/m4_vector_wave/wave_engine.py
@@ -138,7 +138,7 @@ def compute_voxel_wave(
         - Superposition of multiple wave centers supported
 
     Wave Trackers Updated:
-        - ampL_local_rms_am: RMS amplitude via EMA on ψ² (for energy/force gradients)
+        - amp_local_rms_am: RMS amplitude via EMA on ψ² (for energy/force gradients)
         - freq_local_cross_rHz: Frequency via zero-crossing detection with EMA smoothing
 
     See research/01_wolff_lafreniere.md for full derivation and theory.
@@ -154,9 +154,8 @@ def compute_voxel_wave(
         temporal_phase: Current temporal phase (ω·t)
     """
     # Reset before accumulation
-    prev_disp = wave_field.psiL_am[i, j, k]
-    wave_field.psiL_am[i, j, k] = 0.0
-    trackers.ampL_local_envelope_am[i, j, k] = 0.0
+    prev_disp = wave_field.displacement_am[i, j, k]
+    wave_field.displacement_am[i, j, k] = ti.Vector([0.0, 0.0, 0.0])
 
     # ================================================================
     # WAVE PROPAGATION: Update voxels using wave functions
@@ -207,186 +206,20 @@ def compute_voxel_wave(
             - ti.sin(temporal_phase + source_offset) * quadrature_term
         )
 
-        wave_field.psiL_am[i, j, k] += base_amplitude_am * wave_field.scale_factor * oscillator
-
-        # ================================================================
-        # ANALYTICAL SIGNED AMPLITUDE ENVELOPE
-        # TODO: Refine envelope model for force calculations
-        # TODO: Archive previous envelope models in research/
-        # Particles don't respond to 10²⁵ Hz oscillation frequencies.
-        # Particle's mass (inertia) acts as a low-pass filter, averaging out the rapid
-        # oscillations and responding only to the time-averaged energy-density (envelope).
-        # This envelope drives the force calculations, computed directly from wave functions.
-        # Applies superposition principle for multiple wave-centers, with signed charge sign.
-        # Avoids computationally expensive real-time tracking methods (RMS, zero-crossing).
-        # Also avoids instability from real-time EMS calculations of moving wave-centers.
-        # ================================================================
-        # Charge sign: cos(0)=+1 (eg: positron), cos(π)=-1 (eg: electron)
-        charge_sign = ti.cos(source_offset)
-
-        # TODO: Investigate why these constants work well for envelope
-        golden_ratio = (1 + ti.sqrt(5)) / 2  # ~1.6180339887
-        # weight_factor = 2.0 * ti.math.pi**2  # ~19.7392088, decay, damping
-        # offset_factor = 1 / (wavelength_grid * golden_ratio)
-
-        # # SPIKED 1/r ==================================
-        # if r_grid < 0.5:  # CENTER VOXEL only, avoids singularity
-        #     trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #         base_amplitude_am * wave_field.scale_factor * k_grid * 2
-        #     )  # finite value at center, k_grid / constant + offset
-        # else:  # FAR-FIELD: smooth 1/r decay
-        #     trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #         base_amplitude_am * wave_field.scale_factor * 1.0 / r_grid
-        #     )  # spiked 1/r decay
-
-        # # SMOOTHED 1/r ==================================
-        # trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #     base_amplitude_am
-        #     * wave_field.scale_factor
-        #     * k_grid
-        #     / ti.sqrt((k_grid * r_grid) ** 2 + 1)
-        # )  # smoothed 1/r decay
-
-        # # DAMPED SMOOTHED 1/r ==================================
-        # trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #     base_amplitude_am
-        #     * wave_field.scale_factor
-        #     * k_grid
-        #     / ti.sqrt((k_grid * r_grid) ** 2 + (2 * ti.math.pi) ** 2)
-        # )  # smoothed 1/r decay
-
-        # # WOLFF-ORIGINAL ENVELOPE ==================================
-        # if r_grid < 0.5:  # CENTER VOXEL only, avoids singularity
-        #     trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #         base_amplitude_am * wave_field.scale_factor * k_grid
-        #     )  # finite value at center, k_grid
-        # else:
-        #     trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #         base_amplitude_am * wave_field.scale_factor * ti.sin(k_grid * r_grid) / r_grid
-        #     )  # standing-smooth sin(kr)/r decay
-
-        # # WOLFF ONLY AT NEAR-FIELD ==================================
-        # if r_grid < 0.5:  # CENTER VOXEL only, avoids singularity
-        #     trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #         base_amplitude_am * wave_field.scale_factor * k_grid
-        #     )  # finite value at center, k_grid
-        # else:
-        #     if r_grid <= (2.5 * ti.math.pi / k_grid):  # NEAR-FIELD: time-dilated-1.25λ
-        #         trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #             base_amplitude_am
-        #             * wave_field.scale_factor
-        #             * ti.sin(k_grid * r_grid)
-        #             / r_grid
-        #         )  # standing-smooth sin(kr)/r decay
-        #     else:  # FAR-FIELD: smooth 1/r decay
-        #         trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #             base_amplitude_am * wave_field.scale_factor * 1.0 / r_grid
-        #         )  # smooth 1/r decay
-
-        # # ABS WOLFF ONLY NEAR-FIELD ==================================
-        # if r_grid < 0.5:  # CENTER VOXEL only, avoids singularity
-        #     trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #         base_amplitude_am * wave_field.scale_factor * k_grid
-        #     )  # finite value at center, k_grid
-        # else:
-        #     if r_grid <= (2.5 * ti.math.pi / k_grid):  # NEAR-FIELD: time-dilated-1.25λ
-        #         trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #             base_amplitude_am
-        #             * wave_field.scale_factor
-        #             * ti.abs(ti.sin(k_grid * r_grid))
-        #             / r_grid
-        #         )  # standing-smooth sin(kr)/r decay
-        #     else:  # FAR-FIELD: smooth 1/r decay
-        #         trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #             base_amplitude_am * wave_field.scale_factor * 1.0 / r_grid
-        #         )  # smooth 1/r decay
-
-        # # DAMPED+OFFSET WOLFF NEAR-FIELD ==================================
-        # if r_grid < 0.5:  # CENTER VOXEL only, avoids singularity
-        #     trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #         base_amplitude_am * wave_field.scale_factor * k_grid / (2 * ti.math.pi)
-        #         + 1 / (wavelength_grid * golden_ratio)
-        #     )  # finite value at center, k_grid / constant + offset
-        # else:
-        #     if r_grid <= (2.5 * ti.math.pi / k_grid):  # NEAR-FIELD: time-dilated-1.25λ
-        #         trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #             base_amplitude_am
-        #             * wave_field.scale_factor
-        #             * ti.sin(k_grid * r_grid)
-        #             / (r_grid * 2 * ti.math.pi)
-        #             + 1 / (wavelength_grid * golden_ratio)
-        #         )  # standing-smooth sin(kr)/(r·constant) + offset decay
-        #     else:  # FAR-FIELD: smooth 1/r decay
-        #         trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #             base_amplitude_am * wave_field.scale_factor * 1.0 / r_grid
-        #         )  # smooth 1/r decay
-
-        # # ABS DAMPED+OFFSET WOLFF NEAR-FIELD ==================================
-        # if r_grid < 0.5:  # CENTER VOXEL only, avoids singularity
-        #     trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #         base_amplitude_am * wave_field.scale_factor * k_grid / (2)
-        #         + 1 / (wavelength_grid * golden_ratio)
-        #     )  # finite value at center, k_grid / constant + offset
-        # else:
-        #     if r_grid <= (2.5 * ti.math.pi / k_grid):  # NEAR-FIELD: time-dilated-1.5λ
-        #         trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #             base_amplitude_am
-        #             * wave_field.scale_factor
-        #             * ti.abs(ti.sin(k_grid * r_grid))
-        #             / (r_grid * 2)
-        #             + 1 / (wavelength_grid * golden_ratio)
-        #         )  # standing-smooth sin(kr)/(r·constant) + offset decay
-        #     else:  # FAR-FIELD: smooth 1/r decay
-        #         trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #             base_amplitude_am * wave_field.scale_factor * 1.0 / r_grid
-        #         )  # smooth 1/r decay
-
-        # DAMPED + WOLFF ==================================
-        if r_grid < 0.5:  # CENTER VOXEL only, avoids singularity
-            trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-                base_amplitude_am * wave_field.scale_factor * (k_grid / (2 * ti.math.pi))
-            )  # finite value at center, k_grid / constant
-        else:
-            if r_grid <= (1.25 * 2 * ti.math.pi / k_grid):  # NEAR-FIELD: time-dilated-1.25λ
-                trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-                    base_amplitude_am
-                    * wave_field.scale_factor
-                    * (
-                        k_grid / ti.sqrt((k_grid * r_grid) ** 2 + (48))
-                        + ti.sin(k_grid * r_grid) / (r_grid * 4)
-                    )
-                )  # smoothed 1/r decay
-            else:  # FAR-FIELD: smooth 1/r decay
-                trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-                    base_amplitude_am * wave_field.scale_factor * 1.0 / r_grid
-                )  # smooth 1/r decay
-
-        # # FLAT NEAR-FIELD ==================================
-        # if r_grid < 0.5:  # CENTER VOXEL only, avoids singularity
-        #     trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #         base_amplitude_am * wave_field.scale_factor * k_grid / (2 * ti.math.pi * 1.25)
-        #     )  # finite value at center, k_grid
-        # else:
-        #     if r_grid <= (2.5 * ti.math.pi / k_grid):  # NEAR-FIELD: time-dilated-1.25λ
-        #         trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #             base_amplitude_am
-        #             * wave_field.scale_factor
-        #             * k_grid
-        #             / (2 * ti.math.pi * 1.25)
-        #         )  # standing-smooth sin(kr)/r decay
-        #     else:  # FAR-FIELD: smooth 1/r decay
-        #         trackers.ampL_local_envelope_am[i, j, k] += charge_sign * (
-        #             base_amplitude_am * wave_field.scale_factor * 1.0 / r_grid
-        #         )  # smooth 1/r decay
+        wave_field.displacement_am[i, j, k] += (
+            base_amplitude_am * wave_field.scale_factor * oscillator
+        )
 
     # Precision rounding to ensure wave cancellation
     # Critical for opposing phase sources (180°) that should annihilate
     # Floating-point: (+1.250001) + (-1.249999) = 0.000002 (imperfect cancel)
     # With rounding: (+1.2500) + (-1.2500) = 0.0 (perfect cancel)
     precision = ti.cast(1e4, ti.f32)  # round to 4 decimal places
-    wave_field.psiL_am[i, j, k] = ti.round(wave_field.psiL_am[i, j, k] * precision) / precision
+    wave_field.displacement_am[i, j, k] = (
+        ti.round(wave_field.displacement_am[i, j, k] * precision) / precision
+    )
 
-    curr_disp = wave_field.psiL_am[i, j, k]
+    curr_disp = wave_field.displacement_am[i, j, k]
 
     # ================================================================
     # WAVE-TRACKERS: Update amplitude and frequency trackers for visualization and forces
@@ -405,26 +238,18 @@ def compute_voxel_wave(
     # instantaneous displacement (inertia acts as low-pass filter at ~10²⁵ Hz)
     # EMA on ψ²: rms² = α * ψ² + (1 - α) * rms²_old, then rms = √(rms²)
     # α controls adaptation speed: higher = faster response, lower = smoother
-    # 2 polarities tracked: longitudinal & transverse
-    # Longitudinal RMS amplitude
-    disp2_L = wave_field.psiL_am[i, j, k] ** 2
-    current_rms2_L = trackers.ampL_local_rms_am[i, j, k] ** 2
-    alpha_rms_L = 0.005  # EMA smoothing factor for RMS tracking
-    new_rms2_L = alpha_rms_L * disp2_L + (1.0 - alpha_rms_L) * current_rms2_L
-    new_ampL = ti.sqrt(new_rms2_L)
+    # RMS amplitude
+    disp2 = wave_field.displacement_am[i, j, k] ** 2
+    current_rms2 = trackers.amp_local_rms_am[i, j, k] ** 2
+    alpha_rms = 0.005  # EMA smoothing factor for RMS tracking
+    new_rms2 = alpha_rms * disp2 + (1.0 - alpha_rms) * current_rms2
+    new_amp = ti.sqrt(new_rms2)
+
     # Unconditional decay clears trails from moving sources
     # Active regions counteract decay via EMA update from strong displacement
     # Stale regions (waves propagated away) decay to zero over time
     decay_factor = ti.cast(0.99, ti.f32)  # ~100 frames to ~37%, ~230 to ~10%
-    trackers.ampL_local_rms_am[i, j, k] = new_ampL * decay_factor
-
-    # Transverse RMS amplitude
-    disp2_T = wave_field.psiT_am[i, j, k] ** 2
-    current_rms2_T = trackers.ampT_local_rms_am[i, j, k] ** 2
-    alpha_rms_T = 0.005  # EMA smoothing factor for RMS tracking
-    new_rms2_T = alpha_rms_T * disp2_T + (1.0 - alpha_rms_T) * current_rms2_T
-    new_ampT = ti.sqrt(new_rms2_T)
-    trackers.ampT_local_rms_am[i, j, k] = new_ampT * decay_factor
+    trackers.amp_local_rms_am[i, j, k] = new_amp * decay_factor
 
     # TODO: review new frequency tracking method
     # FREQUENCY tracking, via zero-crossing detection with EMA smoothing
@@ -542,13 +367,13 @@ def propagate_wave_full(
 # ================================================================
 
 # Cached slice buffers (initialized on first call)
-_slice_xy_ampL = None
+_slice_xy_amp = None
 _slice_xy_ampT = None
 _slice_xy_freq = None
-_slice_xz_ampL = None
+_slice_xz_amp = None
 _slice_xz_ampT = None
 _slice_xz_freq = None
-_slice_yz_ampL = None
+_slice_yz_amp = None
 _slice_yz_ampT = None
 _slice_yz_freq = None
 
@@ -556,45 +381,45 @@ _slice_yz_freq = None
 @ti.kernel
 def _copy_slice_xy(
     trackers: ti.template(),  # type: ignore
-    slice_ampL: ti.template(),  # type: ignore
-    slice_ampT: ti.template(),  # type: ignore
+    slice_amp: ti.template(),  # type: ignore
+    slice_ampP: ti.template(),  # type: ignore
     slice_freq: ti.template(),  # type: ignore
     mid_z: ti.i32,  # type: ignore
 ):
     """Copy center XY slice (fixed z) to 2D buffer."""
-    for i, j in slice_ampL:
-        slice_ampL[i, j] = trackers.ampL_local_rms_am[i, j, mid_z]
-        slice_ampT[i, j] = trackers.ampT_local_rms_am[i, j, mid_z]
+    for i, j in slice_amp:
+        slice_amp[i, j] = trackers.amp_local_rms_am[i, j, mid_z]
+        slice_ampP[i, j] = trackers.amp_local_peak_am[i, j, mid_z]
         slice_freq[i, j] = trackers.freq_local_cross_rHz[i, j, mid_z]
 
 
 @ti.kernel
 def _copy_slice_xz(
     trackers: ti.template(),  # type: ignore
-    slice_ampL: ti.template(),  # type: ignore
-    slice_ampT: ti.template(),  # type: ignore
+    slice_amp: ti.template(),  # type: ignore
+    slice_ampP: ti.template(),  # type: ignore
     slice_freq: ti.template(),  # type: ignore
     mid_y: ti.i32,  # type: ignore
 ):
     """Copy center XZ slice (fixed y) to 2D buffer."""
-    for i, k in slice_ampL:
-        slice_ampL[i, k] = trackers.ampL_local_rms_am[i, mid_y, k]
-        slice_ampT[i, k] = trackers.ampT_local_rms_am[i, mid_y, k]
+    for i, k in slice_amp:
+        slice_amp[i, k] = trackers.amp_local_rms_am[i, mid_y, k]
+        slice_ampP[i, k] = trackers.amp_local_peak_am[i, mid_y, k]
         slice_freq[i, k] = trackers.freq_local_cross_rHz[i, mid_y, k]
 
 
 @ti.kernel
 def _copy_slice_yz(
     trackers: ti.template(),  # type: ignore
-    slice_ampL: ti.template(),  # type: ignore
-    slice_ampT: ti.template(),  # type: ignore
+    slice_amp: ti.template(),  # type: ignore
+    slice_ampP: ti.template(),  # type: ignore
     slice_freq: ti.template(),  # type: ignore
     mid_x: ti.i32,  # type: ignore
 ):
     """Copy center YZ slice (fixed x) to 2D buffer."""
-    for j, k in slice_ampL:
-        slice_ampL[j, k] = trackers.ampL_local_rms_am[mid_x, j, k]
-        slice_ampT[j, k] = trackers.ampT_local_rms_am[mid_x, j, k]
+    for j, k in slice_amp:
+        slice_amp[j, k] = trackers.amp_local_rms_am[mid_x, j, k]
+        slice_ampP[j, k] = trackers.amp_local_peak_am[mid_x, j, k]
         slice_freq[j, k] = trackers.freq_local_cross_rHz[mid_x, j, k]
 
 
@@ -615,51 +440,51 @@ def sample_avg_trackers(
         wave_field: WaveField instance containing grid dimensions
         trackers: WaveTrackers instance with per-voxel and average fields
     """
-    global _slice_xy_ampL, _slice_xy_ampT, _slice_xy_freq
-    global _slice_xz_ampL, _slice_xz_ampT, _slice_xz_freq
-    global _slice_yz_ampL, _slice_yz_ampT, _slice_yz_freq
+    global _slice_xy_amp, _slice_xy_ampP, _slice_xy_freq
+    global _slice_xz_amp, _slice_xz_ampP, _slice_xz_freq
+    global _slice_yz_amp, _slice_yz_ampP, _slice_yz_freq
 
     nx, ny, nz = wave_field.nx, wave_field.ny, wave_field.nz
 
     # Initialize slice buffers once
-    if _slice_xy_ampL is None:
-        _slice_xy_ampL = ti.field(dtype=ti.f32, shape=(nx, ny))
-        _slice_xy_ampT = ti.field(dtype=ti.f32, shape=(nx, ny))
+    if _slice_xy_amp is None:
+        _slice_xy_amp = ti.field(dtype=ti.f32, shape=(nx, ny))
+        _slice_xy_ampP = ti.field(dtype=ti.f32, shape=(nx, ny))
         _slice_xy_freq = ti.field(dtype=ti.f32, shape=(nx, ny))
-        _slice_xz_ampL = ti.field(dtype=ti.f32, shape=(nx, nz))
-        _slice_xz_ampT = ti.field(dtype=ti.f32, shape=(nx, nz))
+        _slice_xz_amp = ti.field(dtype=ti.f32, shape=(nx, nz))
+        _slice_xz_ampP = ti.field(dtype=ti.f32, shape=(nx, nz))
         _slice_xz_freq = ti.field(dtype=ti.f32, shape=(nx, nz))
-        _slice_yz_ampL = ti.field(dtype=ti.f32, shape=(ny, nz))
-        _slice_yz_ampT = ti.field(dtype=ti.f32, shape=(ny, nz))
+        _slice_yz_amp = ti.field(dtype=ti.f32, shape=(ny, nz))
+        _slice_yz_ampP = ti.field(dtype=ti.f32, shape=(ny, nz))
         _slice_yz_freq = ti.field(dtype=ti.f32, shape=(ny, nz))
 
     # Copy 3 center slices to 2D buffers (parallel kernels)
     mid_x, mid_y, mid_z = nx // 2, ny // 2, nz // 2
-    _copy_slice_xy(trackers, _slice_xy_ampL, _slice_xy_ampT, _slice_xy_freq, mid_z)
-    _copy_slice_xz(trackers, _slice_xz_ampL, _slice_xz_ampT, _slice_xz_freq, mid_y)
-    _copy_slice_yz(trackers, _slice_yz_ampL, _slice_yz_ampT, _slice_yz_freq, mid_x)
+    _copy_slice_xy(trackers, _slice_xy_amp, _slice_xy_ampP, _slice_xy_freq, mid_z)
+    _copy_slice_xz(trackers, _slice_xz_amp, _slice_xz_ampP, _slice_xz_freq, mid_y)
+    _copy_slice_yz(trackers, _slice_yz_amp, _slice_yz_ampP, _slice_yz_freq, mid_x)
 
     # Transfer 2D slices to CPU for numpy operations
     # Exclude boundary voxels
-    xy_ampL = _slice_xy_ampL.to_numpy()[1:-1, 1:-1]
-    xy_ampT = _slice_xy_ampT.to_numpy()[1:-1, 1:-1]
+    xy_amp = _slice_xy_amp.to_numpy()[1:-1, 1:-1]
+    xy_ampP = _slice_xy_ampP.to_numpy()[1:-1, 1:-1]
     xy_freq = _slice_xy_freq.to_numpy()[1:-1, 1:-1]
-    xz_ampL = _slice_xz_ampL.to_numpy()[1:-1, 1:-1]
-    xz_ampT = _slice_xz_ampT.to_numpy()[1:-1, 1:-1]
+    xz_amp = _slice_xz_amp.to_numpy()[1:-1, 1:-1]
+    xz_ampP = _slice_xz_ampP.to_numpy()[1:-1, 1:-1]
     xz_freq = _slice_xz_freq.to_numpy()[1:-1, 1:-1]
-    yz_ampL = _slice_yz_ampL.to_numpy()[1:-1, 1:-1]
-    yz_ampT = _slice_yz_ampT.to_numpy()[1:-1, 1:-1]
+    yz_amp = _slice_yz_amp.to_numpy()[1:-1, 1:-1]
+    yz_ampP = _slice_yz_ampP.to_numpy()[1:-1, 1:-1]
     yz_freq = _slice_yz_freq.to_numpy()[1:-1, 1:-1]
 
     # Compute RMS amplitude: √(⟨A²⟩) for correct energy weighting
-    # ampL_local_rms_am contains per-voxel RMS values, square them for energy
-    total_ampL_squared = (xy_ampL**2).sum() + (xz_ampL**2).sum() + (yz_ampL**2).sum()
-    total_ampT_squared = (xy_ampT**2).sum() + (xz_ampT**2).sum() + (yz_ampT**2).sum()
+    # amp_local_rms_am contains per-voxel RMS values, square them for energy
+    total_amp_squared = (xy_amp**2).sum() + (xz_amp**2).sum() + (yz_amp**2).sum()
+    total_ampP_squared = (xy_ampP**2).sum() + (xz_ampP**2).sum() + (yz_ampP**2).sum()
     total_freq = xy_freq.sum() + xz_freq.sum() + yz_freq.sum()
-    n_samples = xy_ampL.size + xz_ampL.size + yz_ampL.size
+    n_samples = xy_amp.size + xz_amp.size + yz_amp.size
 
-    trackers.ampL_global_rms_am[None] = float(np.sqrt(total_ampL_squared / n_samples))
-    trackers.ampT_global_rms_am[None] = float(np.sqrt(total_ampT_squared / n_samples))
+    trackers.amp_global_rms_am[None] = float(np.sqrt(total_amp_squared / n_samples))
+    trackers.ampP_global_rms_am[None] = float(np.sqrt(total_ampP_squared / n_samples))
     trackers.freq_global_avg_rHz[None] = float(total_freq / n_samples)
 
 
@@ -693,11 +518,10 @@ def update_flux_mesh_values(
     # Always update all planes (conditionals cause GPU branch divergence)
     for i, j in ti.ndrange(wave_field.nx, wave_field.ny):
         # Sample longitudinal displacement at this voxel
-        psiL_value = wave_field.psiL_am[i, j, wave_field.fm_plane_z_idx]
-        psiT_value = wave_field.psiT_am[i, j, wave_field.fm_plane_z_idx]
-        ampLr_value = trackers.ampL_local_rms_am[i, j, wave_field.fm_plane_z_idx]
-        ampLe_value = trackers.ampL_local_envelope_am[i, j, wave_field.fm_plane_z_idx]
-        ampT_value = trackers.ampT_local_rms_am[i, j, wave_field.fm_plane_z_idx]
+        psi_value = wave_field.displacement_am[i, j, wave_field.fm_plane_z_idx]
+        vel_value = wave_field.velocity_am[i, j, wave_field.fm_plane_z_idx]
+        amp_value = trackers.amp_local_rms_am[i, j, wave_field.fm_plane_z_idx]
+        ampP_value = trackers.amp_local_peak_am[i, j, wave_field.fm_plane_z_idx]
         freq_value = trackers.freq_local_cross_rHz[i, j, wave_field.fm_plane_z_idx]
         univ_edge_z = wave_field.universe_size_am[2]
 
@@ -714,40 +538,40 @@ def update_flux_mesh_values(
             )
         elif wave_menu == 4:  # greenyellow
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_greenyellow_color(
-                ampLe_value,
-                -trackers.ampL_global_rms_am[None] * 2,
-                trackers.ampL_global_rms_am[None] * 2,
+                ampP_value,
+                -trackers.amp_global_rms_am[None] * 2,
+                trackers.amp_global_rms_am[None] * 2,
             )
             wave_field.fluxmesh_xy_vertices[i, j][2] = (
-                ampLe_value / univ_edge_z * warp_mesh
+                ampP_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
         elif wave_menu == 3:  # viridis
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_viridis_color(
-                ampLr_value, 0, trackers.ampL_global_rms_am[None] * 2
+                amp_value, 0, trackers.amp_global_rms_am[None] * 2
             )
             wave_field.fluxmesh_xy_vertices[i, j][2] = (
-                ampLr_value / univ_edge_z * warp_mesh
+                amp_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
         elif wave_menu == 2:  # bluered
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_bluered_color(
-                psiT_value,
-                -trackers.ampT_global_rms_am[None] * 2,
-                trackers.ampT_global_rms_am[None] * 2,
+                vel_value,
+                -trackers.amp_global_rms_am[None] * 2,
+                trackers.amp_global_rms_am[None] * 2,
             )
             wave_field.fluxmesh_xy_vertices[i, j][2] = (
-                psiT_value / univ_edge_z * warp_mesh
+                vel_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
         else:  # default to greenyellow (wave_menu == 1)
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_greenyellow_color(
-                psiL_value,
-                -trackers.ampL_global_rms_am[None] * 2,
-                trackers.ampL_global_rms_am[None] * 2,
+                psi_value,
+                -trackers.amp_global_rms_am[None] * 2,
+                trackers.amp_global_rms_am[None] * 2,
             )
             wave_field.fluxmesh_xy_vertices[i, j][2] = (
-                psiL_value / univ_edge_z * warp_mesh
+                psi_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
 
@@ -756,11 +580,10 @@ def update_flux_mesh_values(
     # ================================================================
     for i, k in ti.ndrange(wave_field.nx, wave_field.nz):
         # Sample longitudinal displacement at this voxel
-        psiL_value = wave_field.psiL_am[i, wave_field.fm_plane_y_idx, k]
-        psiT_value = wave_field.psiT_am[i, wave_field.fm_plane_y_idx, k]
-        ampLr_value = trackers.ampL_local_rms_am[i, wave_field.fm_plane_y_idx, k]
-        ampLe_value = trackers.ampL_local_envelope_am[i, wave_field.fm_plane_y_idx, k]
-        ampT_value = trackers.ampT_local_rms_am[i, wave_field.fm_plane_y_idx, k]
+        psi_value = wave_field.displacement_am[i, wave_field.fm_plane_y_idx, k]
+        vel_value = wave_field.velocity_am[i, wave_field.fm_plane_y_idx, k]
+        amp_value = trackers.amp_local_rms_am[i, wave_field.fm_plane_y_idx, k]
+        ampP_value = trackers.amp_local_peak_am[i, wave_field.fm_plane_y_idx, k]
         freq_value = trackers.freq_local_cross_rHz[i, wave_field.fm_plane_y_idx, k]
         univ_edge_y = wave_field.universe_size_am[1]
 
@@ -777,40 +600,40 @@ def update_flux_mesh_values(
             )
         elif wave_menu == 4:  # greenyellow
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_greenyellow_color(
-                ampLe_value,
-                -trackers.ampL_global_rms_am[None] * 2,
-                trackers.ampL_global_rms_am[None] * 2,
+                ampP_value,
+                -trackers.amp_global_rms_am[None] * 2,
+                trackers.amp_global_rms_am[None] * 2,
             )
             wave_field.fluxmesh_xz_vertices[i, k][1] = (
-                ampLe_value / univ_edge_y * warp_mesh
+                ampP_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
         elif wave_menu == 3:  # viridis
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_viridis_color(
-                ampLr_value, 0, trackers.ampL_global_rms_am[None] * 2
+                amp_value, 0, trackers.amp_global_rms_am[None] * 2
             )
             wave_field.fluxmesh_xz_vertices[i, k][1] = (
-                ampLr_value / univ_edge_y * warp_mesh
+                amp_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
         elif wave_menu == 2:  # bluered
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_bluered_color(
-                psiT_value,
-                -trackers.ampT_global_rms_am[None] * 2,
-                trackers.ampT_global_rms_am[None] * 2,
+                vel_value,
+                -trackers.amp_global_rms_am[None] * 2,
+                trackers.amp_global_rms_am[None] * 2,
             )
             wave_field.fluxmesh_xz_vertices[i, k][1] = (
-                psiT_value / univ_edge_y * warp_mesh
+                vel_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
         else:  # default to greenyellow (wave_menu == 1)
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_greenyellow_color(
-                psiL_value,
-                -trackers.ampL_global_rms_am[None] * 2,
-                trackers.ampL_global_rms_am[None] * 2,
+                psi_value,
+                -trackers.amp_global_rms_am[None] * 2,
+                trackers.amp_global_rms_am[None] * 2,
             )
             wave_field.fluxmesh_xz_vertices[i, k][1] = (
-                psiL_value / univ_edge_y * warp_mesh
+                psi_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
 
@@ -819,11 +642,10 @@ def update_flux_mesh_values(
     # ================================================================
     for j, k in ti.ndrange(wave_field.ny, wave_field.nz):
         # Sample longitudinal displacement at this voxel
-        psiL_value = wave_field.psiL_am[wave_field.fm_plane_x_idx, j, k]
-        psiT_value = wave_field.psiT_am[wave_field.fm_plane_x_idx, j, k]
-        ampLr_value = trackers.ampL_local_rms_am[wave_field.fm_plane_x_idx, j, k]
-        ampLe_value = trackers.ampL_local_envelope_am[wave_field.fm_plane_x_idx, j, k]
-        ampT_value = trackers.ampT_local_rms_am[wave_field.fm_plane_x_idx, j, k]
+        psi_value = wave_field.displacement_am[wave_field.fm_plane_x_idx, j, k]
+        vel_value = wave_field.velocity_am[wave_field.fm_plane_x_idx, j, k]
+        amp_value = trackers.amp_local_rms_am[wave_field.fm_plane_x_idx, j, k]
+        ampP_value = trackers.amp_local_peak_am[wave_field.fm_plane_x_idx, j, k]
         freq_value = trackers.freq_local_cross_rHz[wave_field.fm_plane_x_idx, j, k]
         univ_edge_x = wave_field.universe_size_am[0]
 
@@ -840,39 +662,39 @@ def update_flux_mesh_values(
             )
         elif wave_menu == 4:  # greenyellow
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_greenyellow_color(
-                ampLe_value,
-                -trackers.ampL_global_rms_am[None] * 2,
-                trackers.ampL_global_rms_am[None] * 2,
+                ampP_value,
+                -trackers.amp_global_rms_am[None] * 2,
+                trackers.amp_global_rms_am[None] * 2,
             )
             wave_field.fluxmesh_yz_vertices[j, k][0] = (
-                ampLe_value / univ_edge_x * warp_mesh
+                ampP_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )
         elif wave_menu == 3:  # viridis
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_viridis_color(
-                ampLr_value, 0, trackers.ampL_global_rms_am[None] * 2
+                amp_value, 0, trackers.amp_global_rms_am[None] * 2
             )
             wave_field.fluxmesh_yz_vertices[j, k][0] = (
-                ampLr_value / univ_edge_x * warp_mesh
+                amp_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )
         elif wave_menu == 2:  # bluered
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_bluered_color(
-                psiT_value,
-                -trackers.ampT_global_rms_am[None] * 2,
-                trackers.ampT_global_rms_am[None] * 2,
+                vel_value,
+                -trackers.amp_global_rms_am[None] * 2,
+                trackers.amp_global_rms_am[None] * 2,
             )
             wave_field.fluxmesh_yz_vertices[j, k][0] = (
-                psiT_value / univ_edge_x * warp_mesh
+                vel_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )
         else:  # default to greenyellow (wave_menu == 1)
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_greenyellow_color(
-                psiL_value,
-                -trackers.ampL_global_rms_am[None] * 2,
-                trackers.ampL_global_rms_am[None] * 2,
+                psi_value,
+                -trackers.amp_global_rms_am[None] * 2,
+                trackers.amp_global_rms_am[None] * 2,
             )
             wave_field.fluxmesh_yz_vertices[j, k][0] = (
-                psiL_value / univ_edge_x * warp_mesh
+                psi_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )

--- a/openwave/xperiments/m4_vector_wave/wave_engine.py
+++ b/openwave/xperiments/m4_vector_wave/wave_engine.py
@@ -540,7 +540,7 @@ def update_flux_mesh_values(
             )
         else:  # default to orange (wave_menu == 1)
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_orange_color(
-                psi_value, 0, trackers.amp_global_rms_am[None] * 10
+                psi_value, 0, trackers.amp_global_rms_am[None] * 4
             )
             wave_field.fluxmesh_xy_vertices[i, j][2] = (
                 psi_value / univ_edge_z * warp_mesh
@@ -578,7 +578,7 @@ def update_flux_mesh_values(
             )
         else:  # default to orange (wave_menu == 1)
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_orange_color(
-                psi_value, 0, trackers.amp_global_rms_am[None] * 10
+                psi_value, 0, trackers.amp_global_rms_am[None] * 4
             )
             wave_field.fluxmesh_xz_vertices[i, k][1] = (
                 psi_value / univ_edge_y * warp_mesh
@@ -616,7 +616,7 @@ def update_flux_mesh_values(
             )
         else:  # default to orange (wave_menu == 1)
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_orange_color(
-                psi_value, 0, trackers.amp_global_rms_am[None] * 10
+                psi_value, 0, trackers.amp_global_rms_am[None] * 4
             )
             wave_field.fluxmesh_yz_vertices[j, k][0] = (
                 psi_value / univ_edge_x * warp_mesh

--- a/openwave/xperiments/m4_vector_wave/wave_engine.py
+++ b/openwave/xperiments/m4_vector_wave/wave_engine.py
@@ -299,10 +299,16 @@ def propagate_wave_neighbors(
         elapsed_t_rs: Elapsed simulation time (rs)
         num_selected: Number of selected voxels to process
     """
-    # Compute wave parameters
-    omega_rs = 2.0 * ti.math.pi * base_frequency_rHz / wave_field.scale_factor
+    # Compute angular frequency (ω = 2πf) for temporal phase variation
+    omega_rs = (
+        2.0 * ti.math.pi * base_frequency_rHz / wave_field.scale_factor
+    )  # angular frequency (rad/rs)
+
+    # Compute angular wave number (k = 2π/λ) for spatial phase variation
     wavelength_grid = base_wavelength * wave_field.scale_factor / wave_field.dx
-    k_grid = 2.0 * ti.math.pi / wavelength_grid
+    k_grid = 2.0 * ti.math.pi / wavelength_grid  # radians per grid index
+
+    # Temporal phase: φ = ω·t, oscillatory in time
     temporal_phase = omega_rs * elapsed_t_rs
 
     # Iterate only over selected voxels (neighbors of wave centers)

--- a/openwave/xperiments/m4_vector_wave/wave_engine.py
+++ b/openwave/xperiments/m4_vector_wave/wave_engine.py
@@ -368,13 +368,10 @@ def propagate_wave_full(
 
 # Cached slice buffers (initialized on first call)
 _slice_xy_amp = None
-_slice_xy_ampT = None
 _slice_xy_freq = None
 _slice_xz_amp = None
-_slice_xz_ampT = None
 _slice_xz_freq = None
 _slice_yz_amp = None
-_slice_yz_ampT = None
 _slice_yz_freq = None
 
 
@@ -440,51 +437,43 @@ def sample_avg_trackers(
         wave_field: WaveField instance containing grid dimensions
         trackers: WaveTrackers instance with per-voxel and average fields
     """
-    global _slice_xy_amp, _slice_xy_ampP, _slice_xy_freq
-    global _slice_xz_amp, _slice_xz_ampP, _slice_xz_freq
-    global _slice_yz_amp, _slice_yz_ampP, _slice_yz_freq
+    global _slice_xy_amp, _slice_xy_freq
+    global _slice_xz_amp, _slice_xz_freq
+    global _slice_yz_amp, _slice_yz_freq
 
     nx, ny, nz = wave_field.nx, wave_field.ny, wave_field.nz
 
     # Initialize slice buffers once
     if _slice_xy_amp is None:
         _slice_xy_amp = ti.field(dtype=ti.f32, shape=(nx, ny))
-        _slice_xy_ampP = ti.field(dtype=ti.f32, shape=(nx, ny))
         _slice_xy_freq = ti.field(dtype=ti.f32, shape=(nx, ny))
         _slice_xz_amp = ti.field(dtype=ti.f32, shape=(nx, nz))
-        _slice_xz_ampP = ti.field(dtype=ti.f32, shape=(nx, nz))
         _slice_xz_freq = ti.field(dtype=ti.f32, shape=(nx, nz))
         _slice_yz_amp = ti.field(dtype=ti.f32, shape=(ny, nz))
-        _slice_yz_ampP = ti.field(dtype=ti.f32, shape=(ny, nz))
         _slice_yz_freq = ti.field(dtype=ti.f32, shape=(ny, nz))
 
     # Copy 3 center slices to 2D buffers (parallel kernels)
     mid_x, mid_y, mid_z = nx // 2, ny // 2, nz // 2
-    _copy_slice_xy(trackers, _slice_xy_amp, _slice_xy_ampP, _slice_xy_freq, mid_z)
-    _copy_slice_xz(trackers, _slice_xz_amp, _slice_xz_ampP, _slice_xz_freq, mid_y)
-    _copy_slice_yz(trackers, _slice_yz_amp, _slice_yz_ampP, _slice_yz_freq, mid_x)
+    _copy_slice_xy(trackers, _slice_xy_amp, _slice_xy_freq, mid_z)
+    _copy_slice_xz(trackers, _slice_xz_amp, _slice_xz_freq, mid_y)
+    _copy_slice_yz(trackers, _slice_yz_amp, _slice_yz_freq, mid_x)
 
     # Transfer 2D slices to CPU for numpy operations
     # Exclude boundary voxels
     xy_amp = _slice_xy_amp.to_numpy()[1:-1, 1:-1]
-    xy_ampP = _slice_xy_ampP.to_numpy()[1:-1, 1:-1]
     xy_freq = _slice_xy_freq.to_numpy()[1:-1, 1:-1]
     xz_amp = _slice_xz_amp.to_numpy()[1:-1, 1:-1]
-    xz_ampP = _slice_xz_ampP.to_numpy()[1:-1, 1:-1]
     xz_freq = _slice_xz_freq.to_numpy()[1:-1, 1:-1]
     yz_amp = _slice_yz_amp.to_numpy()[1:-1, 1:-1]
-    yz_ampP = _slice_yz_ampP.to_numpy()[1:-1, 1:-1]
     yz_freq = _slice_yz_freq.to_numpy()[1:-1, 1:-1]
 
     # Compute RMS amplitude: √(⟨A²⟩) for correct energy weighting
     # amp_local_rms_am contains per-voxel RMS values, square them for energy
     total_amp_squared = (xy_amp**2).sum() + (xz_amp**2).sum() + (yz_amp**2).sum()
-    total_ampP_squared = (xy_ampP**2).sum() + (xz_ampP**2).sum() + (yz_ampP**2).sum()
     total_freq = xy_freq.sum() + xz_freq.sum() + yz_freq.sum()
     n_samples = xy_amp.size + xz_amp.size + yz_amp.size
 
     trackers.amp_global_rms_am[None] = float(np.sqrt(total_amp_squared / n_samples))
-    trackers.ampP_global_rms_am[None] = float(np.sqrt(total_ampP_squared / n_samples))
     trackers.freq_global_avg_rHz[None] = float(total_freq / n_samples)
 
 

--- a/openwave/xperiments/m4_vector_wave/wave_engine.py
+++ b/openwave/xperiments/m4_vector_wave/wave_engine.py
@@ -157,6 +157,11 @@ def compute_voxel_wave(
     prev_disp = wave_field.displacement_am[i, j, k]
     wave_field.displacement_am[i, j, k] = ti.Vector([0.0, 0.0, 0.0])
 
+    # TODO: review this reference radius logic, currently set to 1λ, ensures finite amplitude at r=0 and sets 1/r falloff reference point, but may need adjustment based on observed behavior or specific wave scenarios
+    # Reference radius for amplitude normalization (r₀ = 1λ)
+    # Prevents singularity at r=0 and sets 1/r falloff reference point
+    r_reference_am = base_wavelength_am
+
     # ================================================================
     # WAVE PROPAGATION: Update voxels using wave functions
     # ================================================================
@@ -166,6 +171,12 @@ def compute_voxel_wave(
         if wave_center.active[wc_idx] == 0:
             continue
 
+        # TODO: review dir_vec logic, duplicating dist/r_grid calculations, consider optimization if needed
+        # Get direction from voxel to wave center (normalized vector)
+        dir_vec = [i, j, k] - wave_center.position_grid[wc_idx]
+        dist = ti.sqrt(dir_vec.dot(dir_vec)) + 1e-10  # add small value to prevent div by zero
+        direction = dir_vec / dist  # normalized direction vector for wave propagation
+
         # Compute radial distance from wave center (in grid indices)
         r_grid = ti.sqrt(
             (i - wave_center.position_grid[wc_idx][0]) ** 2
@@ -173,51 +184,40 @@ def compute_voxel_wave(
             + (k - wave_center.position_grid[wc_idx][2]) ** 2
         )
 
-        # Cache source-specific phase offset
-        source_offset = wave_center.offset[wc_idx]
-
         # Spatial phase: φ = k·r, creates spherical wave fronts, dimensionless, in radians
         spatial_phase = k_grid * r_grid
 
-        # ================================================================
-        # Combined and Adjusted WOLFF-LAFRENIERE canonical form:
-        #   ψ(r,t) = A · [sin(ωt - kr) - sin(ωt)] / r
-        # Expanded form:
-        #   ψ(r,t) = A · [-cos(ωt) · sin(kr)/r - sin(ωt) · (1 - cos(kr))/r]
-        #   ψ(r,t) = A · [-cos(ωt) · Phase(r) - sin(ωt) · Quadrature(r)]
-        # ================================================================
-        # Phase term: sin(kr)/r → k as r→0 (physical units)
-        phase_term = ti.select(
-            r_grid < 0.5,  # threshold in grid units (catches center voxel only)
-            k_grid,  # analytical limit
-            ti.sin(spatial_phase) / r_grid,
-        )
+        # TODO: review this logic
+        # Cache source-specific phase offset
+        source_offset = wave_center.offset[wc_idx]
 
-        # Quadrature term: (1-cos(kr))/r → 0 as r→0
-        quadrature_term = ti.select(
-            r_grid < 0.5,  # threshold in grid units (catches center voxel only)
-            0.0,  # analytical limit
-            (1 - ti.cos(spatial_phase)) / r_grid,
-        )
+        # Phase shift between in/out waves (at wave-center)
+        phase_shift = ti.math.pi
 
-        # Oscillator with source_offset phase shift
-        oscillator = (
-            -ti.cos(temporal_phase + source_offset) * phase_term
-            - ti.sin(temporal_phase + source_offset) * quadrature_term
-        )
+        # Amplitude falloff for spherical wave: A(r) = A₀/r
+        # Clamp to r_min to avoid singularity at r = 0
+        r_safe_am = ti.max(r_grid, r_reference_am)
+        amplitude_falloff = r_reference_am / r_safe_am
+        # Total amplitude at this distance (with visualization scaling)
+        amplitude_at_r_am = base_amplitude_am * amplitude_falloff
 
+        # Accumulate this source's contribution (wave superposition)
+        # A(r)·cos(ωt ± kr + φ)·direction, negative for outward propagation, amp falloff
         wave_field.displacement_am[i, j, k] += (
-            base_amplitude_am * wave_field.scale_factor * oscillator
-        )
+            amplitude_at_r_am
+            * wave_field.scale_factor
+            * ti.cos(temporal_phase - spatial_phase + source_offset + phase_shift)  # oscillator
+        ) * direction
 
+    # TODO: consider precision rounding to ensure perfect cancellation
     # Precision rounding to ensure wave cancellation
     # Critical for opposing phase sources (180°) that should annihilate
     # Floating-point: (+1.250001) + (-1.249999) = 0.000002 (imperfect cancel)
     # With rounding: (+1.2500) + (-1.2500) = 0.0 (perfect cancel)
-    precision = ti.cast(1e4, ti.f32)  # round to 4 decimal places
-    wave_field.displacement_am[i, j, k] = (
-        ti.round(wave_field.displacement_am[i, j, k] * precision) / precision
-    )
+    # precision = ti.cast(1e4, ti.f32)  # round to 4 decimal places
+    # wave_field.displacement_am[i, j, k] = (
+    #     ti.round(wave_field.displacement_am[i, j, k] * precision) / precision
+    # )
 
     curr_disp = wave_field.displacement_am[i, j, k]
 
@@ -231,6 +231,8 @@ def compute_voxel_wave(
     #     trackers.ampL_local_peak_am[i, j, k] * decay_factor_peak
     # )
 
+    # TODO: review EMS method for amplitude tracking (values compared to peak amp for force)
+    # TODO: review how vector displacement (has direction component) is handled in RMS calculation
     # RMS AMPLITUDE tracking via EMA on ψ² (squared displacement)
     # Running RMS: tracks √⟨ψ²⟩ - the energy-equivalent amplitude (Energy ∝ ψ²)
     # Used for: energy calculation, force gradients, visualization scaling
@@ -239,7 +241,7 @@ def compute_voxel_wave(
     # EMA on ψ²: rms² = α * ψ² + (1 - α) * rms²_old, then rms = √(rms²)
     # α controls adaptation speed: higher = faster response, lower = smoother
     # RMS amplitude
-    disp2 = wave_field.displacement_am[i, j, k] ** 2
+    disp2 = wave_field.displacement_am[i, j, k].norm() ** 2
     current_rms2 = trackers.amp_local_rms_am[i, j, k] ** 2
     alpha_rms = 0.005  # EMA smoothing factor for RMS tracking
     new_rms2 = alpha_rms * disp2 + (1.0 - alpha_rms) * current_rms2
@@ -258,19 +260,24 @@ def compute_voxel_wave(
     # More robust than peak detection since it's amplitude-independent
     # EMA smoothing: f_new = α * f_measured + (1 - α) * f_old
     # α controls adaptation speed: higher = faster response, lower = smoother
-    if prev_disp < 0.0 and curr_disp >= 0.0:  # Zero crossing detected
-        period_rs = elapsed_t_rs - trackers.last_crossing[i, j, k]
-        if period_rs > dt_rs * 2:  # Filter out spurious crossings
-            measured_freq = 1.0 / period_rs  # in rHz
-            current_freq = trackers.freq_local_cross_rHz[i, j, k]
-            alpha_freq = 0.05  # EMA smoothing factor for frequency
-            trackers.freq_local_cross_rHz[i, j, k] = (
-                alpha_freq * measured_freq + (1.0 - alpha_freq) * current_freq
-            )
-        trackers.last_crossing[i, j, k] = elapsed_t_rs
 
-    # Unconditional frequency decay (counteracted by zero-crossing updates in active regions)
-    trackers.freq_local_cross_rHz[i, j, k] *= decay_factor
+    # if prev_disp < 0.0 and curr_disp >= 0.0:  # Zero crossing detected
+    #     period_rs = elapsed_t_rs - trackers.last_crossing[i, j, k]
+    #     if period_rs > dt_rs * 2:  # Filter out spurious crossings
+    #         measured_freq = 1.0 / period_rs  # in rHz
+    #         current_freq = trackers.freq_local_cross_rHz[i, j, k]
+    #         alpha_freq = 0.05  # EMA smoothing factor for frequency
+    #         trackers.freq_local_cross_rHz[i, j, k] = (
+    #             alpha_freq * measured_freq + (1.0 - alpha_freq) * current_freq
+    #         )
+    #     trackers.last_crossing[i, j, k] = elapsed_t_rs
+
+    # # Unconditional frequency decay (counteracted by zero-crossing updates in active regions)
+    # trackers.freq_local_cross_rHz[i, j, k] *= decay_factor
+
+    trackers.freq_local_cross_rHz[i, j, k] = (
+        base_frequency_rHz  # TODO: fixed frequency for testing, replace with above method for dynamic frequency
+    )
 
 
 @ti.kernel
@@ -385,14 +392,12 @@ _slice_yz_freq = None
 def _copy_slice_xy(
     trackers: ti.template(),  # type: ignore
     slice_amp: ti.template(),  # type: ignore
-    slice_ampP: ti.template(),  # type: ignore
     slice_freq: ti.template(),  # type: ignore
     mid_z: ti.i32,  # type: ignore
 ):
     """Copy center XY slice (fixed z) to 2D buffer."""
     for i, j in slice_amp:
         slice_amp[i, j] = trackers.amp_local_rms_am[i, j, mid_z]
-        slice_ampP[i, j] = trackers.amp_local_peak_am[i, j, mid_z]
         slice_freq[i, j] = trackers.freq_local_cross_rHz[i, j, mid_z]
 
 
@@ -400,14 +405,12 @@ def _copy_slice_xy(
 def _copy_slice_xz(
     trackers: ti.template(),  # type: ignore
     slice_amp: ti.template(),  # type: ignore
-    slice_ampP: ti.template(),  # type: ignore
     slice_freq: ti.template(),  # type: ignore
     mid_y: ti.i32,  # type: ignore
 ):
     """Copy center XZ slice (fixed y) to 2D buffer."""
     for i, k in slice_amp:
         slice_amp[i, k] = trackers.amp_local_rms_am[i, mid_y, k]
-        slice_ampP[i, k] = trackers.amp_local_peak_am[i, mid_y, k]
         slice_freq[i, k] = trackers.freq_local_cross_rHz[i, mid_y, k]
 
 
@@ -415,14 +418,12 @@ def _copy_slice_xz(
 def _copy_slice_yz(
     trackers: ti.template(),  # type: ignore
     slice_amp: ti.template(),  # type: ignore
-    slice_ampP: ti.template(),  # type: ignore
     slice_freq: ti.template(),  # type: ignore
     mid_x: ti.i32,  # type: ignore
 ):
     """Copy center YZ slice (fixed x) to 2D buffer."""
     for j, k in slice_amp:
         slice_amp[j, k] = trackers.amp_local_rms_am[mid_x, j, k]
-        slice_ampP[j, k] = trackers.amp_local_peak_am[mid_x, j, k]
         slice_freq[j, k] = trackers.freq_local_cross_rHz[mid_x, j, k]
 
 
@@ -513,16 +514,14 @@ def update_flux_mesh_values(
     # Always update all planes (conditionals cause GPU branch divergence)
     for i, j in ti.ndrange(wave_field.nx, wave_field.ny):
         # Sample longitudinal displacement at this voxel
-        psi_value = wave_field.displacement_am[i, j, wave_field.fm_plane_z_idx]
-        vel_value = wave_field.velocity_am[i, j, wave_field.fm_plane_z_idx]
+        psi_value = wave_field.displacement_am[i, j, wave_field.fm_plane_z_idx].norm()
         amp_value = trackers.amp_local_rms_am[i, j, wave_field.fm_plane_z_idx]
-        ampP_value = trackers.amp_local_peak_am[i, j, wave_field.fm_plane_z_idx]
         freq_value = trackers.freq_local_cross_rHz[i, j, wave_field.fm_plane_z_idx]
         univ_edge_z = wave_field.universe_size_am[2]
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if wave_menu == 5:  # blueprint
+        if wave_menu == 3:  # blueprint
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_blueprint_color(
                 freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
             )
@@ -531,39 +530,17 @@ def update_flux_mesh_values(
             ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[2] * (
                 wave_field.nz / wave_field.max_grid_size
             )
-        elif wave_menu == 4:  # greenyellow
-            wave_field.fluxmesh_xy_colors[i, j] = colormap.get_greenyellow_color(
-                ampP_value,
-                -trackers.amp_global_rms_am[None] * 2,
-                trackers.amp_global_rms_am[None] * 2,
-            )
-            wave_field.fluxmesh_xy_vertices[i, j][2] = (
-                ampP_value / univ_edge_z * warp_mesh
-                + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
-            )
-        elif wave_menu == 3:  # viridis
-            wave_field.fluxmesh_xy_colors[i, j] = colormap.get_viridis_color(
+        elif wave_menu == 2:  # ironbow
+            wave_field.fluxmesh_xy_colors[i, j] = colormap.get_ironbow_color(
                 amp_value, 0, trackers.amp_global_rms_am[None] * 2
             )
             wave_field.fluxmesh_xy_vertices[i, j][2] = (
                 amp_value / univ_edge_z * warp_mesh
                 + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
             )
-        elif wave_menu == 2:  # bluered
-            wave_field.fluxmesh_xy_colors[i, j] = colormap.get_bluered_color(
-                vel_value,
-                -trackers.amp_global_rms_am[None] * 2,
-                trackers.amp_global_rms_am[None] * 2,
-            )
-            wave_field.fluxmesh_xy_vertices[i, j][2] = (
-                vel_value / univ_edge_z * warp_mesh
-                + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
-            )
-        else:  # default to greenyellow (wave_menu == 1)
-            wave_field.fluxmesh_xy_colors[i, j] = colormap.get_greenyellow_color(
-                psi_value,
-                -trackers.amp_global_rms_am[None] * 2,
-                trackers.amp_global_rms_am[None] * 2,
+        else:  # default to orange (wave_menu == 1)
+            wave_field.fluxmesh_xy_colors[i, j] = colormap.get_orange_color(
+                psi_value, 0, trackers.amp_global_rms_am[None] * 10
             )
             wave_field.fluxmesh_xy_vertices[i, j][2] = (
                 psi_value / univ_edge_z * warp_mesh
@@ -575,16 +552,14 @@ def update_flux_mesh_values(
     # ================================================================
     for i, k in ti.ndrange(wave_field.nx, wave_field.nz):
         # Sample longitudinal displacement at this voxel
-        psi_value = wave_field.displacement_am[i, wave_field.fm_plane_y_idx, k]
-        vel_value = wave_field.velocity_am[i, wave_field.fm_plane_y_idx, k]
+        psi_value = wave_field.displacement_am[i, wave_field.fm_plane_y_idx, k].norm()
         amp_value = trackers.amp_local_rms_am[i, wave_field.fm_plane_y_idx, k]
-        ampP_value = trackers.amp_local_peak_am[i, wave_field.fm_plane_y_idx, k]
         freq_value = trackers.freq_local_cross_rHz[i, wave_field.fm_plane_y_idx, k]
         univ_edge_y = wave_field.universe_size_am[1]
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if wave_menu == 5:  # blueprint
+        if wave_menu == 3:  # blueprint
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_blueprint_color(
                 freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
             )
@@ -593,39 +568,17 @@ def update_flux_mesh_values(
             ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[1] * (
                 wave_field.ny / wave_field.max_grid_size
             )
-        elif wave_menu == 4:  # greenyellow
-            wave_field.fluxmesh_xz_colors[i, k] = colormap.get_greenyellow_color(
-                ampP_value,
-                -trackers.amp_global_rms_am[None] * 2,
-                trackers.amp_global_rms_am[None] * 2,
-            )
-            wave_field.fluxmesh_xz_vertices[i, k][1] = (
-                ampP_value / univ_edge_y * warp_mesh
-                + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
-            )
-        elif wave_menu == 3:  # viridis
-            wave_field.fluxmesh_xz_colors[i, k] = colormap.get_viridis_color(
+        elif wave_menu == 2:  # ironbow
+            wave_field.fluxmesh_xz_colors[i, k] = colormap.get_ironbow_color(
                 amp_value, 0, trackers.amp_global_rms_am[None] * 2
             )
             wave_field.fluxmesh_xz_vertices[i, k][1] = (
                 amp_value / univ_edge_y * warp_mesh
                 + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
             )
-        elif wave_menu == 2:  # bluered
-            wave_field.fluxmesh_xz_colors[i, k] = colormap.get_bluered_color(
-                vel_value,
-                -trackers.amp_global_rms_am[None] * 2,
-                trackers.amp_global_rms_am[None] * 2,
-            )
-            wave_field.fluxmesh_xz_vertices[i, k][1] = (
-                vel_value / univ_edge_y * warp_mesh
-                + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
-            )
-        else:  # default to greenyellow (wave_menu == 1)
-            wave_field.fluxmesh_xz_colors[i, k] = colormap.get_greenyellow_color(
-                psi_value,
-                -trackers.amp_global_rms_am[None] * 2,
-                trackers.amp_global_rms_am[None] * 2,
+        else:  # default to orange (wave_menu == 1)
+            wave_field.fluxmesh_xz_colors[i, k] = colormap.get_orange_color(
+                psi_value, 0, trackers.amp_global_rms_am[None] * 10
             )
             wave_field.fluxmesh_xz_vertices[i, k][1] = (
                 psi_value / univ_edge_y * warp_mesh
@@ -637,16 +590,14 @@ def update_flux_mesh_values(
     # ================================================================
     for j, k in ti.ndrange(wave_field.ny, wave_field.nz):
         # Sample longitudinal displacement at this voxel
-        psi_value = wave_field.displacement_am[wave_field.fm_plane_x_idx, j, k]
-        vel_value = wave_field.velocity_am[wave_field.fm_plane_x_idx, j, k]
+        psi_value = wave_field.displacement_am[wave_field.fm_plane_x_idx, j, k].norm()
         amp_value = trackers.amp_local_rms_am[wave_field.fm_plane_x_idx, j, k]
-        ampP_value = trackers.amp_local_peak_am[wave_field.fm_plane_x_idx, j, k]
         freq_value = trackers.freq_local_cross_rHz[wave_field.fm_plane_x_idx, j, k]
         univ_edge_x = wave_field.universe_size_am[0]
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if wave_menu == 5:  # blueprint
+        if wave_menu == 3:  # blueprint
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_blueprint_color(
                 freq_value, 0.0, trackers.freq_global_avg_rHz[None] * 2
             )
@@ -655,39 +606,17 @@ def update_flux_mesh_values(
             ] / 3000 * warp_mesh + wave_field.flux_mesh_planes[0] * (
                 wave_field.nx / wave_field.max_grid_size
             )
-        elif wave_menu == 4:  # greenyellow
-            wave_field.fluxmesh_yz_colors[j, k] = colormap.get_greenyellow_color(
-                ampP_value,
-                -trackers.amp_global_rms_am[None] * 2,
-                trackers.amp_global_rms_am[None] * 2,
-            )
-            wave_field.fluxmesh_yz_vertices[j, k][0] = (
-                ampP_value / univ_edge_x * warp_mesh
-                + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
-            )
-        elif wave_menu == 3:  # viridis
-            wave_field.fluxmesh_yz_colors[j, k] = colormap.get_viridis_color(
+        elif wave_menu == 2:  # ironbow
+            wave_field.fluxmesh_yz_colors[j, k] = colormap.get_ironbow_color(
                 amp_value, 0, trackers.amp_global_rms_am[None] * 2
             )
             wave_field.fluxmesh_yz_vertices[j, k][0] = (
                 amp_value / univ_edge_x * warp_mesh
                 + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
             )
-        elif wave_menu == 2:  # bluered
-            wave_field.fluxmesh_yz_colors[j, k] = colormap.get_bluered_color(
-                vel_value,
-                -trackers.amp_global_rms_am[None] * 2,
-                trackers.amp_global_rms_am[None] * 2,
-            )
-            wave_field.fluxmesh_yz_vertices[j, k][0] = (
-                vel_value / univ_edge_x * warp_mesh
-                + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
-            )
-        else:  # default to greenyellow (wave_menu == 1)
-            wave_field.fluxmesh_yz_colors[j, k] = colormap.get_greenyellow_color(
-                psi_value,
-                -trackers.amp_global_rms_am[None] * 2,
-                trackers.amp_global_rms_am[None] * 2,
+        else:  # default to orange (wave_menu == 1)
+            wave_field.fluxmesh_yz_colors[j, k] = colormap.get_orange_color(
+                psi_value, 0, trackers.amp_global_rms_am[None] * 10
             )
             wave_field.fluxmesh_yz_vertices[j, k][0] = (
                 psi_value / univ_edge_x * warp_mesh

--- a/openwave/xperiments/m4_vector_wave/xparameters/electric_attraction.py
+++ b/openwave/xperiments/m4_vector_wave/xparameters/electric_attraction.py
@@ -24,8 +24,8 @@ XPARAMETERS = {
         "COUNT": 2,  # Number of wave-centers for this xperiment
         # Wave-Center positions: normalized coordinates (0-1 range, relative to max universe edge)
         "POSITION": [
-            [0.25, 0.50, 0.50],
-            [0.75, 0.50, 0.50],
+            [0.45, 0.50, 0.50],
+            [0.55, 0.50, 0.50],
         ],
         # Phase offsets for each wave-center (integer degrees, converted to radians internally)
         "PHASE_OFFSETS_DEG": [0, 180],

--- a/openwave/xperiments/m4_vector_wave/xparameters/electric_attraction.py
+++ b/openwave/xperiments/m4_vector_wave/xparameters/electric_attraction.py
@@ -24,8 +24,8 @@ XPARAMETERS = {
         "COUNT": 2,  # Number of wave-centers for this xperiment
         # Wave-Center positions: normalized coordinates (0-1 range, relative to max universe edge)
         "POSITION": [
-            [0.45, 0.50, 0.50],
-            [0.55, 0.50, 0.50],
+            [0.25, 0.50, 0.50],
+            [0.75, 0.50, 0.50],
         ],
         # Phase offsets for each wave-center (integer degrees, converted to radians internally)
         "PHASE_OFFSETS_DEG": [0, 180],


### PR DESCRIPTION
This pull request standardizes amplitude variable naming across multiple wave simulation modules and improves clarity in code comments and parameter files. The changes also introduce a new experiment parameter file and adjust simulation toggles for improved wave visualization.

**Amplitude variable naming standardization:**

* Replaced `amp_local_peak_am` with `amplitude_am` in wave engine files for radial wave and spring-mass simulations (`wave_engine.py`, `wave_engine_euler.py`, `wave_engine_leapfrog.py`, `wave_engine_xpbd.py`). This affects both the definition and usage of the amplitude variable throughout these files. [[1]](diffhunk://#diff-baef05e9d0455ab9f35d98e4566f9b1e397ad63d92d2a64a88504ea02944253eL19-R19) [[2]](diffhunk://#diff-1444698730e9f26209df4014cc9bcf2d68ca34fccfaa76661ae53fc10d05081cL15-R15) [[3]](diffhunk://#diff-1444698730e9f26209df4014cc9bcf2d68ca34fccfaa76661ae53fc10d05081cL61-R65) [[4]](diffhunk://#diff-6a3026ee8abf3cb86dfe5f66943aa45ac35626a1b5bc406cc4d98e819cf3e9dcL15-R15) [[5]](diffhunk://#diff-6a3026ee8abf3cb86dfe5f66943aa45ac35626a1b5bc406cc4d98e819cf3e9dcL61-R65) [[6]](diffhunk://#diff-d0f94e6ae229d8038b8ccff3e755745d06d941885b2a5537fd7fe164688eb20bL26-R26) [[7]](diffhunk://#diff-d0f94e6ae229d8038b8ccff3e755745d06d941885b2a5537fd7fe164688eb20bL77-R81)
* Updated output dictionary keys in `measure_wave_speed` to use `amplitude_am` instead of `amp_local_peak_am` for consistency. [[1]](diffhunk://#diff-d0f94e6ae229d8038b8ccff3e755745d06d941885b2a5537fd7fe164688eb20bL573-R571) [[2]](diffhunk://#diff-d0f94e6ae229d8038b8ccff3e755745d06d941885b2a5537fd7fe164688eb20bL613-R611)

**Wave simulation parameter and comment improvements:**

* Changed `wavelength_am` to `base_wavelength_am` and improved related comments in `m1_granule_motion/wave_engine.py` for clarity and consistency. [[1]](diffhunk://#diff-c4696d539b7224cdb6030d3c48f5bda037178e42a3259405607d1e1b34a3361aL21-R21) [[2]](diffhunk://#diff-c4696d539b7224cdb6030d3c48f5bda037178e42a3259405607d1e1b34a3361aL252-R275)
* Revised comments to clarify the distinction between "in-wave" and "base-wave" computations, and improved the description of wave propagation direction and energy conservation. [[1]](diffhunk://#diff-c4696d539b7224cdb6030d3c48f5bda037178e42a3259405607d1e1b34a3361aL110-R110) [[2]](diffhunk://#diff-c4696d539b7224cdb6030d3c48f5bda037178e42a3259405607d1e1b34a3361aL252-R275)

**Experiment configuration enhancements:**

* Added a new experiment parameter file `xparameters/medium_disturbance.py` demonstrating standing wave patterns from multiple sources, including detailed documentation and parameter settings for visualization.
* Changed the `OUT_WAVE_TOGGLE` default from `0` to `1` in `xparameters/granule_motion.py` to enable outward wave propagation by default.

**Minor code and comment improvements:**

* Fixed comments and variable names for wave center calculations in `m3_wolff_lafreniere/wave_engine.py` to clarify the source of radial distance calculations.
* Consolidated amplitude variables in `m4_vector_wave/_launcher.py` by merging `ampL_global_rms` and `ampT_global_rms` into a single `amp_global_rms` variable. [[1]](diffhunk://#diff-a936669edb27b8819e4087e9917bc60addb880c1040bad2ce9f8cbaef103ba45L115-R115) [[2]](diffhunk://#diff-a936669edb27b8819e4087e9917bc60addb880c1040bad2ce9f8cbaef103ba45L217-R216)

**Initialization consistency:**

* Ensured consistent initialization order for `amp_local_peak_am` in `spacetime_medium.py`, moving the field definition to after `velocity_am`. [[1]](diffhunk://#diff-16cf5b54b98a2e35225dd458a739595072ef9cdbbf24d5b93add03ef7ca3b3bfL159-R160) [[2]](diffhunk://#diff-16cf5b54b98a2e35225dd458a739595072ef9cdbbf24d5b93add03ef7ca3b3bfL655-R656)