### PR TITLE
VECTOR-WARP: Use vector displacement for flux mesh motion

### DIFF
--- a/openwave/xperiments/m5_lagrangian_field/_launcher.py
+++ b/openwave/xperiments/m5_lagrangian_field/_launcher.py
@@ -342,12 +342,16 @@ def display_wave_menu(state):
     with render.gui.sub_window("WAVE MENU", 0.00, 0.73, 0.15, 0.15) as sub:
         if sub.checkbox("Displacement (Magnitude)", state.WAVE_MENU == 1):
             state.WAVE_MENU = 1
+            state.wave_field.create_flux_mesh()
         if sub.checkbox("Amplitude (EMA RMS)", state.WAVE_MENU == 2):
             state.WAVE_MENU = 2
+            state.wave_field.create_flux_mesh()
         if sub.checkbox("Frequency (L&T)", state.WAVE_MENU == 3):
             state.WAVE_MENU = 3
+            state.wave_field.create_flux_mesh()
         if sub.checkbox("Hamiltonian (M5.0g)", state.WAVE_MENU == 4):
             state.WAVE_MENU = 4
+            state.wave_field.create_flux_mesh()
         # Display gradient palette with 2× average range for headroom (allows peak visualization)
         if state.WAVE_MENU == 1:  # Displacement on orange gradient
             render.canvas.triangles(og_palette_vertices, per_vertex_color=og_palette_colors)

