### PR TITLE
Add granule positional displacement

### DIFF
--- a/openwave/i_o/render.py
+++ b/openwave/i_o/render.py
@@ -208,6 +208,7 @@ def handle_camera():
     camera.position(cam_x, cam_y, cam_z)
     camera.lookat(orbit_center[0], orbit_center[1], orbit_center[2])
     camera.up(0, 0, 1)
+    camera.projection_mode(ti.ui.ProjectionMode.Perspective)
     scene.set_camera(camera)
 
 

--- a/openwave/xperiments/m3_wolff_lafreniere/_launcher.py
+++ b/openwave/xperiments/m3_wolff_lafreniere/_launcher.py
@@ -308,7 +308,7 @@ def display_wave_menu(state):
 
 def display_level_specs(state, level_bar_vertices):
     """Display OpenWave level specifications overlay."""
-    render.canvas.triangles(level_bar_vertices, color=colormap.DARK_BLUE[1])
+    render.canvas.triangles(level_bar_vertices, color=colormap.GREEN[1])
     with render.gui.sub_window("WOLFF-LAFRENIERE METHOD", 0.84, 0.01, 0.16, 0.16) as sub:
         sub.text("Medium: Indexed Voxel Grid")
         sub.text("Data-Structure: Scalar Field")

--- a/openwave/xperiments/m4_vector_wave/_launcher.py
+++ b/openwave/xperiments/m4_vector_wave/_launcher.py
@@ -135,6 +135,7 @@ class SimulationState:
         self.SHOW_FLUX_MESH = 0
         self.WARP_MESH = 300
         self.PARTICLE_SHELL = False
+        self.SHOW_GRANULES = False
         self.TIMESTEP = 0.0
         self.PAUSED = False
 
@@ -177,6 +178,7 @@ class SimulationState:
         self.SHOW_FLUX_MESH = ui["SHOW_FLUX_MESH"]
         self.WARP_MESH = ui["WARP_MESH"]
         self.PARTICLE_SHELL = ui["PARTICLE_SHELL"]
+        self.SHOW_GRANULES = ui["SHOW_GRANULES"]
         self.TIMESTEP = ui["TIMESTEP"]
         self.PAUSED = ui["PAUSED"]
 
@@ -254,12 +256,13 @@ def display_xperiment_launcher(xperiment_mgr, state):
 
 def display_controls(state):
     """Display the controls UI overlay."""
-    with render.gui.sub_window("CONTROLS", 0.00, 0.37, 0.16, 0.27) as sub:
+    with render.gui.sub_window("CONTROLS", 0.00, 0.37, 0.16, 0.30) as sub:
         state.SHOW_AXIS = sub.checkbox(f"Axis (ticks: {state.TICK_SPACING})", state.SHOW_AXIS)
         state.SHOW_EDGES = sub.checkbox("Sim Universe Edges", state.SHOW_EDGES)
         state.SHOW_FLUX_MESH = sub.slider_int("Flux Mesh", state.SHOW_FLUX_MESH, 0, 3)
         state.WARP_MESH = sub.slider_int("Warp Mesh", state.WARP_MESH, 0, 300)
         state.PARTICLE_SHELL = sub.checkbox("Particle Shell", state.PARTICLE_SHELL)
+        state.SHOW_GRANULES = sub.checkbox("Show Granule Motion", state.SHOW_GRANULES)
         state.TIMESTEP = sub.slider_float("Timestep", state.TIMESTEP, 0.1, 30.0)
         state.APPLY_MOTION = sub.checkbox("Apply Motion", state.APPLY_MOTION)
         if state.PAUSED:
@@ -298,7 +301,7 @@ def display_wave_menu(state):
 
 def display_level_specs(state, level_bar_vertices):
     """Display OpenWave level specifications overlay."""
-    render.canvas.triangles(level_bar_vertices, color=colormap.GREEN[1])
+    render.canvas.triangles(level_bar_vertices, color=colormap.DARK_BLUE[1])
     with render.gui.sub_window("VECTOR-WAVE METHOD", 0.84, 0.01, 0.16, 0.16) as sub:
         sub.text("Medium: Indexed Voxel Grid")
         sub.text("Data-Structure: Vector Field")
@@ -479,7 +482,7 @@ def render_elements(state):
     if state.SHOW_EDGES:
         render.scene.lines(state.wave_field.edge_lines, width=1, color=colormap.COLOR_MEDIUM[1])
 
