### PR TITLE
Adjust wave phase conventions and shifts

### DIFF
--- a/openwave/xperiments/m1_granule_motion/wave_engine.py
+++ b/openwave/xperiments/m1_granule_motion/wave_engine.py
@@ -191,7 +191,7 @@ def oscillate_granules(
 
     Wave Superposition Principle:
         x_total(t) = Σ[x_i(t)] for all wave sources i
-        x_i(t) = x_eq + A_i(r_i)·cos(ωt + kr_i + φ_source_i)·dir_i
+        x_i(t) = x_eq + A_i(r_i)·cos(kr_i + ωt + φ_source_i)·dir_i
 
     Where for each wave source i:
         - r_i: distance from wave source i to granule
@@ -266,13 +266,13 @@ def oscillate_granules(
             # Vector from vertex to granule equilibrium position
             r_vec = equilibrium_am[granule_idx] - universe_vertices_am[v]
             r_mag = r_vec.norm()
-            # A·cos(ωt - kr)·direction, negative for outward propagation, full amp
+            # A·cos(kr - ωt)·direction, negative for outward propagation, full amp
             base_wave_psi += (
                 base_wave_toggle
                 * base_amplitude_am
                 * amp_boost
                 / 8  # base-wave do not superpose, split per vertex for energy conservation
-                * ti.cos(temporal_phase - k_am * r_mag)
+                * ti.cos(k_am * r_mag - temporal_phase)
             ) * (r_vec / r_mag)
 
         # Initialize accumulation variables for wave superposition
@@ -284,9 +284,6 @@ def oscillate_granules(
             # Get precomputed direction and distance for this granule-source pair
             direction = sources_direction[granule_idx, source_idx]
             r_am = sources_distance_am[granule_idx, source_idx]
-
-            # Phase shift between in/out waves (at wave-center)
-            phase_shift = ti.math.pi
 
             # Source phase offset: initial phase of this wave-center
             source_offset = sources_phase_offset[source_idx]
@@ -306,34 +303,34 @@ def oscillate_granules(
 
             # MAIN WAVE FUNCTION ========================================
             # IN & OUT Wave displacement from this source
-            # A·cos(ωt ± kr + φ)·direction, positive for inward propagation, full amp
-            # A(r)·cos(ωt ± kr + φ)·direction, negative for outward propagation, amp falloff
+            # A·cos(kr + ωt + φ)·direction, positive for inward propagation, full amp
+            # A(r)·sin(kr - ωt - φ)·direction, negative for outward propagation, amp falloff
             in_wave_psi = (
                 in_wave_toggle
                 * base_amplitude_am
                 * amp_boost
                 / num_sources  # incoming wave do not superpose, split per WC for energy conservation
-                * ti.cos(temporal_phase + spatial_phase + source_offset)
+                * ti.cos(spatial_phase + (temporal_phase + source_offset))
             )
             out_wave_psi = (
                 out_wave_toggle
                 * amplitude_at_r_cap_am
-                * ti.cos(temporal_phase - spatial_phase + source_offset + phase_shift)
+                * ti.sin(spatial_phase - (temporal_phase + source_offset))
             )
             source_displacement_am = (in_wave_psi + out_wave_psi) * direction
 
-            # Wave velocity from this source: -A(r)·ω·sin(ωt ± kr + φ)·direction
+            # Wave velocity from this source: -A(r)·ω·sin(kr ± ωt + φ)·direction
             in_wave_vel = (
                 in_wave_toggle
                 * -base_amplitude_am
                 * omega_slo
-                * ti.sin(temporal_phase + spatial_phase + source_offset)
+                * ti.sin(spatial_phase + (temporal_phase + source_offset))
             ) / num_sources  # incoming wave do not superpose, gets split per WC
             out_wave_vel = (
                 out_wave_toggle
                 * -amplitude_at_r_cap_am
                 * omega_slo
-                * ti.sin(temporal_phase - spatial_phase + source_offset + phase_shift)
+                * ti.sin(spatial_phase - (temporal_phase + source_offset))
             )
             source_velocity_am = (in_wave_vel + out_wave_vel) * direction
 

--- a/openwave/xperiments/m3_wolff_lafreniere/research/wave1D_plot.py
+++ b/openwave/xperiments/m3_wolff_lafreniere/research/wave1D_plot.py
@@ -166,7 +166,7 @@ def compute_wave_ampfalloff(
         direction: +1 for incoming wave, -1 for outgoing wave
         source: Wave source (1 = wc1, 2 = wc2) for phase offset
     """
-    phase_shift = np.pi  # phase shift between in/out waves (at wave-center)
+    phase_shift = np.pi / 2  # phase shift between in/out waves (at wave-center)
     source_offset = get_source_offset(source)
     # λ as reference radius → amplitude = A₀ at r = λ
     # Clamp r to avoid singularity at r = 0 (min r = λ)

--- a/openwave/xperiments/m4_vector_wave/research/wave1D_plot.py
+++ b/openwave/xperiments/m4_vector_wave/research/wave1D_plot.py
@@ -167,7 +167,7 @@ def compute_wave_ampfalloff(
         direction: +1 for incoming wave, -1 for outgoing wave
         source: Wave source (1 = wc1, 2 = wc2) for phase offset
     """
-    phase_shift = 0  # phase shift between in/out waves (at wave-center)
+    phase_shift = np.pi / 2  # phase shift between in/out waves (at wave-center)
     source_offset = get_source_offset(source)
     # λ as reference radius → amplitude = A₀ at r = λ
     # Clamp r to avoid singularity at r = 0 (min r = λ)


### PR DESCRIPTION
Unify and correct phase ordering and phase-shifts for wave computations. In m1_granule_motion/wave_engine.py the spatial/temporal terms were reordered (kr before ωt) and corresponding cos/sin arguments and velocity expressions were updated; a redundant per-source phase_shift was removed. In both m3_wolff_lafreniere and m4_vector_wave wave1D_plot.py the in/out phase offset was changed to π/2 to match the updated phase convention and in/out wave relationship. These changes align spatial and temporal phase usage across the modules and fix inconsistent in/out phase handling.