--- a/openwave/xperiments/m5_lagrangian_field/lagrangian_engine.py
+++ b/openwave/xperiments/m5_lagrangian_field/lagrangian_engine.py
@@ -697,7 +697,7 @@ def update_flux_mesh_values(
     # to displacement view in the meantime.
     for i, j in ti.ndrange(wave_field.nx, wave_field.ny):
         # Sample displacement at this voxel
-        disp_value = wave_field.psi_am[i, j, wave_field.fm_plane_z_idx].norm()
+        disp_value = wave_field.psi_am[i, j, wave_field.fm_plane_z_idx]
         amp_value = trackers.amp_local_emarms_am[i, j, wave_field.fm_plane_z_idx]
         freq_value = trackers.freq_local_cross_rHz[i, j, wave_field.fm_plane_z_idx]
         univ_edge_z = wave_field.universe_size_am[2]
@@ -706,11 +706,12 @@ def update_flux_mesh_values(
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
         if wave_menu == 4:  # ironbow
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_ironbow_color(
-                disp_value, 0, trackers.amp_global_emarms_am[None] * 4
+                disp_value.norm(), 0, trackers.amp_global_emarms_am[None] * 4
             )
-            wave_field.fluxmesh_xy_vertices[i, j][2] = (
-                disp_value / univ_edge_z * warp_mesh
-                + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
+            wave_field.fluxmesh_xy_vertices[i, j][
+                2
+            ] = disp_value.norm() / univ_edge_z * warp_mesh + wave_field.flux_mesh_planes[2] * (
+                wave_field.nz / wave_field.max_grid_size
             )
         elif wave_menu == 3:  # blueprint
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_blueprint_color(
@@ -731,11 +732,17 @@ def update_flux_mesh_values(
             )
         else:  # default to orange (wave_menu == 1 or 4)
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_orange_color(
-                disp_value, 0, trackers.amp_global_emarms_am[None] * 4
+                disp_value.norm(), 0, trackers.amp_global_emarms_am[None] * 4
             )
-            wave_field.fluxmesh_xy_vertices[i, j][2] = (
-                disp_value / univ_edge_z * warp_mesh
-                + wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
+            wave_field.fluxmesh_xy_vertices[i, j] = ti.Vector(
+                [
+                    (ti.cast(i, ti.f32) + 0.5) / wave_field.max_grid_size
+                    + disp_value[0] / wave_field.universe_size_am[0] * warp_mesh,
+                    (ti.cast(j, ti.f32) + 0.5) / wave_field.max_grid_size
+                    + disp_value[1] / wave_field.universe_size_am[1] * warp_mesh,
+                    wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size)
+                    + disp_value[2] / wave_field.universe_size_am[2] * warp_mesh,
+                ]
             )
 
     # ================================================================
@@ -743,7 +750,7 @@ def update_flux_mesh_values(
     # ================================================================
     for i, k in ti.ndrange(wave_field.nx, wave_field.nz):
         # Sample displacement at this voxel
-        disp_value = wave_field.psi_am[i, wave_field.fm_plane_y_idx, k].norm()
+        disp_value = wave_field.psi_am[i, wave_field.fm_plane_y_idx, k]
         amp_value = trackers.amp_local_emarms_am[i, wave_field.fm_plane_y_idx, k]
         freq_value = trackers.freq_local_cross_rHz[i, wave_field.fm_plane_y_idx, k]
         univ_edge_y = wave_field.universe_size_am[1]
@@ -752,11 +759,12 @@ def update_flux_mesh_values(
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
         if wave_menu == 4:  # ironbow
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_ironbow_color(
-                disp_value, 0, trackers.amp_global_emarms_am[None] * 4
+                disp_value.norm(), 0, trackers.amp_global_emarms_am[None] * 4
             )
-            wave_field.fluxmesh_xz_vertices[i, k][1] = (
-                disp_value / univ_edge_y * warp_mesh
-                + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
+            wave_field.fluxmesh_xz_vertices[i, k][
+                1
+            ] = disp_value.norm() / univ_edge_y * warp_mesh + wave_field.flux_mesh_planes[1] * (
+                wave_field.ny / wave_field.max_grid_size
             )
         elif wave_menu == 3:  # blueprint
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_blueprint_color(
@@ -777,11 +785,17 @@ def update_flux_mesh_values(
             )
         else:  # default to orange (wave_menu == 1 or 4)
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_orange_color(
-                disp_value, 0, trackers.amp_global_emarms_am[None] * 4
+                disp_value.norm(), 0, trackers.amp_global_emarms_am[None] * 4
             )
-            wave_field.fluxmesh_xz_vertices[i, k][1] = (
-                disp_value / univ_edge_y * warp_mesh
-                + wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
+            wave_field.fluxmesh_xz_vertices[i, k] = ti.Vector(
+                [
+                    (ti.cast(i, ti.f32) + 0.5) / wave_field.max_grid_size
+                    + disp_value[0] / wave_field.universe_size_am[0] * warp_mesh,
+                    wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size)
+                    + disp_value[1] / wave_field.universe_size_am[1] * warp_mesh,
+                    (ti.cast(k, ti.f32) + 0.5) / wave_field.max_grid_size
+                    + disp_value[2] / wave_field.universe_size_am[2] * warp_mesh,
+                ]
             )
 
     # ================================================================
@@ -789,7 +803,7 @@ def update_flux_mesh_values(
     # ================================================================
     for j, k in ti.ndrange(wave_field.ny, wave_field.nz):
         # Sample displacement at this voxel
-        disp_value = wave_field.psi_am[wave_field.fm_plane_x_idx, j, k].norm()
+        disp_value = wave_field.psi_am[wave_field.fm_plane_x_idx, j, k]
         amp_value = trackers.amp_local_emarms_am[wave_field.fm_plane_x_idx, j, k]
         freq_value = trackers.freq_local_cross_rHz[wave_field.fm_plane_x_idx, j, k]
         univ_edge_x = wave_field.universe_size_am[0]
@@ -798,11 +812,12 @@ def update_flux_mesh_values(
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
         if wave_menu == 4:  # ironbow
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_ironbow_color(
-                disp_value, 0, trackers.amp_global_emarms_am[None] * 4
+                disp_value.norm(), 0, trackers.amp_global_emarms_am[None] * 4
             )
-            wave_field.fluxmesh_yz_vertices[j, k][0] = (
-                disp_value / univ_edge_x * warp_mesh
-                + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
+            wave_field.fluxmesh_yz_vertices[j, k][
+                0
+            ] = disp_value.norm() / univ_edge_x * warp_mesh + wave_field.flux_mesh_planes[0] * (
+                wave_field.nx / wave_field.max_grid_size
             )
         elif wave_menu == 3:  # blueprint
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_blueprint_color(
@@ -823,9 +838,15 @@ def update_flux_mesh_values(
             )
         else:  # default to orange (wave_menu == 1 or 4)
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_orange_color(
-                disp_value, 0, trackers.amp_global_emarms_am[None] * 4
+                disp_value.norm(), 0, trackers.amp_global_emarms_am[None] * 4
             )
-            wave_field.fluxmesh_yz_vertices[j, k][0] = (
-                disp_value / univ_edge_x * warp_mesh
-                + wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
+            wave_field.fluxmesh_yz_vertices[j, k] = ti.Vector(
+                [
+                    wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size)
+                    + disp_value[0] / wave_field.universe_size_am[0] * warp_mesh,
+                    (ti.cast(j, ti.f32) + 0.5) / wave_field.max_grid_size
+                    + disp_value[1] / wave_field.universe_size_am[1] * warp_mesh,
+                    (ti.cast(k, ti.f32) + 0.5) / wave_field.max_grid_size
+                    + disp_value[2] / wave_field.universe_size_am[2] * warp_mesh,
+                ]
             )

--- a/openwave/xperiments/m5_lagrangian_field/xparameters/_test_smoke.py
+++ b/openwave/xperiments/m5_lagrangian_field/xparameters/_test_smoke.py
@@ -35,7 +35,7 @@ XPARAMETERS = {
         "DESCRIPTION": "Seeded traveling plane wave — visual leapfrog verification",
     },
     "camera": {
-        "INITIAL_POSITION": [0.37, 1.45, 1.24],
+        "INITIAL_POSITION": [0.97, 1.44, 1.11],
     },
     "universe": {
         "SIZE": [UNIVERSE_EDGE, UNIVERSE_EDGE, UNIVERSE_EDGE],
@@ -54,8 +54,8 @@ XPARAMETERS = {
         "SHOW_GRID": False,
         "SHOW_EDGES": True,
         "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],
-        "SHOW_FLUX_MESH": 1,
-        "WARP_MESH": 50,
+        "SHOW_FLUX_MESH": 3,
+        "WARP_MESH": 40,
         "PARTICLE_SHELL": False,
         "SHOW_GRANULES": False,
         "SIM_SPEED": 1.0,


### PR DESCRIPTION
Switch flux-mesh sampling to use the full displacement vector (psi_am) and use its norm only for color mapping. Compute flux-mesh vertex positions from each displacement component scaled by universe_size_am to produce full 3D warping, and reconstruct per-axis vertex vectors instead of writing single components. Call create_flux_mesh() when changing the WAVE_MENU to ensure the mesh is recreated on mode switch. Also lower the smoke-test WARP_MESH from 50 to 1 to reduce exaggerated deformation in tests.