-    if state.SHOW_FLUX_MESH > 0:
+    if state.SHOW_FLUX_MESH > 0 and state.SHOW_GRANULES == False:
         ewave.update_flux_mesh_values(
             state.wave_field,
             state.trackers,
@@ -522,6 +525,21 @@ def render_elements(state):
             )
             # Render particle shell at wave-center position
             render.scene.particles(position, radius, color=color)
+
+    # Render granule positional displacement (only when flux mesh is active, since position
+    # is sampled from full-grid displacement data)
+    if state.SHOW_GRANULES and state.SHOW_FLUX_MESH > 0:
+        max_particles = 101
+        granule_radius = 0.002  # in screen space (relative to max universe edge and scale factor)
+        amp_boost = state.WARP_MESH  # Boost granule displacement for better visibility
+        nx, ny = state.wave_field.nx, state.wave_field.ny
+        stride = max(1, int(np.ceil(np.sqrt(nx * ny / max_particles))))
+        sampled_nx = (nx + stride - 1) // stride
+        sampled_ny = (ny + stride - 1) // stride
+        num_render = min(sampled_nx * sampled_ny, max_particles)
+        ewave.sample_position_to_render(state.wave_field, amp_boost, stride, num_render)
+        pos_np = state.wave_field.position_render.to_numpy()[:num_render]
+        render.scene.particles(pos_np, granule_radius, color=colormap.COLOR_MEDIUM[1])
 
 
 # ================================================================

--- a/openwave/xperiments/m4_vector_wave/spacetime_medium.py
+++ b/openwave/xperiments/m4_vector_wave/spacetime_medium.py
@@ -113,6 +113,7 @@ class WaveField:
         # Scales 1e-17 m values to ~10 am, well within f32 range
         # Wave displacement vector field (ψ)
         self.displacement_am = ti.Vector.field(3, dtype=ti.f32, shape=self.grid_size)  # am, ψ
+        self.position_render = ti.Vector.field(3, dtype=ti.f32, shape=(self.nx * self.ny))  # flat
         # TODO: check need for velocity field = pressure / density
         # Wave velocity vector field (v = dψ/dt)
         # self.velocity_am = ti.Vector.field(3, dtype=ti.f32, shape=self.grid_size)  # am/s

--- a/openwave/xperiments/m4_vector_wave/wave_engine.py
+++ b/openwave/xperiments/m4_vector_wave/wave_engine.py
@@ -369,6 +369,38 @@ def propagate_wave_full(
 
 
 # ================================================================
+# POSITION RENDER
+# ================================================================
+
+
+@ti.kernel
+def sample_position_to_render(
+    wave_field: ti.template(),  # type: ignore
+    amp_boost: ti.f32,  # type: ignore
+    stride: ti.i32,  # type: ignore
+    num_render: ti.i32,  # type: ignore
+):
+    """Sample positions from z flux_mesh plane with stride, writing to 1D position_render.
+
+    Samples every `stride`-th voxel from the XY plane at the z flux mesh index,
+    capping output at `num_render` particles for performance.
+    """
+    k = int(wave_field.flux_mesh_planes[2] * wave_field.grid_size[2])
+    max_dim = ti.cast(wave_field.max_grid_size, ti.f32)
+    sampled_ny = (wave_field.ny + stride - 1) // stride  # cols per sampled row
+
+    for render_idx in range(num_render):
+        si = render_idx // sampled_ny  # sampled row index
+        sj = render_idx % sampled_ny  # sampled col index
+        i = si * stride
+        j = sj * stride
+        displaced = amp_boost * wave_field.displacement_am[i, j, k] / wave_field.dx_am + ti.Vector(
+            [ti.cast(i, ti.f32), ti.cast(j, ti.f32), ti.cast(k, ti.f32)]
+        )
+        wave_field.position_render[render_idx] = displaced / max_dim
+
+
+# ================================================================
 # 3-PLANE SAMPLING FOR AVERAGE TRACKERS
 # ================================================================
 # PERFORMANCE NOTE: Full GPU reduction (atomic_add over all voxels) causes

--- a/openwave/xperiments/m4_vector_wave/xparameters/0035_waves.py
+++ b/openwave/xperiments/m4_vector_wave/xparameters/0035_waves.py
@@ -39,6 +39,7 @@ XPARAMETERS = {
         "SHOW_FLUX_MESH": 1,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "WARP_MESH": 300,  # Visual warp mesh effect intensity
         "PARTICLE_SHELL": False,  # Toggle to enable/disable particle shell rendering
+        "SHOW_GRANULES": False,  # Toggle to show/hide granule particles (rendered as points)
         "TIMESTEP": 5.0,  # Simulation timestep in rontoseconds (10-27s)
         "PAUSED": False,  # Pause/Start simulation toggle
     },

--- a/openwave/xperiments/m4_vector_wave/xparameters/electric_attraction.py
+++ b/openwave/xperiments/m4_vector_wave/xparameters/electric_attraction.py
@@ -40,6 +40,7 @@ XPARAMETERS = {
         "SHOW_FLUX_MESH": 1,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "WARP_MESH": 300,  # Visual warp mesh effect intensity
         "PARTICLE_SHELL": True,  # Toggle to enable/disable particle shell rendering
+        "SHOW_GRANULES": False,  # Toggle to show/hide granule particles (rendered as points)
         "TIMESTEP": 5.0,  # Simulation timestep in rontoseconds (10-27s)
         "PAUSED": False,  # Pause/Start simulation toggle
     },

--- a/openwave/xperiments/m4_vector_wave/xparameters/electric_attraction2.py
+++ b/openwave/xperiments/m4_vector_wave/xparameters/electric_attraction2.py
@@ -40,6 +40,7 @@ XPARAMETERS = {
         "SHOW_FLUX_MESH": 1,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "WARP_MESH": 300,  # Visual warp mesh effect intensity
         "PARTICLE_SHELL": True,  # Toggle to enable/disable particle shell rendering
+        "SHOW_GRANULES": False,  # Toggle to show/hide granule particles (rendered as points)
         "TIMESTEP": 5.0,  # Simulation timestep in rontoseconds (10-27s)
         "PAUSED": False,  # Pause/Start simulation toggle
     },

--- a/openwave/xperiments/m4_vector_wave/xparameters/electric_attraction3.py
+++ b/openwave/xperiments/m4_vector_wave/xparameters/electric_attraction3.py
@@ -40,6 +40,7 @@ XPARAMETERS = {
         "SHOW_FLUX_MESH": 1,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "WARP_MESH": 300,  # Visual warp mesh effect intensity
         "PARTICLE_SHELL": True,  # Toggle to enable/disable particle shell rendering
+        "SHOW_GRANULES": False,  # Toggle to show/hide granule particles (rendered as points)
         "TIMESTEP": 5.0,  # Simulation timestep in rontoseconds (10-27s)
         "PAUSED": False,  # Pause/Start simulation toggle
     },

--- a/openwave/xperiments/m4_vector_wave/xparameters/electric_repulsion.py
+++ b/openwave/xperiments/m4_vector_wave/xparameters/electric_repulsion.py
@@ -40,6 +40,7 @@ XPARAMETERS = {
         "SHOW_FLUX_MESH": 1,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "WARP_MESH": 300,  # Visual warp mesh effect intensity
         "PARTICLE_SHELL": True,  # Toggle to enable/disable particle shell rendering
+        "SHOW_GRANULES": False,  # Toggle to show/hide granule particles (rendered as points)
         "TIMESTEP": 5.0,  # Simulation timestep in rontoseconds (10-27s)
         "PAUSED": False,  # Pause/Start simulation toggle
     },

--- a/openwave/xperiments/m4_vector_wave/xparameters/electric_repulsion2.py
+++ b/openwave/xperiments/m4_vector_wave/xparameters/electric_repulsion2.py
@@ -40,6 +40,7 @@ XPARAMETERS = {
         "SHOW_FLUX_MESH": 2,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "WARP_MESH": 300,  # Visual warp mesh effect intensity
         "PARTICLE_SHELL": True,  # Toggle to enable/disable particle shell rendering
+        "SHOW_GRANULES": False,  # Toggle to show/hide granule particles (rendered as points)
         "TIMESTEP": 5.0,  # Simulation timestep in rontoseconds (10-27s)
         "PAUSED": False,  # Pause/Start simulation toggle
     },

--- a/openwave/xperiments/m4_vector_wave/xparameters/electric_repulsion3.py
+++ b/openwave/xperiments/m4_vector_wave/xparameters/electric_repulsion3.py
@@ -40,6 +40,7 @@ XPARAMETERS = {
         "SHOW_FLUX_MESH": 1,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "WARP_MESH": 300,  # Visual warp mesh effect intensity
         "PARTICLE_SHELL": True,  # Toggle to enable/disable particle shell rendering
+        "SHOW_GRANULES": False,  # Toggle to show/hide granule particles (rendered as points)
         "TIMESTEP": 5.0,  # Simulation timestep in rontoseconds (10-27s)
         "PAUSED": False,  # Pause/Start simulation toggle
     },

--- a/openwave/xperiments/m4_vector_wave/xparameters/electric_repulsion4.py
+++ b/openwave/xperiments/m4_vector_wave/xparameters/electric_repulsion4.py
@@ -42,6 +42,7 @@ XPARAMETERS = {
         "SHOW_FLUX_MESH": 2,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "WARP_MESH": 300,  # Visual warp mesh effect intensity
         "PARTICLE_SHELL": True,  # Toggle to enable/disable particle shell rendering
+        "SHOW_GRANULES": False,  # Toggle to show/hide granule particles (rendered as points)
         "TIMESTEP": 5.0,  # Simulation timestep in rontoseconds (10-27s)
         "PAUSED": False,  # Pause/Start simulation toggle
     },

--- a/openwave/xperiments/m4_vector_wave/xparameters/electric_repulsion5.py
+++ b/openwave/xperiments/m4_vector_wave/xparameters/electric_repulsion5.py
@@ -63,6 +63,7 @@ XPARAMETERS = {
         "SHOW_FLUX_MESH": 2,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "WARP_MESH": 300,  # Visual warp mesh effect intensity
         "PARTICLE_SHELL": True,  # Toggle to enable/disable particle shell rendering
+        "SHOW_GRANULES": False,  # Toggle to show/hide granule particles (rendered as points)
         "TIMESTEP": 5.0,  # Simulation timestep in rontoseconds (10-27s)
         "PAUSED": False,  # Pause/Start simulation toggle
     },

--- a/openwave/xperiments/m4_vector_wave/xparameters/test_max.py
+++ b/openwave/xperiments/m4_vector_wave/xparameters/test_max.py
@@ -43,6 +43,7 @@ XPARAMETERS = {
         "SHOW_FLUX_MESH": 1,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "WARP_MESH": 200,  # Visual warp mesh effect intensity
         "PARTICLE_SHELL": False,  # Toggle to enable/disable particle shell rendering
+        "SHOW_GRANULES": False,  # Toggle to show/hide granule particles (rendered as points)
         "TIMESTEP": 5.0,  # Simulation timestep in rontoseconds (10-27s)
         "PAUSED": False,  # Pause/Start simulation toggle
     },

--- a/openwave/xperiments/m4_vector_wave/xparameters/test_stress.py
+++ b/openwave/xperiments/m4_vector_wave/xparameters/test_stress.py
@@ -39,6 +39,7 @@ XPARAMETERS = {
         "SHOW_FLUX_MESH": 1,  # Flux Mesh toggle, 0: none, 1: xy, 2: xy+xz, 3: xy+xz+yz
         "WARP_MESH": 0,  # Visual warp mesh effect intensity
         "PARTICLE_SHELL": False,  # Toggle to enable/disable particle shell rendering
+        "SHOW_GRANULES": False,  # Toggle to show/hide granule particles (rendered as points)
         "TIMESTEP": 5.0,  # Simulation timestep in rontoseconds (10-27s)
         "PAUSED": False,  # Pause/Start simulation toggle
     },


### PR DESCRIPTION
Introduce optional granule/particle visualization and enable perspective projection.

- Render: set camera.projection_mode to Perspective to fix 3D view.
- m4_vector_wave: add SHOW_GRANULES state, UI checkbox, and adjusted controls sub-window height; only render granules when flux mesh is active. Implement position_render field and a Ti kernel sample_position_to_render to sample displacement positions (capped and strided for performance) and render granules as particles (uses WARP_MESH as amplitude boost).
- spacetime_medium: add position_render buffer used for flattened render positions.
- wave_engine: add kernel to sample XY plane positions into position_render, normalizing by grid size.
- xparameters: add SHOW_GRANULES default False across various vector-wave experiment presets.
- m3_wolff_lafreniere/_launcher.py and m4_vector_wave/_launcher.py: swap/adjust level bar colors for overlays.

These changes add a performant, toggleable granule visualization for the vector-wave experiment and fix camera projection for correct 3D rendering.