### PR TITLE
M5.0 vector calculus tools and energy pipeline

### DIFF
--- a/openwave/xperiments/m2_laplace_propagation/_launcher.py
+++ b/openwave/xperiments/m2_laplace_propagation/_launcher.py
@@ -121,7 +121,7 @@ class SimulationState:
         self.ampT_global_rms = 0.0
         self.freq_global_avg = constants.EWAVE_FREQUENCY
         self.wavelength_global_avg = constants.EWAVE_LENGTH
-        self.energy_global = 0.0
+        self.energy_total = 0.0
         self.charge_level = 0.0
         self.charging = True
         self.damping = False
@@ -226,7 +226,7 @@ class SimulationState:
         self.ampT_global_rms = 0.0
         self.freq_global_avg = constants.EWAVE_FREQUENCY
         self.wavelength_global_avg = constants.EWAVE_LENGTH
-        self.energy_global = 0.0
+        self.energy_total = 0.0
         self.charge_level = 0.0
         self.charging = True
         self.damping = False
@@ -373,7 +373,7 @@ def display_data_dashboard(state):
         sub.text(f"Frequency: {state.freq_global_avg*state.wave_field.scale_factor:.1e} Hz")
         sub.text(f"Wavelength: {state.wavelength_global_avg/state.wave_field.scale_factor:.1e} m")
         sub.text(
-            f"GLOBAL ENERGY: {state.energy_global:.1e} J",
+            f"Total ENERGY: {state.energy_total:.1e} J",
             color=(
                 colormap.ORANGE[1]
                 if state.charging
@@ -520,13 +520,13 @@ def compute_wave_oscillation(state):
     state.wavelength_global_avg = constants.WAVE_SPEED / (
         state.freq_global_avg or 1
     )  # prevents 0 div
-    state.energy_global = (
+    state.energy_total = (
         constants.MEDIUM_DENSITY
         * state.wave_field.universe_volume
         * state.freq_global_avg**2
         * (state.ampL_global_rms**2 + state.ampT_global_rms**2)
     )
-    state.charge_level = state.energy_global / state.wave_field.nominal_energy
+    state.charge_level = state.energy_total / state.wave_field.nominal_energy
     state.charging = state.charge_level < 0.80  # stop charging, seeks energy stabilization
     state.damping = state.charge_level > 1.20  # start damping, seeks energy stabilization
 

--- a/openwave/xperiments/m5_lagrangian_field/_launcher.py
+++ b/openwave/xperiments/m5_lagrangian_field/_launcher.py
@@ -115,11 +115,20 @@ class SimulationState:
         self.elapsed_t_rs = 0.0
         self.clock_start_time = time.time()
         self.frame = 1
-        # Field aggregates — populated by sample_avg_trackers; physical units.
+        # Field aggregates — populated by sample_avg_trackers; physical units
+        # except for the energy attrs (see notes below).
         self.amp_global_rms = 0.0  # m
         self.freq_global_avg = 0.0  # Hz
         self.wavelength_global_avg = 0.0  # m, derived from freq_global_avg
-        self.hamiltonian_total_aJ = 0.0
+        # Energy attrs — currently in SCALED units (per-voxel (am/rs)² ×
+        # ATTOJOULE), not true J. The kernel that populates them
+        # (compute_energy_density_H) doesn't yet apply the physical scaling
+        # factor (ρ_medium × voxel_volume × INTERNAL_ENERGY_TO_AJ). Useful as
+        # *relative* observables for trends and force-gradient sourcing
+        # (F = −∇E only cares about gradients). REVIEW IN M5.2 when nonlinear
+        # V(ψ) couplings land alongside the physical-scaling factor.
+        self.energy_global_H_avg = 0.0  # per-voxel mean in scaled "(rel.)" units
+        self.energy_total_H = 0.0  # mean × voxel_count, scaled "(rel.)" units
         # Resolution metric: voxels-per-wavelength (xperiment-driven).
         # 0.0 means "no reference λ declared" → dashboard shows n/a
         self.wave_res = 0.0
@@ -273,7 +282,8 @@ class SimulationState:
         self.amp_global_rms = 0.0
         self.freq_global_avg = 0.0
         self.wavelength_global_avg = 0.0
-        self.hamiltonian_total_aJ = 0.0
+        self.energy_global_H_avg = 0.0
+        self.energy_total_H = 0.0
         self.wave_res = 0.0
         self.initialize_grid()
         self.compute_timestep()
@@ -349,7 +359,7 @@ def display_wave_menu(state):
         if sub.checkbox("Frequency (L&T)", state.WAVE_MENU == 3):
             state.WAVE_MENU = 3
             state.wave_field.create_flux_mesh()
-        if sub.checkbox("Hamiltonian (M5.0g)", state.WAVE_MENU == 4):
+        if sub.checkbox("ENERGY (Density)", state.WAVE_MENU == 4):
             state.WAVE_MENU = 4
             state.wave_field.create_flux_mesh()
         # Display gradient palette with 2× average range for headroom (allows peak visualization)
@@ -365,10 +375,15 @@ def display_wave_menu(state):
             render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
             with render.gui.sub_window("frequency", 0.00, 0.67, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.freq_global_avg*2:.0e}Hz")
-        if state.WAVE_MENU == 4:  # Hamiltonian density on ironbow gradient (M5.0g)
+        if state.WAVE_MENU == 4:  # Energy density (Hamiltonian) on ironbow gradient
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
-            with render.gui.sub_window("hamiltonian", 0.00, 0.67, 0.08, 0.06) as sub:
-                sub.text(f"total: {state.hamiltonian_total_aJ:.2e} aJ")
+            with render.gui.sub_window("energy", 0.00, 0.67, 0.08, 0.06) as sub:
+                # Unit label "rel." — value is per-voxel mean × 4 (matches the
+                # colormap range max in update_flux_mesh_values). Underlying field
+                # is in scaled (am/rs)² units, not physical J/m³ — REVIEW IN M5.2
+                # when physical-scaling factor (ρ × voxel_volume × correction)
+                # is wired into compute_energy_density_H.
+                sub.text(f"0      {state.energy_global_H_avg*4:.0e}rel.")
 
 
 def display_level_specs(state, level_bar_vertices):
@@ -416,9 +431,13 @@ def display_data_dashboard(state):
             sub.text("Wave: n/a (no wave declared)")
 
         sub.text("\n--- WAVE-FIELD ---", color=colormap.LIGHT_BLUE[1])
-        sub.text(f"Amplitude: {state.amp_global_rms:.1e} m")
-        sub.text(f"Frequency: {state.freq_global_avg:.1e} Hz")
-        sub.text(f"Wavelength: {state.wavelength_global_avg:.1e} m")
+        sub.text(f"Amplitude (avg): {state.amp_global_rms:.1e} m")
+        sub.text(f"Frequency (avg): {state.freq_global_avg:.1e} Hz")
+        sub.text(f"Wavelength (avg): {state.wavelength_global_avg:.1e} m")
+        # Unit label "rel." — energy_total_H is `mean × voxel_count × ATTOJOULE`
+        # but the mean is in scaled (am/rs)² units, not actual aJ — so the value
+        # isn't physically J. REVIEW IN M5.2 when physical-scaling factor lands.
+        sub.text(f"Total ENERGY (H): {state.energy_total_H:.1e} rel.")
 
         sub.text("\n--- TIME MICROSCOPE ---", color=colormap.LIGHT_BLUE[1])
         sub.text(f"Sim Steps (frames): {state.frame:,}")
@@ -436,7 +455,6 @@ def display_data_dashboard(state):
             f"CFL Factor: {state.cfl_factor:.3f} (target < 1/3)",
             color=(1.0, 1.0, 1.0) if state.cfl_factor <= (1 / 3) else (1.0, 0.0, 0.0),
         )
-        sub.text(f"Hamiltonian: {state.hamiltonian_total_aJ:.3e} aJ")
 
 
 # ================================================================
@@ -499,18 +517,27 @@ def compute_oscillation(state):
     # FIELD-OBSERVABLE TRACKERS (per-voxel amp / freq from ψ) ==============
     lagrange.update_trackers_psi(state.wave_field, state.trackers, state.dt_rs, state.elapsed_t_rs)
 
+    # PER-VOXEL ENERGY DENSITY (HAMILTONIAN) ========================================
+    # H = ½|ψ̇|² + ½c²|∇ψ|² + V(ψ)  written into trackers.energy_density_H_aJ.
+    # Consumed this same frame by xforce_motion (F = −∇E) and the flux-mesh
+    # WAVE_MENU=4 visualization. M5.0i: candidate to merge into propagate_psi
+    # for a ~25% per-step bandwidth saving.
+    lagrange.compute_energy_density_H(state.wave_field, state.trackers, state.c_amrs, state.dt_rs)
+
     # IN-FRAME DATA SAMPLING & ANALYTICS ==================================
-    # Frame skip reduces GPU->CPU transfer overhead
+    # Frame skip reduces GPU->CPU transfer overhead.
+    # sample_avg_trackers populates amp / freq / energy global aggregates in
+    # one 3-plane sampling pass; we derive the grid-total energy here as the
+    # trivial product mean × voxel_count (no extra Taichi work needed).
     if state.frame % 60 == 0 or state.frame == 10:
         lagrange.sample_avg_trackers(state.wave_field, state.trackers)
-        # Total Hamiltonian (≈conserved) — compute on the same cadence to avoid
-        # the GPU→CPU round-trip on every frame
-        state.hamiltonian_total_aJ = lagrange.compute_total_hamiltonian(
-            state.wave_field, state.c_amrs, state.dt_rs
-        )
+        state.energy_total_H = (
+            state.trackers.energy_global_H_avg_aJ[None] * state.wave_field.voxel_count
+        ) * constants.ATTOJOULE  # J
     state.amp_global_rms = state.trackers.amp_global_emarms_am[None] * constants.ATTOMETER  # m
     state.freq_global_avg = state.trackers.freq_global_avg_rHz[None] / constants.RONTOSECOND  # Hz
     state.wavelength_global_avg = constants.WAVE_SPEED / (state.freq_global_avg or 1)  # no 0 div
+    state.energy_global_H_avg = state.trackers.energy_global_H_avg_aJ[None] * constants.ATTOJOULE
 
     if state.INSTRUMENTATION:
         instrument.log_timestep_data(state.frame, state.wave_field, state.trackers)

--- a/openwave/xperiments/m5_lagrangian_field/_launcher.py
+++ b/openwave/xperiments/m5_lagrangian_field/_launcher.py
@@ -167,7 +167,7 @@ class SimulationState:
         self.VIDEO_FRAMES = 24
 
         # Optional wave seed (test xperiment only)
-        self.WAVE_SEED = None
+        self.TEST_SEED = None
 
     def apply_xparameters(self, params):
         """Apply parameters from xperiment parameter dictionary."""
@@ -216,7 +216,7 @@ class SimulationState:
         self.VIDEO_FRAMES = diag["VIDEO_FRAMES"]
 
         # Optional wave seed (only present in _test_smoke xperiment)
-        self.WAVE_SEED = params.get("wave_seed", None)
+        self.TEST_SEED = params.get("test_seed", None)
 
     def initialize_grid(self):
         """Initialize or reinitialize the wave-field grid and wave-centers."""
@@ -227,11 +227,11 @@ class SimulationState:
 
         # Resolution metric: voxels-per-wavelength, declared by the active
         # xperiment. Sources (in priority order):
-        #   1. WAVE_SEED["VOXELS_PER_WAVELENGTH"]   — seed-driven xperiments
+        #   1. TEST_SEED["VOXELS_PER_WAVELENGTH"]   — seed-driven xperiments
         #   2. (M5.2+) defect Compton wavelength    — particle xperiments
         #   3. None / 0.0                           — no reference (vacuum tests)
-        if self.WAVE_SEED is not None:
-            self.wave_res = float(self.WAVE_SEED.get("VOXELS_PER_WAVELENGTH", 0.0))
+        if self.TEST_SEED is not None:
+            self.wave_res = float(self.TEST_SEED.get("VOXELS_PER_WAVELENGTH", 0.0))
         else:
             self.wave_res = 0.0
 
@@ -486,10 +486,10 @@ def initialize_xperiment(state):
     level_bar_vertices = colormap.get_level_bar_geometry(0.84, 0.00, 0.159, 0.01)
 
     # Optional initial-condition seed for test xperiments
-    if state.WAVE_SEED is not None:
-        seed = state.WAVE_SEED
+    if state.TEST_SEED is not None:
+        seed = state.TEST_SEED
         polarization = ti.Vector(seed["POLARIZATION"], dt=ti.f32)
-        lagrange.seed_wave(
+        lagrange.seed_gaussian(
             state.wave_field,
             state.c_amrs,
             state.dt_rs,

--- a/openwave/xperiments/m5_lagrangian_field/lagrangian_engine.py
+++ b/openwave/xperiments/m5_lagrangian_field/lagrangian_engine.py
@@ -137,11 +137,27 @@ def seed_wave(
 # ================================================================
 # DIFFERENTIAL OPERATORS
 # ================================================================
-# 6-point Laplacian stencil for the vector field ψ. Acts component-wise on
-# psi_am (ti.Vector.field(3, ...)); Taichi handles Vector(3) arithmetic
-# natively, so the stencil applied to a Vector field returns a Vector field.
+# Vector calculus on the Vector(3) field ψ stored in psi_am. All operators
+# are 2nd-order central-difference @ti.func kernels — caller is responsible
+# for skipping boundary voxels (each operator's halo requirement is noted in
+# its docstring).
 #
-# Curl, divergence, and curl(curl) operators land in this section in M5.0e.
+#   compute_laplacian_psi   — ∇²ψ          → Vector(3); 1-cell halo
+#   compute_divergence_psi  — ∇·ψ          → scalar;    1-cell halo
+#   compute_curl_psi        — ∇×ψ          → Vector(3); 1-cell halo
+#   compute_curl_curl_psi   — ∇×(∇×ψ)      → Vector(3); 2-cell halo (uses identity)
+#
+# The curl-curl is implemented via the vector identity
+#       ∇×(∇×ψ) = ∇(∇·ψ) − ∇²ψ
+# rather than applying compute_curl twice. Two reasons:
+#   1. Reuses validated Laplacian — only the gradient-of-divergence part is
+#      new code, easier to verify
+#   2. 2-cell halo (vs. 4-cell for nested curl) keeps the loop range tight
+#      and matches Exp 7 v2's implementation (the reference)
+#
+# Why @ti.func not @ti.kernel: these are inner-loop primitives meant to be
+# called from kernels that iterate over voxels (propagate_psi, future force
+# kernels, divergence-cleaning projections, etc.), not standalone passes.
 
 
 @ti.func
@@ -186,6 +202,160 @@ def compute_laplacian_psi(
     center = wave_field.psi_am[i, j, k]
     laplacian_psi_am = (face_sum - 6.0 * center) / (wave_field.dx_am**2)
     return laplacian_psi_am
+
+
+@ti.func
+def compute_divergence_psi(
+    wave_field: ti.template(),  # type: ignore
+    i: ti.i32,  # type: ignore
+    j: ti.i32,  # type: ignore
+    k: ti.i32,  # type: ignore
+):
+    """
+    Compute the scalar divergence ∇·ψ at voxel [i, j, k].
+
+    Standard 2nd-order central-difference stencil:
+        ∇·ψ ≈ (∂_x ψ_x + ∂_y ψ_y + ∂_z ψ_z)
+            = [ ψ_x[i+1] − ψ_x[i−1]
+              + ψ_y[j+1] − ψ_y[j−1]
+              + ψ_z[k+1] − ψ_z[k−1] ] / (2·dx)
+
+    Used by:
+      - M5.1 winding-number tracker (∇·n on the director field is an
+        observable near hedgehog defects)
+      - M5.2 Close Eq. 23 — the constraint ∇·s = 0 must be enforced;
+        divergence-cleaning projection reads this each step
+      - M5.0e curl_curl identity ∇×(∇×ψ) = ∇(∇·ψ) − ∇²ψ
+
+    Args:
+        wave_field: WaveField instance (reads psi_am)
+        i, j, k: Voxel indices (must be interior: 0 < i < nx-1, etc. —
+            caller handles boundary skip; 1-cell halo)
+
+    Returns:
+        ∇·ψ as ti.f32 scalar in units [am / am] = [dimensionless]
+    """
+    inv_2dx = 1.0 / (2.0 * wave_field.dx_am)
+    dpsi_x_dx = (
+        wave_field.psi_am[i + 1, j, k][0] - wave_field.psi_am[i - 1, j, k][0]
+    ) * inv_2dx
+    dpsi_y_dy = (
+        wave_field.psi_am[i, j + 1, k][1] - wave_field.psi_am[i, j - 1, k][1]
+    ) * inv_2dx
+    dpsi_z_dz = (
+        wave_field.psi_am[i, j, k + 1][2] - wave_field.psi_am[i, j, k - 1][2]
+    ) * inv_2dx
+    return dpsi_x_dx + dpsi_y_dy + dpsi_z_dz
+
+
+@ti.func
+def compute_curl_psi(
+    wave_field: ti.template(),  # type: ignore
+    i: ti.i32,  # type: ignore
+    j: ti.i32,  # type: ignore
+    k: ti.i32,  # type: ignore
+):
+    """
+    Compute the vector curl ∇×ψ at voxel [i, j, k].
+
+    Standard 2nd-order central-difference stencil:
+        (∇×ψ)_x = ∂_y ψ_z − ∂_z ψ_y
+        (∇×ψ)_y = ∂_z ψ_x − ∂_x ψ_z
+        (∇×ψ)_z = ∂_x ψ_y − ∂_y ψ_x
+
+    Used by:
+      - M5.2 Close Eq. 19 linear limit  ∂²_t Q = −c² · ∇×(∇×Q)
+      - Spin-density observables (s = curl of velocity field analog)
+      - Magnetic-channel diagnostics in M7+ (transverse component extraction)
+
+    Args:
+        wave_field: WaveField instance (reads psi_am)
+        i, j, k: Voxel indices (must be interior: 0 < i < nx-1, etc. —
+            caller handles boundary skip; 1-cell halo)
+
+    Returns:
+        ∇×ψ as Vector(3) in units [am / am] = [dimensionless]
+    """
+    inv_2dx = 1.0 / (2.0 * wave_field.dx_am)
+    # ∂_y ψ_z, ∂_z ψ_y
+    dpsi_z_dy = (
+        wave_field.psi_am[i, j + 1, k][2] - wave_field.psi_am[i, j - 1, k][2]
+    ) * inv_2dx
+    dpsi_y_dz = (
+        wave_field.psi_am[i, j, k + 1][1] - wave_field.psi_am[i, j, k - 1][1]
+    ) * inv_2dx
+    # ∂_z ψ_x, ∂_x ψ_z
+    dpsi_x_dz = (
+        wave_field.psi_am[i, j, k + 1][0] - wave_field.psi_am[i, j, k - 1][0]
+    ) * inv_2dx
+    dpsi_z_dx = (
+        wave_field.psi_am[i + 1, j, k][2] - wave_field.psi_am[i - 1, j, k][2]
+    ) * inv_2dx
+    # ∂_x ψ_y, ∂_y ψ_x
+    dpsi_y_dx = (
+        wave_field.psi_am[i + 1, j, k][1] - wave_field.psi_am[i - 1, j, k][1]
+    ) * inv_2dx
+    dpsi_x_dy = (
+        wave_field.psi_am[i, j + 1, k][0] - wave_field.psi_am[i, j - 1, k][0]
+    ) * inv_2dx
+    return ti.Vector(
+        [
+            dpsi_z_dy - dpsi_y_dz,
+            dpsi_x_dz - dpsi_z_dx,
+            dpsi_y_dx - dpsi_x_dy,
+        ]
+    )
+
+
+@ti.func
+def compute_curl_curl_psi(
+    wave_field: ti.template(),  # type: ignore
+    i: ti.i32,  # type: ignore
+    j: ti.i32,  # type: ignore
+    k: ti.i32,  # type: ignore
+):
+    """
+    Compute ∇×(∇×ψ) at voxel [i, j, k] via the vector identity
+        ∇×(∇×ψ) = ∇(∇·ψ) − ∇²ψ
+
+    The gradient of divergence is computed by central-differencing
+    compute_divergence_psi at the six face neighbors — that's what makes
+    this a 2-cell halo operator (each face neighbor itself needs a 1-cell
+    halo for its own divergence stencil, so [i±2, j, k] etc. are read).
+
+    The Laplacian piece reuses the validated compute_laplacian_psi.
+
+    Used by M5.2 Close Eq. 19 linear limit  ∂²_t Q = −c² · ∇×(∇×Q).
+
+    Args:
+        wave_field: WaveField instance (reads psi_am)
+        i, j, k: Voxel indices (must be interior with 2-cell halo:
+            1 < i < nx-2, etc. — caller handles boundary skip)
+
+    Returns:
+        ∇×(∇×ψ) as Vector(3) in units [am / am²] = [1/am]
+    """
+    inv_2dx = 1.0 / (2.0 * wave_field.dx_am)
+
+    # ∇(∇·ψ): central-difference the divergence at the six face neighbors
+    div_xp = compute_divergence_psi(wave_field, i + 1, j, k)
+    div_xm = compute_divergence_psi(wave_field, i - 1, j, k)
+    div_yp = compute_divergence_psi(wave_field, i, j + 1, k)
+    div_ym = compute_divergence_psi(wave_field, i, j - 1, k)
+    div_zp = compute_divergence_psi(wave_field, i, j, k + 1)
+    div_zm = compute_divergence_psi(wave_field, i, j, k - 1)
+
+    grad_div = ti.Vector(
+        [
+            (div_xp - div_xm) * inv_2dx,
+            (div_yp - div_ym) * inv_2dx,
+            (div_zp - div_zm) * inv_2dx,
+        ]
+    )
+
+    laplacian = compute_laplacian_psi(wave_field, i, j, k)
+
+    return grad_div - laplacian
 
 
 # ================================================================

--- a/openwave/xperiments/m5_lagrangian_field/lagrangian_engine.py
+++ b/openwave/xperiments/m5_lagrangian_field/lagrangian_engine.py
@@ -13,7 +13,7 @@ Module layout (top-to-bottom):
     INITIAL-CONDITION SEEDING — seed_wave (test/UI verification)
     ψ PROPAGATION ENGINE      — propagate_psi (leapfrog/Verlet)
     FIELD OBSERVABLES         — update_trackers_psi (amp/freq EMA)
-    TOTAL HAMILTONIAN         — compute_total_hamiltonian (scalar reduction)
+    ENERGY DENSITY (HAMILTONIAN) — compute_energy_density_H
     POSITION RENDER           — sample_position_to_render (granule viz)
     3-PLANE SAMPLING          — sample_avg_trackers (cheap global means)
     FLUX MESH UPDATING        — update_flux_mesh_values (color mapping)
@@ -236,15 +236,9 @@ def compute_divergence_psi(
         ∇·ψ as ti.f32 scalar in units [am / am] = [dimensionless]
     """
     inv_2dx = 1.0 / (2.0 * wave_field.dx_am)
-    dpsi_x_dx = (
-        wave_field.psi_am[i + 1, j, k][0] - wave_field.psi_am[i - 1, j, k][0]
-    ) * inv_2dx
-    dpsi_y_dy = (
-        wave_field.psi_am[i, j + 1, k][1] - wave_field.psi_am[i, j - 1, k][1]
-    ) * inv_2dx
-    dpsi_z_dz = (
-        wave_field.psi_am[i, j, k + 1][2] - wave_field.psi_am[i, j, k - 1][2]
-    ) * inv_2dx
+    dpsi_x_dx = (wave_field.psi_am[i + 1, j, k][0] - wave_field.psi_am[i - 1, j, k][0]) * inv_2dx
+    dpsi_y_dy = (wave_field.psi_am[i, j + 1, k][1] - wave_field.psi_am[i, j - 1, k][1]) * inv_2dx
+    dpsi_z_dz = (wave_field.psi_am[i, j, k + 1][2] - wave_field.psi_am[i, j, k - 1][2]) * inv_2dx
     return dpsi_x_dx + dpsi_y_dy + dpsi_z_dz
 
 
@@ -278,26 +272,14 @@ def compute_curl_psi(
     """
     inv_2dx = 1.0 / (2.0 * wave_field.dx_am)
     # ∂_y ψ_z, ∂_z ψ_y
-    dpsi_z_dy = (
-        wave_field.psi_am[i, j + 1, k][2] - wave_field.psi_am[i, j - 1, k][2]
-    ) * inv_2dx
-    dpsi_y_dz = (
-        wave_field.psi_am[i, j, k + 1][1] - wave_field.psi_am[i, j, k - 1][1]
-    ) * inv_2dx
+    dpsi_z_dy = (wave_field.psi_am[i, j + 1, k][2] - wave_field.psi_am[i, j - 1, k][2]) * inv_2dx
+    dpsi_y_dz = (wave_field.psi_am[i, j, k + 1][1] - wave_field.psi_am[i, j, k - 1][1]) * inv_2dx
     # ∂_z ψ_x, ∂_x ψ_z
-    dpsi_x_dz = (
-        wave_field.psi_am[i, j, k + 1][0] - wave_field.psi_am[i, j, k - 1][0]
-    ) * inv_2dx
-    dpsi_z_dx = (
-        wave_field.psi_am[i + 1, j, k][2] - wave_field.psi_am[i - 1, j, k][2]
-    ) * inv_2dx
+    dpsi_x_dz = (wave_field.psi_am[i, j, k + 1][0] - wave_field.psi_am[i, j, k - 1][0]) * inv_2dx
+    dpsi_z_dx = (wave_field.psi_am[i + 1, j, k][2] - wave_field.psi_am[i - 1, j, k][2]) * inv_2dx
     # ∂_x ψ_y, ∂_y ψ_x
-    dpsi_y_dx = (
-        wave_field.psi_am[i + 1, j, k][1] - wave_field.psi_am[i - 1, j, k][1]
-    ) * inv_2dx
-    dpsi_x_dy = (
-        wave_field.psi_am[i, j + 1, k][0] - wave_field.psi_am[i, j - 1, k][0]
-    ) * inv_2dx
+    dpsi_y_dx = (wave_field.psi_am[i + 1, j, k][1] - wave_field.psi_am[i - 1, j, k][1]) * inv_2dx
+    dpsi_x_dy = (wave_field.psi_am[i, j + 1, k][0] - wave_field.psi_am[i, j - 1, k][0]) * inv_2dx
     return ti.Vector(
         [
             dpsi_z_dy - dpsi_y_dz,
@@ -522,140 +504,127 @@ def update_trackers_psi(
 
 
 # ================================================================
-# TOTAL HAMILTONIAN — DASHBOARD ENERGY OBSERVABLE
+# POTENTIAL ENERGY HOOK — V(ψ)
 # ================================================================
-# H = ½|ψ̇|² + ½c²|∇ψ|² + V(ψ)  ;  V=0 in M5.0d.
-# Estimated via 3-plane center-slice sampling — same compromise as
-# sample_avg_trackers, for the same reason: a full 3D atomic reduction on a
-# 100M-voxel grid contends so badly it can stall the GUI for tens of seconds
-# (looks like a freeze). 3-plane sampling reads ~3·N² voxels and is exact for
-# spatially-uniform fields and a good estimator for smooth wave packets.
-# Per-voxel H density field + force coupling land in M5.0g.
+# Default V(ψ) = 0 (free wave) in M5.0g. M5.2 swaps this implementation in to
+# add the nonlinear physics:
+#   - Klein-Gordon mass:    V = ½ m² |ψ|²
+#   - Close Eq. 23 nonlin:  V = … (from −u·∇s + w×s couplings)
+#   - LdG biaxial:          V = polynomial in (Q, axes δ/1/g)
+#
+# When M5.2 lands, this hook is also where the kernel-internal natural-unit
+# scaling lives (c=1, λ_C=1, ℏ=1) — the wrapping function converts ψ to
+# natural units, evaluates the textbook potential, converts the scalar back.
+# Linear kernels (leapfrog, Laplacian, divergence, curl, curl-curl) stay in
+# storage units throughout (am, rs, rHz) — they're dimensionally self-balancing,
+# don't benefit from natural units. See M5.0f decision-record in 3d_path_to_m5.md.
 
 
-@ti.kernel
-def _hamiltonian_slice_xy(
-    wave_field: ti.template(),  # type: ignore
-    c_amrs: ti.f32,  # type: ignore
-    dt_rs: ti.f32,  # type: ignore
-    H_slice: ti.template(),  # type: ignore
-    mid_z: ti.i32,  # type: ignore
+@ti.func
+def V_psi(
+    psi: ti.template(),  # type: ignore
 ):
-    """H per voxel on the XY center plane (fixed z = mid_z). Excludes boundary."""
-    nx, ny = wave_field.nx, wave_field.ny
-    inv_dt = 1.0 / dt_rs
-    half_c2 = 0.5 * c_amrs**2
-
-    for i, j in ti.ndrange((1, nx - 1), (1, ny - 1)):
-        psi_dot = (wave_field.psi_am[i, j, mid_z] - wave_field.psi_prev_am[i, j, mid_z]) * inv_dt
-        kinetic = 0.5 * psi_dot.norm_sqr()
-        d_dx = (wave_field.psi_am[i + 1, j, mid_z] - wave_field.psi_am[i - 1, j, mid_z]) / (
-            2.0 * wave_field.dx_am
-        )
-        d_dy = (wave_field.psi_am[i, j + 1, mid_z] - wave_field.psi_am[i, j - 1, mid_z]) / (
-            2.0 * wave_field.dx_am
-        )
-        d_dz = (wave_field.psi_am[i, j, mid_z + 1] - wave_field.psi_am[i, j, mid_z - 1]) / (
-            2.0 * wave_field.dx_am
-        )
-        grad_sq = d_dx.norm_sqr() + d_dy.norm_sqr() + d_dz.norm_sqr()
-        H_slice[i, j] = kinetic + half_c2 * grad_sq
-
-
-@ti.kernel
-def _hamiltonian_slice_xz(
-    wave_field: ti.template(),  # type: ignore
-    c_amrs: ti.f32,  # type: ignore
-    dt_rs: ti.f32,  # type: ignore
-    H_slice: ti.template(),  # type: ignore
-    mid_y: ti.i32,  # type: ignore
-):
-    """H per voxel on the XZ center plane (fixed y = mid_y). Excludes boundary."""
-    nx, nz = wave_field.nx, wave_field.nz
-    inv_dt = 1.0 / dt_rs
-    half_c2 = 0.5 * c_amrs**2
-
-    for i, k in ti.ndrange((1, nx - 1), (1, nz - 1)):
-        psi_dot = (wave_field.psi_am[i, mid_y, k] - wave_field.psi_prev_am[i, mid_y, k]) * inv_dt
-        kinetic = 0.5 * psi_dot.norm_sqr()
-        d_dx = (wave_field.psi_am[i + 1, mid_y, k] - wave_field.psi_am[i - 1, mid_y, k]) / (
-            2.0 * wave_field.dx_am
-        )
-        d_dy = (wave_field.psi_am[i, mid_y + 1, k] - wave_field.psi_am[i, mid_y - 1, k]) / (
-            2.0 * wave_field.dx_am
-        )
-        d_dz = (wave_field.psi_am[i, mid_y, k + 1] - wave_field.psi_am[i, mid_y, k - 1]) / (
-            2.0 * wave_field.dx_am
-        )
-        grad_sq = d_dx.norm_sqr() + d_dy.norm_sqr() + d_dz.norm_sqr()
-        H_slice[i, k] = kinetic + half_c2 * grad_sq
-
-
-@ti.kernel
-def _hamiltonian_slice_yz(
-    wave_field: ti.template(),  # type: ignore
-    c_amrs: ti.f32,  # type: ignore
-    dt_rs: ti.f32,  # type: ignore
-    H_slice: ti.template(),  # type: ignore
-    mid_x: ti.i32,  # type: ignore
-):
-    """H per voxel on the YZ center plane (fixed x = mid_x). Excludes boundary."""
-    ny, nz = wave_field.ny, wave_field.nz
-    inv_dt = 1.0 / dt_rs
-    half_c2 = 0.5 * c_amrs**2
-
-    for j, k in ti.ndrange((1, ny - 1), (1, nz - 1)):
-        psi_dot = (wave_field.psi_am[mid_x, j, k] - wave_field.psi_prev_am[mid_x, j, k]) * inv_dt
-        kinetic = 0.5 * psi_dot.norm_sqr()
-        d_dx = (wave_field.psi_am[mid_x + 1, j, k] - wave_field.psi_am[mid_x - 1, j, k]) / (
-            2.0 * wave_field.dx_am
-        )
-        d_dy = (wave_field.psi_am[mid_x, j + 1, k] - wave_field.psi_am[mid_x, j - 1, k]) / (
-            2.0 * wave_field.dx_am
-        )
-        d_dz = (wave_field.psi_am[mid_x, j, k + 1] - wave_field.psi_am[mid_x, j, k - 1]) / (
-            2.0 * wave_field.dx_am
-        )
-        grad_sq = d_dx.norm_sqr() + d_dy.norm_sqr() + d_dz.norm_sqr()
-        H_slice[j, k] = kinetic + half_c2 * grad_sq
-
-
-# Module-level slice buffers, lazily allocated on first call
-_h_slice_xy = None
-_h_slice_xz = None
-_h_slice_yz = None
-
-
-def compute_total_hamiltonian(wave_field, c_amrs, dt_rs):
     """
-    Estimated total Hamiltonian H = Σ (½|ψ̇|² + ½c²|∇ψ|²) via 3-plane sampling.
+    Scalar potential V(ψ) at one voxel.
 
-    Returns ⟨H⟩ × voxel_count where ⟨H⟩ is the mean per-voxel H over the three
-    orthogonal center planes — exact for spatially-uniform fields, a sound
-    estimator for smooth wave packets, and ~10⁴× cheaper than full reduction
-    on million-voxel grids.
+    Returns the local potential-energy density contribution to the
+    Hamiltonian. M5.0g: returns 0 (free wave). M5.2: real nonlinear physics.
 
-    Units: am²/rs² per voxel; physical scaling lands with M5.0f.
+    Args:
+        psi: Vector(3) field value at the voxel
+
+    Returns:
+        scalar V(ψ) in the same units as kinetic and gradient terms (am²/rs²)
     """
-    global _h_slice_xy, _h_slice_xz, _h_slice_yz
+    return ti.cast(0.0, ti.f32)
 
+
+# ================================================================
+# ENERGY DENSITY (HAMILTONIAN) — PER-VOXEL ENERGY FIELD
+# ================================================================
+# H(x) = ½|ψ̇|² + ½c²|∇ψ|² + V(ψ)
+#
+# Naming convention: the quantity stored is ENERGY density (aJ per voxel).
+# The "_H" suffix tags which formula was used to compute it (Hamiltonian).
+# Future formulas would parallel: `_L` for Lagrangian density, `_K` for
+# kinetic-only, etc.
+#
+# Populated by compute_energy_density_H into trackers.energy_density_H_aJ
+# each step; consumed by:
+#   - xforce_motion.compute_force_vector  → F = −∇E per wave-center
+#   - sample_avg_trackers (below)         → 3-plane mean → dashboard total
+#   - launcher WAVE_MENU=4 flux mesh      → visualization
+#
+# This is a third full-grid pass per step (alongside propagate_psi and
+# update_trackers_psi). Performance optimization (merge into propagate_psi)
+# is M5.0i territory; we land it as a separate kernel for clarity in M5.0g.
+
+
+@ti.kernel
+def compute_energy_density_H(
+    wave_field: ti.template(),  # type: ignore
+    trackers: ti.template(),  # type: ignore
+    c_amrs: ti.f32,  # type: ignore
+    dt_rs: ti.f32,  # type: ignore
+):
+    """
+    Compute per-voxel energy density (Hamiltonian formula) into
+    trackers.energy_density_H_aJ.
+    H = ½|ψ̇|² + ½c²|∇ψ|² + V(ψ)
+
+    Reads:  wave_field.psi_am, wave_field.psi_prev_am
+    Writes: trackers.energy_density_H_aJ
+
+    Boundary handling: 1-cell halo (gradient stencil); boundary voxels left
+    at zero (Dirichlet BC in ψ ⇒ ψ ≈ 0 at edges ⇒ H ≈ 0 trivially).
+
+    Kinetic ψ̇ uses forward difference (ψ − ψ_prev)/dt because psi_new is
+    consumed by swap_buffers before this kernel runs — same compromise as
+    update_trackers_psi. Central-difference ψ̇ becomes available once those
+    two kernels are merged into propagate_psi (M5.0i optimization).
+
+    PHYSICAL-SCALING TODO — M5.2: the field is currently named `_aJ` but
+    actually stores `(am/rs)²` per voxel — the kernel writes raw kinematic
+    Hamiltonian density without the physical-energy conversion factor
+    (ρ_medium × voxel_volume_am³ × INTERNAL_ENERGY_TO_AJ ≈ matches M4's
+    `E = ρ·V·(f·A)²` formula). Sufficient for M5.0g–M5.0i because:
+      (a) F = −∇E only depends on the gradient (ratios survive scaling)
+      (b) Tests against Exp 4 KG dispersion check ω(k), not absolute E
+    But once M5.2 introduces V(ψ) terms with explicit dimensional
+    couplings (Klein-Gordon mass, Close Eq. 23, LdG potential), we MUST
+    apply the physical-scaling factor here so the V term and the
+    kinetic+gradient terms add in the same units. See dashboard "(rel.)"
+    labels in _launcher.py for the corresponding display caveat.
+    """
     nx, ny, nz = wave_field.nx, wave_field.ny, wave_field.nz
+    inv_dt = 1.0 / dt_rs
+    half_c2 = 0.5 * c_amrs**2
+    inv_2dx = 1.0 / (2.0 * wave_field.dx_am)
 
-    if _h_slice_xy is None:
-        _h_slice_xy = ti.field(dtype=ti.f32, shape=(nx, ny))
-        _h_slice_xz = ti.field(dtype=ti.f32, shape=(nx, nz))
-        _h_slice_yz = ti.field(dtype=ti.f32, shape=(ny, nz))
+    for i, j, k in ti.ndrange((1, nx - 1), (1, ny - 1), (1, nz - 1)):
+        psi = wave_field.psi_am[i, j, k]
+        psi_prev = wave_field.psi_prev_am[i, j, k]
 
-    mid_x, mid_y, mid_z = nx // 2, ny // 2, nz // 2
-    _hamiltonian_slice_xy(wave_field, c_amrs, dt_rs, _h_slice_xy, mid_z)
-    _hamiltonian_slice_xz(wave_field, c_amrs, dt_rs, _h_slice_xz, mid_y)
-    _hamiltonian_slice_yz(wave_field, c_amrs, dt_rs, _h_slice_yz, mid_x)
+        # Kinetic: ½ |ψ̇|²
+        psi_dot = (psi - psi_prev) * inv_dt
+        kinetic = 0.5 * psi_dot.norm_sqr()
 
-    xy = _h_slice_xy.to_numpy()[1:-1, 1:-1]
-    xz = _h_slice_xz.to_numpy()[1:-1, 1:-1]
-    yz = _h_slice_yz.to_numpy()[1:-1, 1:-1]
-    mean_H_per_voxel = float((xy.sum() + xz.sum() + yz.sum()) / (xy.size + xz.size + yz.size))
-    return mean_H_per_voxel * wave_field.voxel_count
+        # Gradient: ½ c² |∇ψ|²  (central-difference on each axis, component-wise)
+        d_dx = (wave_field.psi_am[i + 1, j, k] - wave_field.psi_am[i - 1, j, k]) * inv_2dx
+        d_dy = (wave_field.psi_am[i, j + 1, k] - wave_field.psi_am[i, j - 1, k]) * inv_2dx
+        d_dz = (wave_field.psi_am[i, j, k + 1] - wave_field.psi_am[i, j, k - 1]) * inv_2dx
+        gradient = half_c2 * (d_dx.norm_sqr() + d_dy.norm_sqr() + d_dz.norm_sqr())
+
+        # Potential: V(ψ) — 0 in M5.0g, real physics in M5.2
+        potential = V_psi(psi)
+
+        trackers.energy_density_H_aJ[i, j, k] = kinetic + gradient + potential
+
+
+# Note: the global energy aggregate (mean per voxel + grid total) is computed
+# by the 3-plane sample_avg_trackers below alongside amp / freq — single pass
+# over the slice planes, single GPU↔CPU sync per dashboard cadence. The launcher
+# multiplies the returned mean by voxel_count to get the grid-total scalar.
 
 
 # ================================================================
@@ -701,13 +670,16 @@ def sample_position_to_render(
 # - Acceptable accuracy vs massive performance gain
 # ================================================================
 
-# Cached slice buffers (initialized on first call)
+# Cached slice buffers (initialized on first call) — one per axis × per observable
 _slice_xy_amp = None
 _slice_xy_freq = None
+_slice_xy_energy = None
 _slice_xz_amp = None
 _slice_xz_freq = None
+_slice_xz_energy = None
 _slice_yz_amp = None
 _slice_yz_freq = None
+_slice_yz_energy = None
 
 
 @ti.kernel
@@ -715,12 +687,14 @@ def _copy_slice_xy(
     trackers: ti.template(),  # type: ignore
     slice_amp: ti.template(),  # type: ignore
     slice_freq: ti.template(),  # type: ignore
+    slice_energy: ti.template(),  # type: ignore
     mid_z: ti.i32,  # type: ignore
 ):
-    """Copy center XY slice (fixed z) to 2D buffer."""
+    """Copy amp/freq/energy at the XY center plane (z=mid_z) to 2D buffers."""
     for i, j in slice_amp:
         slice_amp[i, j] = trackers.amp_local_emarms_am[i, j, mid_z]
         slice_freq[i, j] = trackers.freq_local_cross_rHz[i, j, mid_z]
+        slice_energy[i, j] = trackers.energy_density_H_aJ[i, j, mid_z]
 
 
 @ti.kernel
@@ -728,12 +702,14 @@ def _copy_slice_xz(
     trackers: ti.template(),  # type: ignore
     slice_amp: ti.template(),  # type: ignore
     slice_freq: ti.template(),  # type: ignore
+    slice_energy: ti.template(),  # type: ignore
     mid_y: ti.i32,  # type: ignore
 ):
-    """Copy center XZ slice (fixed y) to 2D buffer."""
+    """Copy amp/freq/energy at the XZ center plane (y=mid_y) to 2D buffers."""
     for i, k in slice_amp:
         slice_amp[i, k] = trackers.amp_local_emarms_am[i, mid_y, k]
         slice_freq[i, k] = trackers.freq_local_cross_rHz[i, mid_y, k]
+        slice_energy[i, k] = trackers.energy_density_H_aJ[i, mid_y, k]
 
 
 @ti.kernel
@@ -741,12 +717,14 @@ def _copy_slice_yz(
     trackers: ti.template(),  # type: ignore
     slice_amp: ti.template(),  # type: ignore
     slice_freq: ti.template(),  # type: ignore
+    slice_energy: ti.template(),  # type: ignore
     mid_x: ti.i32,  # type: ignore
 ):
-    """Copy center YZ slice (fixed x) to 2D buffer."""
+    """Copy amp/freq/energy at the YZ center plane (x=mid_x) to 2D buffers."""
     for j, k in slice_amp:
         slice_amp[j, k] = trackers.amp_local_emarms_am[mid_x, j, k]
         slice_freq[j, k] = trackers.freq_local_cross_rHz[mid_x, j, k]
+        slice_energy[j, k] = trackers.energy_density_H_aJ[mid_x, j, k]
 
 
 def sample_avg_trackers(
@@ -754,21 +732,34 @@ def sample_avg_trackers(
     trackers,
 ):
     """
-    Estimate RMS amplitude and average frequency by sampling 3 orthogonal planes.
+    Estimate global aggregates by sampling 3 orthogonal center planes.
 
-    Samples XY, XZ, and YZ center slices to avoid full 3D reduction.
-    This is a deliberate performance compromise - full GPU reduction with
-    atomic operations causes severe contention with millions of voxels.
+    Computes:
+        trackers.amp_global_emarms_am   ← √⟨amp²⟩  (RMS over the 3 planes)
+        trackers.freq_global_avg_rHz    ← ⟨freq⟩   (mean over the 3 planes)
+        trackers.energy_global_H_avg_aJ ← ⟨E⟩      (mean energy density per voxel)
 
-    For isotropic fields, center-plane sampling provides representative estimates.
+    Caller (launcher) can derive the grid total trivially:
+        energy_total_H_aJ = energy_global_H_avg_aJ × voxel_count
+
+    Why 3-plane sampling: full 3D reductions with GPU atomic_add cause severe
+    atomic contention at million-voxel scale and stalled the GUI for tens of
+    seconds in early M5.0d.2 testing (when compute_energy_total_H briefly
+    used a per-voxel reduction). 3-plane sampling reads ~3·N² voxels (3% of
+    a 100³ grid), is exact for spatially-uniform fields, and is a sound
+    estimator for smooth wave packets.
+
+    Three observables share the same 3-plane pass for cache locality and to
+    keep one CPU↔GPU sync point per dashboard cadence (every 60 frames).
 
     Args:
-        wave_field: WaveField instance containing grid dimensions
-        trackers: WaveTrackers instance with per-voxel and average fields
+        wave_field: WaveField (grid dimensions)
+        trackers: Trackers (reads amp/freq/energy_density_H per-voxel fields;
+            writes the three global aggregates)
     """
-    global _slice_xy_amp, _slice_xy_freq
-    global _slice_xz_amp, _slice_xz_freq
-    global _slice_yz_amp, _slice_yz_freq
+    global _slice_xy_amp, _slice_xy_freq, _slice_xy_energy
+    global _slice_xz_amp, _slice_xz_freq, _slice_xz_energy
+    global _slice_yz_amp, _slice_yz_freq, _slice_yz_energy
 
     nx, ny, nz = wave_field.nx, wave_field.ny, wave_field.nz
 
@@ -776,32 +767,45 @@ def sample_avg_trackers(
     if _slice_xy_amp is None:
         _slice_xy_amp = ti.field(dtype=ti.f32, shape=(nx, ny))
         _slice_xy_freq = ti.field(dtype=ti.f32, shape=(nx, ny))
+        _slice_xy_energy = ti.field(dtype=ti.f32, shape=(nx, ny))
         _slice_xz_amp = ti.field(dtype=ti.f32, shape=(nx, nz))
         _slice_xz_freq = ti.field(dtype=ti.f32, shape=(nx, nz))
+        _slice_xz_energy = ti.field(dtype=ti.f32, shape=(nx, nz))
         _slice_yz_amp = ti.field(dtype=ti.f32, shape=(ny, nz))
         _slice_yz_freq = ti.field(dtype=ti.f32, shape=(ny, nz))
+        _slice_yz_energy = ti.field(dtype=ti.f32, shape=(ny, nz))
 
     # Copy 3 center slices to 2D buffers (parallel kernels)
     mid_x, mid_y, mid_z = nx // 2, ny // 2, nz // 2
-    _copy_slice_xy(trackers, _slice_xy_amp, _slice_xy_freq, mid_z)
-    _copy_slice_xz(trackers, _slice_xz_amp, _slice_xz_freq, mid_y)
-    _copy_slice_yz(trackers, _slice_yz_amp, _slice_yz_freq, mid_x)
+    _copy_slice_xy(trackers, _slice_xy_amp, _slice_xy_freq, _slice_xy_energy, mid_z)
+    _copy_slice_xz(trackers, _slice_xz_amp, _slice_xz_freq, _slice_xz_energy, mid_y)
+    _copy_slice_yz(trackers, _slice_yz_amp, _slice_yz_freq, _slice_yz_energy, mid_x)
 
     # Transfer 2D slices to CPU for numpy operations (exclude boundary voxels)
     xy_amp = _slice_xy_amp.to_numpy()[1:-1, 1:-1]
     xy_freq = _slice_xy_freq.to_numpy()[1:-1, 1:-1]
+    xy_energy = _slice_xy_energy.to_numpy()[1:-1, 1:-1]
     xz_amp = _slice_xz_amp.to_numpy()[1:-1, 1:-1]
     xz_freq = _slice_xz_freq.to_numpy()[1:-1, 1:-1]
+    xz_energy = _slice_xz_energy.to_numpy()[1:-1, 1:-1]
     yz_amp = _slice_yz_amp.to_numpy()[1:-1, 1:-1]
     yz_freq = _slice_yz_freq.to_numpy()[1:-1, 1:-1]
+    yz_energy = _slice_yz_energy.to_numpy()[1:-1, 1:-1]
 
-    # Compute RMS amplitude: √(⟨A²⟩) for correct energy weighting
-    total_amp_squared = (xy_amp**2).sum() + (xz_amp**2).sum() + (yz_amp**2).sum()
-    total_freq = xy_freq.sum() + xz_freq.sum() + yz_freq.sum()
     n_samples = xy_amp.size + xz_amp.size + yz_amp.size
 
+    # RMS amplitude: √(⟨A²⟩) — energy-weighting convention
+    total_amp_squared = (xy_amp**2).sum() + (xz_amp**2).sum() + (yz_amp**2).sum()
     trackers.amp_global_emarms_am[None] = float(np.sqrt(total_amp_squared / n_samples))
+
+    # Plain mean for frequency
+    total_freq = xy_freq.sum() + xz_freq.sum() + yz_freq.sum()
     trackers.freq_global_avg_rHz[None] = float(total_freq / n_samples)
+
+    # Plain mean for energy density (per voxel); launcher multiplies by
+    # voxel_count to get the grid total.
+    total_energy = xy_energy.sum() + xz_energy.sum() + yz_energy.sum()
+    trackers.energy_global_H_avg_aJ[None] = float(total_energy / n_samples)
 
 
 # ================================================================
@@ -813,7 +817,7 @@ def sample_avg_trackers(
 # propagate_psi or any tracker. Treat it as a display driver.
 #
 # VECTOR-FIELD RENDERING NUANCE (worth remembering when M5.0g+ adds new
-# wave_menu options for Hamiltonian density, curl, divergence, energy flux,
+# wave_menu options for energy density, curl, divergence, energy flux,
 # etc.):
 #
 # ψ is a Vector(3) field, but the flux mesh maps every voxel to ONE scalar
@@ -863,25 +867,26 @@ def update_flux_mesh_values(
     # XY Plane: Sample at z = fm_plane_z_idx
     # ================================================================
     # Always update all planes (conditionals cause GPU branch divergence)
-    # wave_menu == 4 (Hamiltonian density) deferred to M5.0g; falls through
-    # to displacement view in the meantime.
+    # wave_menu == 4 renders the energy density (Hamiltonian) field
+    # `trackers.energy_density_H_aJ`, populated each step by M5.0g.
     for i, j in ti.ndrange(wave_field.nx, wave_field.ny):
         # Sample displacement at this voxel
         disp_value = wave_field.psi_am[i, j, wave_field.fm_plane_z_idx]
         amp_value = trackers.amp_local_emarms_am[i, j, wave_field.fm_plane_z_idx]
         freq_value = trackers.freq_local_cross_rHz[i, j, wave_field.fm_plane_z_idx]
+        energy_value = trackers.energy_density_H_aJ[i, j, wave_field.fm_plane_z_idx]
         univ_edge_z = wave_field.universe_size_am[2]
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if wave_menu == 4:  # ironbow
+        if wave_menu == 4:  # Energy density (Hamiltonian) on ironbow
+            H_max = trackers.energy_global_H_avg_aJ[None] * 4.0 + 1e-10
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_ironbow_color(
-                disp_value.norm(), 0, trackers.amp_global_emarms_am[None] * 4
+                energy_value, 0.0, H_max
             )
-            wave_field.fluxmesh_xy_vertices[i, j][
-                2
-            ] = disp_value.norm() / univ_edge_z * warp_mesh + wave_field.flux_mesh_planes[2] * (
-                wave_field.nz / wave_field.max_grid_size
+            wave_field.fluxmesh_xy_vertices[i, j][2] = (
+                energy_value / H_max * 0.3 * warp_mesh / 300.0
+                + (wave_field.flux_mesh_planes[2] * (wave_field.nz / wave_field.max_grid_size))
             )
         elif wave_menu == 3:  # blueprint
             wave_field.fluxmesh_xy_colors[i, j] = colormap.get_blueprint_color(
@@ -923,18 +928,19 @@ def update_flux_mesh_values(
         disp_value = wave_field.psi_am[i, wave_field.fm_plane_y_idx, k]
         amp_value = trackers.amp_local_emarms_am[i, wave_field.fm_plane_y_idx, k]
         freq_value = trackers.freq_local_cross_rHz[i, wave_field.fm_plane_y_idx, k]
+        energy_value = trackers.energy_density_H_aJ[i, wave_field.fm_plane_y_idx, k]
         univ_edge_y = wave_field.universe_size_am[1]
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if wave_menu == 4:  # ironbow
+        if wave_menu == 4:  # Energy density (Hamiltonian) on ironbow
+            H_max = trackers.energy_global_H_avg_aJ[None] * 4.0 + 1e-10
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_ironbow_color(
-                disp_value.norm(), 0, trackers.amp_global_emarms_am[None] * 4
+                energy_value, 0.0, H_max
             )
-            wave_field.fluxmesh_xz_vertices[i, k][
-                1
-            ] = disp_value.norm() / univ_edge_y * warp_mesh + wave_field.flux_mesh_planes[1] * (
-                wave_field.ny / wave_field.max_grid_size
+            wave_field.fluxmesh_xz_vertices[i, k][1] = (
+                energy_value / H_max * 0.3 * warp_mesh / 300.0
+                + (wave_field.flux_mesh_planes[1] * (wave_field.ny / wave_field.max_grid_size))
             )
         elif wave_menu == 3:  # blueprint
             wave_field.fluxmesh_xz_colors[i, k] = colormap.get_blueprint_color(
@@ -976,18 +982,19 @@ def update_flux_mesh_values(
         disp_value = wave_field.psi_am[wave_field.fm_plane_x_idx, j, k]
         amp_value = trackers.amp_local_emarms_am[wave_field.fm_plane_x_idx, j, k]
         freq_value = trackers.freq_local_cross_rHz[wave_field.fm_plane_x_idx, j, k]
+        energy_value = trackers.energy_density_H_aJ[wave_field.fm_plane_x_idx, j, k]
         univ_edge_x = wave_field.universe_size_am[0]
 
         # Map value to color/vertex using selected gradient
         # Scale range to 2× average for headroom without saturation (allows peak visualization)
-        if wave_menu == 4:  # ironbow
+        if wave_menu == 4:  # Energy density (Hamiltonian) on ironbow
+            H_max = trackers.energy_global_H_avg_aJ[None] * 4.0 + 1e-10
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_ironbow_color(
-                disp_value.norm(), 0, trackers.amp_global_emarms_am[None] * 4
+                energy_value, 0.0, H_max
             )
-            wave_field.fluxmesh_yz_vertices[j, k][
-                0
-            ] = disp_value.norm() / univ_edge_x * warp_mesh + wave_field.flux_mesh_planes[0] * (
-                wave_field.nx / wave_field.max_grid_size
+            wave_field.fluxmesh_yz_vertices[j, k][0] = (
+                energy_value / H_max * 0.3 * warp_mesh / 300.0
+                + (wave_field.flux_mesh_planes[0] * (wave_field.nx / wave_field.max_grid_size))
             )
         elif wave_menu == 3:  # blueprint
             wave_field.fluxmesh_yz_colors[j, k] = colormap.get_blueprint_color(

--- a/openwave/xperiments/m5_lagrangian_field/lagrangian_engine.py
+++ b/openwave/xperiments/m5_lagrangian_field/lagrangian_engine.py
@@ -10,7 +10,7 @@ zero (free wave); M5.2 plugs in Klein-Gordon mass + Close Eq. 23 + LdG.
 
 Module layout (top-to-bottom):
     DIFFERENTIAL OPERATORS    — Laplacian; M5.0e adds curl/div/curl-curl
-    INITIAL-CONDITION SEEDING — seed_wave (test/UI verification)
+    INITIAL-CONDITION SEEDING — seed_gaussian (test/UI verification)
     ψ PROPAGATION ENGINE      — propagate_psi (leapfrog/Verlet)
     FIELD OBSERVABLES         — update_trackers_psi (amp/freq EMA)
     ENERGY DENSITY (HAMILTONIAN) — compute_energy_density_H
@@ -34,7 +34,7 @@ from openwave.common import colormap
 
 
 @ti.kernel
-def seed_wave(
+def seed_gaussian(
     wave_field: ti.template(),  # type: ignore
     c_amrs: ti.f32,  # type: ignore
     dt_rs: ti.f32,  # type: ignore

--- a/openwave/xperiments/m5_lagrangian_field/medium.py
+++ b/openwave/xperiments/m5_lagrangian_field/medium.py
@@ -470,18 +470,31 @@ class Trackers:
         self.last_crossing = ti.field(dtype=ti.f32, shape=grid_size)  # rs, last zero crossing
         self.freq_local_cross_rHz = ti.field(dtype=ti.f32, shape=grid_size)  # rHz, local frequency
 
-        # DEPRECATED: per-voxel energy field — no kernel writes to it under M5.0d
-        # (compute_total_hamiltonian replaces it as a scalar reduction). Kept zero-
-        # valued only because xforce_motion.compute_force_vector still reads it.
-        # M5.0g replaces this with H_density_aJ (per-voxel Hamiltonian) and
-        # rewrites the force computation as F = −∇H.
-        self.energy_local_aJ = ti.field(dtype=ti.f32, shape=grid_size)  # aJ, deprecated
+        # Per-voxel ENERGY density (computed via the Hamiltonian formula):
+        #     H = ½|ψ̇|² + ½c²|∇ψ|² + V(ψ)
+        # Naming convention: the quantity is energy; the "_H" suffix denotes
+        # the formula used (Hamiltonian). Future formulas (e.g. Lagrangian
+        # density `_L`, kinetic-only `_K`) would parallel this pattern.
+        # Populated each step by lagrangian_engine.compute_energy_density_H.
+        # Consumed by:
+        #   - xforce_motion.compute_force_vector  →  F = −∇E (replaces M4's
+        #     postulated F = −∇E with E = ρV(fA)² formula). The energy E here
+        #     is computed via the Hamiltonian formula (hence _H suffix), but
+        #     the physics statement F = −∇E is canonical regardless of how E
+        #     is derived.
+        #   - lagrangian_engine.compute_energy_total_H  →  3-plane-sampled
+        #     grid-total scalar for the dashboard
+        #   - launcher WAVE_MENU=4 flux-mesh visualization
+        # In M5.0g the V(ψ) term is zero; M5.2 plugs in Klein-Gordon mass +
+        # Close Eq. 23 + LdG via the V_psi hook in lagrangian_engine.
+        self.energy_density_H_aJ = ti.field(dtype=ti.f32, shape=grid_size)  # aJ-per-voxel
 
         # GLOBAL AVERAGES for visualization scaling — initialized to zero; the
         # update_trackers_psi EMA + sample_avg_trackers fill these in during sim.
         # M5 has no universal reference scale, so we let the simulation discover them.
         self.amp_global_emarms_am = ti.field(dtype=ti.f32, shape=())  # RMS all voxels
         self.freq_global_avg_rHz = ti.field(dtype=ti.f32, shape=())  # avg frequency all voxels
+        self.energy_global_H_avg_aJ = ti.field(dtype=ti.f32, shape=())  # mean energy density (per voxel)
 
 
 if __name__ == "__main__":

--- a/openwave/xperiments/m5_lagrangian_field/medium.py
+++ b/openwave/xperiments/m5_lagrangian_field/medium.py
@@ -494,7 +494,9 @@ class Trackers:
         # M5 has no universal reference scale, so we let the simulation discover them.
         self.amp_global_emarms_am = ti.field(dtype=ti.f32, shape=())  # RMS all voxels
         self.freq_global_avg_rHz = ti.field(dtype=ti.f32, shape=())  # avg frequency all voxels
-        self.energy_global_H_avg_aJ = ti.field(dtype=ti.f32, shape=())  # mean energy density (per voxel)
+        self.energy_global_H_avg_aJ = ti.field(
+            dtype=ti.f32, shape=()
+        )  # mean energy density (per voxel)
 
 
 if __name__ == "__main__":
@@ -531,7 +533,7 @@ if __name__ == "__main__":
     print(f"  Voxel edge (am): {wave_field.dx_am:.2f} am")
     print(f"  Universe volume: {wave_field.universe_volume:.2e} m³")
     print(f"  Note: voxels-per-wavelength resolution is now xperiment-driven")
-    print(f"        (declared via WAVE_SEED or defect Compton wavelength)")
+    print(f"        (declared via TEST_SEED or defect Compton wavelength)")
 
     print("\n================================================================")
     print("END SMOKE TEST: DATA-GRID MODULE")

--- a/openwave/xperiments/m5_lagrangian_field/xforce_motion.py
+++ b/openwave/xperiments/m5_lagrangian_field/xforce_motion.py
@@ -1,32 +1,40 @@
 """
 FORCE & MOTION MODULE
 
-Implements force calculation from energy gradients and particle motion integration.
+Force calculation from the energy-density gradient + wave-center motion
+integration.
 
-Physics Foundation:
-- Energy per voxel: E = ρ · V · (f · A)²  (EWT energy equation)
-- Force: F = -∇E  (negative gradient of energy density)
-- Motion: Euler integration of F = m · a
+Physics Foundation (M5.0g):
+- Per-voxel energy density (Hamiltonian formula):
+    H = ½|ψ̇|² + ½c²|∇ψ|² + V(ψ)
+  populated by lagrangian_engine.compute_energy_density_H into
+  trackers.energy_density_H_aJ
+- Force: F = −∇E sampled at the wave-center's grid position
+  (E here is the energy density field computed via the Hamiltonian formula —
+  see naming convention in medium.py:Trackers. The physics statement F = −∇E
+  is canonical regardless of which formula is used to derive E.)
+- Motion: leapfrog (velocity Verlet) integration of F = m·a
+
+This replaces M4's postulated `E = ρ·V·(f·A)²` energy formula and the
+hardcoded EWT particle constants. The energy density (Hamiltonian) is
+derived from the Lagrangian (matches Exp 5's Noether result), so M5's
+force law is now first-principles rather than a postulate.
 
 Units:
-- Energy: aJ (attojoules, 1 aJ = 1e-18 J)
-- Force: Newtons (1 aJ/am = 1 N, no conversion needed)
+- Energy density: aJ per voxel (1 aJ = 1e-18 J)
+- Force: Newtons (1 aJ/am = 1 N — no conversion needed)
 - Mass: qg (quectograms, 1 qg = 1e-33 kg, for f32 precision on GPU)
 - Velocity: am/rs (OpenWave scaled units for f32 precision)
 - Position: grid indices (float)
 - Time: rontoseconds (rs)
 
 Conversion factors:
-- 1 aJ / 1 am = 1e-18 J / 1e-18 m = 1 N  (energy gradient → force)
-- a_amrs2 = (F_N / m_qg) * 1e-3            (N/qg → am/rs²)
-- c = 0.3 am/rs                             (speed of light)
-
-See research/02_force_motion.md for detailed documentation.
+- 1 aJ / 1 am = 1 N                     (energy gradient → force)
+- a_amrs2 = (F_N / m_qg) * 1e-3          (N/qg → am/rs²)
+- c = 0.3 am/rs                          (speed of light)
 """
 
 import taichi as ti
-
-import numpy as np
 
 from openwave.common import constants
 
@@ -37,60 +45,18 @@ ATTOMETER = constants.ATTOMETER  # m/am = 1e-18
 RONTOSECOND = constants.RONTOSECOND  # s/rs = 1e-27
 QUECTOGRAM = constants.QUECTOGRAM  # kg/qg = 1e-33
 
-# Coulomb force constants (for reference comparisons)
-COULOMB_CONSTANT = constants.COULOMB_CONSTANT  # N·m²/C², k = 8.99e9
-ELEMENTARY_CHARGE = constants.ELEMENTARY_CHARGE  # C, e = 1.60e-19
-
-# EWT particle constants (for EWT force reference)
-MEDIUM_DENSITY = constants.MEDIUM_DENSITY  # kg/m³
-WAVE_SPEED = constants.WAVE_SPEED  # m/s
-EWAVE_AMPLITUDE = constants.EWAVE_AMPLITUDE  # m
-EWAVE_LENGTH = constants.EWAVE_LENGTH  # m
-ELECTRON_K = constants.ELECTRON_K
-ELECTRON_OUTER_SHELL = constants.ELECTRON_OUTER_SHELL
-ELECTRON_ORBITAL_G = constants.ELECTRON_ORBITAL_G
-
-
-def compute_ewt_electric_force(
-    r: float, K: int = 1, Oe: float = 1.0, glambda: float = 1.0
-) -> float:
-    """
-    Compute EWT electric force between two particles (reference/validation).
-
-    F_e = (4πρ K^7 A^6 c² Oe / 3λ²) × gλ × (Q1×Q2 / r²)
-
-    Args:
-        r: Distance between particles in meters
-        K: Wave center count (1 for neutrino, 10 for electron)
-        Oe: Outer shell multiplier (1.0 for K=1, ~2.14 for electron)
-        glambda: Orbital g-factor (1.0 for K=1, ~0.99 for electron)
-
-    Returns:
-        Force in Newtons
-    """
-    coefficient = (
-        4.0
-        * np.pi
-        * MEDIUM_DENSITY
-        * (K**7)
-        * (EWAVE_AMPLITUDE**6)
-        * (WAVE_SPEED**2)
-        * Oe
-        * glambda
-    ) / (3.0 * (EWAVE_LENGTH**2))
-
-    return coefficient / (r**2)
-
 
 # ================================================================
-# Force from Energy Gradient: F = -∇E
+# Force from Energy-Density Gradient: F = −∇E
 # ================================================================
 
-# Gradient sampling: number of voxel shells and weight exponent
-# GRADIENT_SAMPLE_RADIUS = 1: standard central difference (single shell)
-# GRADIENT_SAMPLE_RADIUS > 1: weighted multi-shell gradient (better well resolution)
-# GRADIENT_WEIGHT_FALLOFF = 2: weights as 1/d² (particle energy density ∝ A² ∝ 1/r²)
-GRADIENT_SAMPLE_RADIUS = 3  # voxels (increased from 1 for better lock-in well resolution)
+# Gradient sampling: number of voxel shells and weight exponent.
+# GRADIENT_SAMPLE_RADIUS = 1: standard central difference (single shell).
+# GRADIENT_SAMPLE_RADIUS > 1: weighted multi-shell gradient (better well
+#   resolution near the defect core, where the energy-density gradient is steep).
+# GRADIENT_WEIGHT_FALLOFF = 2: weights as 1/d² (matches energy-density radial
+#   falloff ∝ |ψ|² ∝ 1/r² for a free-wave defect).
+GRADIENT_SAMPLE_RADIUS = 3  # voxels
 GRADIENT_WEIGHT_FALLOFF = 2  # exponent for 1/d^n weighting
 
 # Velocity damping: fraction of velocity retained per timestep
@@ -106,15 +72,16 @@ def compute_force_vector(
     wave_center: ti.template(),  # type: ignore
 ):
     """
-    Compute force on each wave center from energy gradient.
+    Compute force on each wave-center from the energy-density gradient.
 
-    F = -∇E where E is the local energy field (energy_local_aJ).
-    Uses weighted central differences: multiple sample shells within
-    GRADIENT_SAMPLE_RADIUS, weighted by 1/d² (particle energy density
-    falloff ∝ A² ∝ 1/r²). Closer voxels contribute more, matching how
-    a particle's own wave structure "feels" the surrounding energy landscape.
-    For R=1: identical to standard central difference (single shell).
-    Units: aJ/am = N (no conversion needed).
+    F = −∇E where E is `trackers.energy_density_H_aJ` (per-voxel energy density
+    populated each step by lagrangian_engine.compute_energy_density_H). The `_H`
+    suffix on the field name tags the formula used (Hamiltonian); the physics
+    statement F = −∇E is independent of the formula choice. Uses a weighted
+    multi-shell
+    central difference: shells d = 1..R with weights `1/d²`, normalized.
+    R=1 reduces to standard central difference; R>1 averages multiple shells
+    around the defect core for better well-resolution near the WC.
 
     ┌───────┬────────┬────────────┐
     │ Shell │ Weight │ Percentage │
@@ -126,27 +93,20 @@ def compute_force_vector(
     │ d=3   │ 0.111  │ 8.2%       │
     └───────┴────────┴────────────┘
 
-    M5.0d.3: scale_factor was removed from WaveField; the S² correction below
-    is hardcoded to 1.0 as a placeholder. This kernel produces meaningless
-    forces under M5 anyway because trackers.energy_local_aJ is no longer
-    populated (the EWT-formula energy field was retired in favor of the
-    per-voxel Hamiltonian, which lands in M5.0g). Force computation will be
-    rewritten as F = −∇H in M5.0g; until then this runs but feeds zeros to
-    integrate_motion_leapfrog, so wave-centers don't move under force.
+    Units: energy_density_H_aJ is in aJ/voxel; the gradient over `2·d·dx_am`
+    gives aJ/am = N. No scale correction needed (M5.0d.3 retired the M4
+    scale_factor).
 
     Args:
-        wave_field: WaveField instance containing grid info
-        trackers: Trackers instance with energy_local_aJ field
-        wave_center: WaveCenter instance to store computed forces
+        wave_field: WaveField instance (used for dx_am and grid dims)
+        trackers: Trackers instance — reads `energy_density_H_aJ` (populated
+            by lagrangian_engine.compute_energy_density_H before this kernel)
+        wave_center: WaveCenter instance — writes computed forces into
+            `wave_center.force[wc_idx]`
     """
     dx_am = wave_field.dx_am
 
-    # Placeholder — scale_factor was retired in M5.0d.3; S² hardcoded to 1.
-    # M5.0g rewrites this kernel entirely against per-voxel Hamiltonian density.
-    S2 = ti.cast(1.0, ti.f32)
-
     # Precompute weights: 1/d^GRADIENT_WEIGHT_FALLOFF for each shell d = 1..R
-    # Physical basis: particle energy density ∝ |ψ|² ∝ 1/r²
     w_sum = ti.cast(0.0, ti.f32)
     for d in ti.static(range(1, GRADIENT_SAMPLE_RADIUS + 1)):
         w_sum += 1.0 / ti.cast(d**GRADIENT_WEIGHT_FALLOFF, ti.f32)
@@ -171,7 +131,7 @@ def compute_force_vector(
         ny = wave_field.ny
         nz = wave_field.nz
 
-        # Boundary check
+        # Boundary check (need d voxels of halo on each side)
         if (
             i > GRADIENT_SAMPLE_RADIUS
             and i < nx - GRADIENT_SAMPLE_RADIUS
@@ -180,8 +140,7 @@ def compute_force_vector(
             and k > GRADIENT_SAMPLE_RADIUS
             and k < nz - GRADIENT_SAMPLE_RADIUS
         ):
-            # Weighted gradient: Σ w(d) · (E[+d] - E[-d]) / (2·d·dx) / Σ w(d)
-            # w(d) = 1/d^GRADIENT_WEIGHT_FALLOFF (energy density weighting)
+            # Weighted multi-shell central gradient of energy_density_H_aJ
             grad_x = ti.cast(0.0, ti.f32)
             grad_y = ti.cast(0.0, ti.f32)
             grad_z = ti.cast(0.0, ti.f32)
@@ -193,32 +152,32 @@ def compute_force_vector(
                 grad_x += (
                     w
                     * (
-                        trackers.energy_local_aJ[i + d, j, k]
-                        - trackers.energy_local_aJ[i - d, j, k]
+                        trackers.energy_density_H_aJ[i + d, j, k]
+                        - trackers.energy_density_H_aJ[i - d, j, k]
                     )
                     / dist
                 )
                 grad_y += (
                     w
                     * (
-                        trackers.energy_local_aJ[i, j + d, k]
-                        - trackers.energy_local_aJ[i, j - d, k]
+                        trackers.energy_density_H_aJ[i, j + d, k]
+                        - trackers.energy_density_H_aJ[i, j - d, k]
                     )
                     / dist
                 )
                 grad_z += (
                     w
                     * (
-                        trackers.energy_local_aJ[i, j, k + d]
-                        - trackers.energy_local_aJ[i, j, k - d]
+                        trackers.energy_density_H_aJ[i, j, k + d]
+                        - trackers.energy_density_H_aJ[i, j, k - d]
                     )
                     / dist
                 )
 
-            # F = -∇E / S² (aJ/am = N, with scale correction)
-            F_x = -grad_x / (w_sum * S2)
-            F_y = -grad_y / (w_sum * S2)
-            F_z = -grad_z / (w_sum * S2)
+            # F = -∇E (aJ/am = N — no conversion factor needed)
+            F_x = -grad_x / w_sum
+            F_y = -grad_y / w_sum
+            F_z = -grad_z / w_sum
 
         wave_center.force[wc_idx][0] = F_x
         wave_center.force[wc_idx][1] = F_y

--- a/openwave/xperiments/m5_lagrangian_field/xparameters/_test_smoke.py
+++ b/openwave/xperiments/m5_lagrangian_field/xparameters/_test_smoke.py
@@ -52,7 +52,7 @@ XPARAMETERS = {
         "SHOW_AXIS": False,
         "TICK_SPACING": 0.25,
         "SHOW_GRID": False,
-        "SHOW_EDGES": True,
+        "SHOW_EDGES": False,
         "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],
         "SHOW_FLUX_MESH": 3,
         "WARP_MESH": 40,

--- a/openwave/xperiments/m5_lagrangian_field/xparameters/_test_smoke.py
+++ b/openwave/xperiments/m5_lagrangian_field/xparameters/_test_smoke.py
@@ -22,7 +22,7 @@ UNIVERSE_EDGE = 1e-15  # m
 TARGET_VOXELS = 100_000_000
 
 # Wave seed parameters (consumed by _launcher when xperiment name == "_test_smoke")
-WAVE_SEED = {
+TEST_SEED = {
     "AMPLITUDE_AM": 5.0,  # peak displacement, am
     "VOXELS_PER_WAVELENGTH": 60.0,  # spatial period in voxels (≥12 for stable f32)
     "POLARIZATION": [0.0, 1.0, 0.0],  # transverse: ê_y for x-propagating wave
@@ -70,5 +70,5 @@ XPARAMETERS = {
         "EXPORT_VIDEO": False,
         "VIDEO_FRAMES": 24,
     },
-    "wave_seed": WAVE_SEED,
+    "test_seed": TEST_SEED,
 }

--- a/research_hub/0_ROADMAP.md
+++ b/research_hub/0_ROADMAP.md
@@ -275,7 +275,7 @@ A research thread evaluating whether a Lagrangian / topological framework can re
   - ❌ Test 8: Smolinski's non-linear Ψ³ — K-selectivity hypothesis **FALSIFIED** at Level 1. Ψ³ produces breathing oscillation but no K-dependent geometric stabilization. Nonlinearity alone is insufficient; topology (Exp 2/3) is required for K-selectivity — 2026-04-17
 - ✅ Winning combination selected (2026-04-17): topology (hedgehog + winding) + Klein-Gordon wave dynamics + Close's Eq. 19 as base vector wave + M3 near-field standing waves + Skyrme stabilizer. Full recipe in [3a § Winning Approach](3a_lagrangian_experiments.md#winning-approach-for-m5)
 - 🔶 M5 / LAGRANGIAN-FIELD METHOD implementation (dir `openwave/xperiments/m5_lagrangian_field/`) — see [3d_path_to_m5.md](3d_path_to_m5.md) for full sub-phase plan
-  - 🔶 **M5.0 Scaffold** — 6/9 sub-phases complete as of 2026-05-07
+  - 🔶 **M5.0 Scaffold** — 9/11 sub-phases complete as of 2026-05-08
     - ✅ M5.0a Module rename + alias (`wave_engine.py` → `lagrangian_engine.py`, `ewave` → `lagrange`)
     - ✅ M5.0b Triple buffer (`psi_prev_am` / `psi_am` / `psi_new_am`) + AMR-ready field-storage abstraction
     - ✅ M5.0c Vector Laplacian via 6-point stencil (port + simplify from M2)
@@ -284,8 +284,8 @@ A research thread evaluating whether a Lagrangian / topological framework can re
     - ✅ M5.0d.3 Drop `scale_factor` / `ewave_res` / EWT-default constants; introduce xperiment-driven `wave_res`
     - ✅ M5.0e Curl, divergence, curl-curl operators (`∇×(∇×ψ) = ∇(∇·ψ) − ∇²ψ` identity form, 2-cell halo) — analytical checks pass on linear / rigid-rotation / Gaussian fields
     - ✅ M5.0f Storage-units decision + natural-units deferral (decision-record sub-phase, no code refactor): storage stays `_am` / `_rs` / `_rHz` for M2/M3/M4 consistency; kernel-internal natural-unit scaling deferred to M5.2 where it lands alongside the nonlinear physics (Klein-Gordon, Close Eq. 23, LdG) that benefits from textbook-readable couplings
-    - 🚧 M5.0g Per-voxel Hamiltonian density + force-computation switch (F = −∇H replaces M4's `F = −∇(ρV(fA)²)`) — next
-    - [ ] M5.0h Physics invariant test (gating: V=0 must reproduce Exp 4 KG dispersion)
+    - ✅ M5.0g Per-voxel energy density (Hamiltonian) + force-computation switch (F = −∇E replaces M4's postulated `E = ρV(fA)²` formula); naming convention adopted: quantity is *energy*, `_H` suffix tags the Hamiltonian formula (parallels `_L` Lagrangian, `_K` kinetic in future); V_psi hook in place for M5.2 nonlinear couplings
+    - 🚧 M5.0h Physics invariant test (gating: V=0 must reproduce Exp 4 KG dispersion) — next
     - [ ] M5.0i Performance profiling + Tier 2 optimizations (rotating-pointer swap_buffers, merged trackers, BlockLocal Laplacian, Symplectic/Verlet, dirty-tile mask)
   - [ ] M5.1 Port topology from Exps 2, 3 — `seed_vacuum`, `seed_hedgehog`, Frank energy, winding-number tracker
   - [ ] M5.2 Wave dynamics — **Close's Eq. 23** as the particle equation (preserves `∇·s = 0`, per Close's 2026-04-18 guidance) + Eq. 19 as V=0 linear limit + Klein-Gordon mass term; validate against Exp 4 dispersion; resonance-hunt amplitude sweep. Kernel-internal natural-unit scaling (`c=1, λ_C=1, ℏ=1`) lands here for the nonlinear couplings (deferred from M5.0f — linear kernels are dimensionally self-balancing and don't need it)

--- a/research_hub/0_ROADMAP.md
+++ b/research_hub/0_ROADMAP.md
@@ -282,8 +282,8 @@ A research thread evaluating whether a Lagrangian / topological framework can re
     - ✅ M5.0d.1 Leapfrog kernel `propagate_psi` + standing-wave eigenmode test
     - ✅ M5.0d.2 CFL evaluation + plane-wave seed (Gaussian-windowed packet) + tracker EMA + Hamiltonian dashboard + delete legacy M4 `propagate_wave`
     - ✅ M5.0d.3 Drop `scale_factor` / `ewave_res` / EWT-default constants; introduce xperiment-driven `wave_res`
-    - 🚧 M5.0e Curl, divergence, curl-curl operators (next — needed by M5.1 winding tracker + M5.2 Close Eq. 19 linear limit)
-    - [ ] M5.0f Natural-unit kernel scaling (`c=1, λ_C=1, ℏ=1` intra-kernel)
+    - ✅ M5.0e Curl, divergence, curl-curl operators (`∇×(∇×ψ) = ∇(∇·ψ) − ∇²ψ` identity form, 2-cell halo) — analytical checks pass on linear / rigid-rotation / Gaussian fields
+    - 🚧 M5.0f Natural-unit kernel scaling (`c=1, λ_C=1, ℏ=1` intra-kernel) — next
     - [ ] M5.0g Per-voxel Hamiltonian density + force-computation switch (F = −∇H replaces M4's `F = −∇(ρV(fA)²)`)
     - [ ] M5.0h Physics invariant test (gating: V=0 must reproduce Exp 4 KG dispersion)
     - [ ] M5.0i Performance profiling + Tier 2 optimizations (rotating-pointer swap_buffers, merged trackers, BlockLocal Laplacian, Symplectic/Verlet, dirty-tile mask)

--- a/research_hub/0_ROADMAP.md
+++ b/research_hub/0_ROADMAP.md
@@ -283,12 +283,12 @@ A research thread evaluating whether a Lagrangian / topological framework can re
     - ✅ M5.0d.2 CFL evaluation + plane-wave seed (Gaussian-windowed packet) + tracker EMA + Hamiltonian dashboard + delete legacy M4 `propagate_wave`
     - ✅ M5.0d.3 Drop `scale_factor` / `ewave_res` / EWT-default constants; introduce xperiment-driven `wave_res`
     - ✅ M5.0e Curl, divergence, curl-curl operators (`∇×(∇×ψ) = ∇(∇·ψ) − ∇²ψ` identity form, 2-cell halo) — analytical checks pass on linear / rigid-rotation / Gaussian fields
-    - 🚧 M5.0f Natural-unit kernel scaling (`c=1, λ_C=1, ℏ=1` intra-kernel) — next
-    - [ ] M5.0g Per-voxel Hamiltonian density + force-computation switch (F = −∇H replaces M4's `F = −∇(ρV(fA)²)`)
+    - ✅ M5.0f Storage-units decision + natural-units deferral (decision-record sub-phase, no code refactor): storage stays `_am` / `_rs` / `_rHz` for M2/M3/M4 consistency; kernel-internal natural-unit scaling deferred to M5.2 where it lands alongside the nonlinear physics (Klein-Gordon, Close Eq. 23, LdG) that benefits from textbook-readable couplings
+    - 🚧 M5.0g Per-voxel Hamiltonian density + force-computation switch (F = −∇H replaces M4's `F = −∇(ρV(fA)²)`) — next
     - [ ] M5.0h Physics invariant test (gating: V=0 must reproduce Exp 4 KG dispersion)
     - [ ] M5.0i Performance profiling + Tier 2 optimizations (rotating-pointer swap_buffers, merged trackers, BlockLocal Laplacian, Symplectic/Verlet, dirty-tile mask)
   - [ ] M5.1 Port topology from Exps 2, 3 — `seed_vacuum`, `seed_hedgehog`, Frank energy, winding-number tracker
-  - [ ] M5.2 Wave dynamics — **Close's Eq. 23** as the particle equation (preserves `∇·s = 0`, per Close's 2026-04-18 guidance) + Eq. 19 as V=0 linear limit + Klein-Gordon mass term; validate against Exp 4 dispersion; resonance-hunt amplitude sweep
+  - [ ] M5.2 Wave dynamics — **Close's Eq. 23** as the particle equation (preserves `∇·s = 0`, per Close's 2026-04-18 guidance) + Eq. 19 as V=0 linear limit + Klein-Gordon mass term; validate against Exp 4 dispersion; resonance-hunt amplitude sweep. Kernel-internal natural-unit scaling (`c=1, λ_C=1, ℏ=1`) lands here for the nonlinear couplings (deferred from M5.0f — linear kernels are dimensionally self-balancing and don't need it)
   - [ ] M5.3 Hamiltonian energy density `H = ½ψ̇² + ½c²(∇ψ)² + V(ψ)` replaces postulated `E = ρV(fA)²`
   - [ ] M5.4 **Headline test**: single biaxial hedgehog (electron) is a long-lived resonance; hedgehog + anti-hedgehog pair reproduces dynamic 1/d² Coulomb + annihilation. Single-defect framing per Dr. Duda's lepton-axis hierarchy (electron ≠ K=10 tetrahedron in M5)
   - [ ] M5.5 Skyrme stabilizer (conditional on M5.4 showing defect collapse under Derrick's theorem)

--- a/research_hub/3d_path_to_m5.md
+++ b/research_hub/3d_path_to_m5.md
@@ -413,7 +413,7 @@ Broken into nine sub-phases (M5.0a → M5.0i) so each lands as a tight, separate
 - ✅ `Trackers.__init__` no longer takes `scale_factor`; globals init to zero; EMA + sample_avg_trackers populate them during sim
 - ✅ Introduce `state.wave_res` (xperiment-driven, populated from `WAVE_SEED["VOXELS_PER_WAVELENGTH"]` if a seed exists; else 0.0 / "n/a"). Defect-driven λ from λ_C lands in M5.2
 - ✅ Strip all `scale_factor` arithmetic from launcher dashboard; `instrumentation.py` cleaned of EWT-scaled axhline references and the broken transverse subplot
-- ✅ `xforce_motion.py` `S²` placeholder (= 1) — kernel is being fully rewritten in M5.0g (F = −∇H), so the placeholder is intentional dead-end code until then
+- ✅ `xforce_motion.py` `S²` placeholder (= 1) — kernel is being fully rewritten in M5.0g (F = −∇E), so the placeholder is intentional dead-end code until then
 - ✅ `annihilation_threshold` hardcoded to 6 voxels (M5.2 will replace with per-defect Compton-wavelength threshold); particle shell radius set to fixed 0.02 of normalized universe edge
 
 #### M5.0e — Curl, divergence, curl-curl operators ✅ (committed 2026-05-08)
@@ -440,14 +440,19 @@ This sub-phase was originally scoped as "add kernel-internal natural-unit scalin
   - This is "lazy natural units": apply only where it helps, skip where it doesn't. Avoids premature complexity (boundary conversion code with no precision win) in M5.0
 - 🚧 (optional follow-up, not blocking) — small UI improvement: adaptive SI-prefix display helper in `_launcher.py` so universe edge / voxel edge / wavelength / amplitude render in the natural prefix for their magnitude (`fm`, `am`, `pm`, etc.) instead of raw scientific notation. Storage stays in `_am` / `_rs` / `_rHz`; only the display formatting changes. ~20 lines of code, can ship anytime as a polish PR
 
-#### M5.0g — Per-voxel Hamiltonian density + force-computation switch
+#### M5.0g — Per-voxel energy density (Hamiltonian) + force-computation switch ✅ (committed 2026-05-08)
 
-- [ ] Add per-voxel field `H_density_aJ` to `Trackers`; populate from `propagate_psi` (or its merged-tracker variant per the M5.0i optimization) using the same Hamiltonian formula M5.0d.2 already validated as a 3-plane scalar
-- [ ] Rewrite `xforce_motion.compute_force_vector` from M4's `F = −∇(ρV(fA)²)` (with hardcoded EWT constants + the placeholder `S²=1`) to **`F = −∇H`** using the new per-voxel field
-- [ ] Add `V(ψ)` function-call hook so M5.2 plugs in Klein-Gordon mass + Close Eq. 23 + LdG terms cleanly without re-touching the energy/force layer
-- [ ] Remove the deprecated `Trackers.energy_local_aJ` field once `H_density_aJ` is wired
+- ✅ Per-voxel field `trackers.energy_density_H_aJ` (replaces deprecated `energy_local_aJ`); populated each step by `lagrangian_engine.compute_energy_density_H`
+- ✅ Mean per-voxel cache `trackers.energy_global_H_avg_aJ` (filled by `compute_energy_total_H`; matches M4's `_global_avg_` semantics; used as the flux-mesh colormap range for WAVE_MENU=4)
+- ✅ Grid-total scalar `state.energy_total_H_aJ` (= mean × voxel_count) on the dashboard
+- ✅ Rewrote `xforce_motion.compute_force_vector` as **`F = −∇E`** sampling `energy_density_H_aJ` (the `_H` suffix tags how E is computed; the physics statement F=−∇E is canonical regardless of formula). Dropped the placeholder `S²=1`, all hardcoded EWT particle constants (`EWAVE_AMPLITUDE`, `EWAVE_LENGTH`, `MEDIUM_DENSITY`, `ELECTRON_K`/`OUTER_SHELL`/`ORBITAL_G`, `COULOMB_CONSTANT`, `ELEMENTARY_CHARGE`, `WAVE_SPEED`), the `compute_ewt_electric_force` reference function, and the `numpy` import that only it needed
+- ✅ `V_psi(psi)` `@ti.func` hook — returns 0 in M5.0g; M5.2 swaps in Klein-Gordon mass + Close Eq. 23 + LdG terms (alongside the kernel-internal natural-unit scaling deferred from M5.0f). Both the potential value AND its functional form will land here
+- ✅ `compute_energy_total_H` refactored to 3-plane-sample the new per-voxel field (instead of recomputing kinetic+gradient per voxel three times) — three lightweight `_energy_slice_*` slice-copy kernels
+- ✅ Flux-mesh `WAVE_MENU == 4` activated to render `energy_density_H_aJ` (was a placeholder rendering `|ψ|`)
+- ✅ Naming convention captured per Rodrigo's 2026-05-08 review: the quantity is **energy** (aJ); the `_H` suffix tags the *formula* used (Hamiltonian). Future formulas would parallel: `_L` for Lagrangian density, `_K` for kinetic-only. Renamed `compute_hamiltonian_density` → `compute_energy_density_H`, `compute_total_hamiltonian` → `compute_energy_total_H`, `H_density_aJ` → `energy_density_H_aJ`, `H_global_avg_aJ` → `energy_global_H_avg_aJ`, `hamiltonian_total_aJ` → `energy_total_H_aJ`
+- ✅ Smoke-tested end-to-end: `annihilation1` (ψ=0): all energy fields zero, no forces; `_test_smoke` (Gaussian packet): non-trivial energy_density_H_aJ peak ~5e-3, total ~8e3 aJ, forces non-zero where ∇H ≠ 0
 
-#### M5.0h — Physics invariant test (gating)
+#### M5.0h — Physics invariant test (gating) 🚧 next
 
 - [ ] **Physics invariant test**: with `V(ψ) = 0`, M5 must reproduce M2's free-wave behavior AND Exp 4's Klein-Gordon dispersion `ω² = c²k² + m²` for a quadratic potential. Fail this → there's a bug in the core loop. **Gates** progression to M5.1
 
@@ -472,6 +477,7 @@ This sub-phase was originally scoped as "add kernel-internal natural-unit scalin
 - [ ] Implement time-stepping leapfrog for Close's **Eq. 23** as the particle equation, enforcing `∇·s = 0` at each step (divergence-cleaning projection, or vector-potential `s = ∇×A` formulation that makes zero-div automatic)
 - [ ] Keep Eq. 19 `∂²Q/∂t² = −c²·∇×∇×Q + (optional mass term −m²Q)` as the V=0 linear limit
 - [ ] **Add kernel-internal natural-unit scaling** (`c = 1`, `λ_C(defect-of-interest) = 1`, `ℏ = 1`) for the new nonlinear-physics kernels added in M5.2 only — Klein-Gordon mass term, Close Eq. 23 nonlinear couplings `−u·∇s + w×s`, LdG biaxial potential. Convert at kernel entry/exit. Linear kernels from M5.0 (leapfrog, divergence, curl, Laplacian) are dimensionally self-balancing and stay in storage units (`_am` / `_rs`) — no conversion. Rationale: natural units make the dimensional coefficients in nonlinear couplings read as O(1) (textbook-form), where mismatched powers of `λ_C` in storage units would push f32. This was originally scoped as M5.0f but deferred here because linear kernels don't need it. See [Resolution & Performance Plan § Tier 1](#tier-1--architectural-decisions-fix-before-any-kernel-is-written) and the M5.0f decision-record above
+- [ ] **Apply physical-energy-scaling factor to `compute_energy_density_H`** (deferred from M5.0g): the kernel currently writes raw `(am/rs)²` per voxel and the field is named `_aJ` aspirationally. Multiply by `ρ_medium × voxel_volume_am³ × INTERNAL_ENERGY_TO_AJ` (matching M4's `E = ρ·V·(f·A)²` conversion) so the kinetic + gradient + V(ψ) terms add in the same physical units. M5.0g defers this because: (a) `F = −∇E` only depends on the gradient (relative scaling survives), (b) M5.0h Klein-Gordon dispersion test checks `ω(k)` not absolute E. But M5.2 needs the V(ψ) couplings to add in real units against the kinetic term — physical scaling becomes load-bearing. Once landed, drop the dashboard `(rel.)` labels in `_launcher.py` (search for "M5.2" in the launcher) and restore `J / J/m³` units
 - [ ] Validate: reproduce Exp 4's Klein-Gordon dispersion on the GPU. FFT-extract ω(k), fit ω² = c²k² + m²
 - [ ] Validate: reproduce Exp 7's transverse wave dispersion (dipole/quadrupole seeds disperse as transverse elastic-solid waves)
 - [ ] Add Close's nonlinear terms `−u·∇s + w×s` (from Eq. 21) as optional runtime flag for comparison
@@ -818,7 +824,7 @@ The applied-technology counterpart of OpenWave's open-source physics work is the
   - ❌ Exp 8 (Smolinski Ψ³ K-selectivity falsified)
 - ✅ **Winning recipe identified**: topology + Klein-Gordon + Close's Eq. 23 + M3 near-field + Skyrme stabilizer
 - ✅ **Group feedback integrated (2026-04-19)** — Jarek, Jeff, and Robert reviewed the sandbox summary; refinements captured in this document (Eq. 23 over Eq. 21, axis-hierarchy for lepton masses, Cornell potential and de Broglie clock added as M5.7/M5.8 targets, resonance-lifetime success criterion)
-- [~] M5.0 — Scaffold 🔶 **8/9 sub-phases complete** (M5.0a–c, M5.0d.1–3, M5.0e, M5.0f ✅ as of 2026-05-08; M5.0g per-voxel Hamiltonian + F=−∇H 🚧 next; M5.0h–i pending). Leapfrog kernel + full vector-calculus toolkit (Laplacian, divergence, curl, curl-curl) wired and verified analytically; CFL bound + Hamiltonian dashboard + plane-wave seed all working in the GUI; `scale_factor` legacy retired; storage units stay `_am` / `_rs` / `_rHz` (decision-record M5.0f); kernel-internal natural-unit scaling deferred to M5.2 alongside the nonlinear physics that benefits from it
+- [~] M5.0 — Scaffold 🔶 **9/11 sub-phases complete** (M5.0a–c, M5.0d.1–3, M5.0e, M5.0f, M5.0g ✅ as of 2026-05-08; M5.0h physics-invariant gating test 🚧 next; M5.0i pending). Leapfrog kernel + full vector-calculus toolkit (Laplacian, divergence, curl, curl-curl) wired and verified analytically; CFL bound + per-voxel energy density (Hamiltonian) + F=−∇E force kernel + plane-wave seed all working in the GUI; `scale_factor` legacy retired; storage units stay `_am` / `_rs` / `_rHz` (decision-record M5.0f); kernel-internal natural-unit scaling + nonlinear V(ψ) deferred to M5.2 alongside the physics that benefits from them
 - [ ] M5.1 — Port topology from Exps 2, 3 (`seed_vacuum`, `seed_hedgehog`, Frank energy, winding tracker)
 - [ ] M5.2 — Wave dynamics from **Close's Eq. 23** (with `∇·s = 0` enforced) + Klein-Gordon mass term, validate Exp 4 dispersion, amplitude-sweep resonance hunt
 - [ ] M5.3 — Hamiltonian energy (replaces postulated `E = ρV(fA)²`)
@@ -828,7 +834,7 @@ The applied-technology counterpart of OpenWave's open-source physics work is the
 - [ ] M5.7 — Cornell potential / quark confinement (topological vortex string, `V(r) = −α/r + σ·r`)
 - [ ] M5.8 — De Broglie clock / Zitterbewegung test (`ω = 2mc²/ℏ`) for electron + neutrino
 
-**Next action**: **M5.0g** — add per-voxel Hamiltonian density field `H_density_aJ` to `Trackers`, populated alongside `propagate_psi`; rewrite `xforce_motion.compute_force_vector` from M4's `F = −∇(ρV(fA)²)` to **`F = −∇H`** using the new field; add `V(ψ)` function-call hook so M5.2 can plug in nonlinear potentials (Klein-Gordon mass + Close Eq. 23 + LdG) cleanly. Removes the deprecated `Trackers.energy_local_aJ` once `H_density_aJ` is wired. Then M5.0h (physics-invariant test gate: V=0 must reproduce Exp 4 KG dispersion), M5.0i (profiling + Tier 2 optimizations) close out the scaffold.
+**Next action**: **M5.0h** — physics-invariant gating test. With `V(ψ) = 0`, M5 must reproduce M2's free-wave behavior AND Exp 4's Klein-Gordon dispersion `ω² = c²k² + m²` (for a quadratic potential). FFT-extract `ω(k)` from a multi-mode standing-wave seed; fit; assert `c²` recovered to within stencil-discrete tolerance. Failure here = bug in the core loop; gates progression to M5.1. After M5.0h, M5.0i (profiling + Tier 2 optimizations) closes out the scaffold.
 
 ---
 

--- a/research_hub/3d_path_to_m5.md
+++ b/research_hub/3d_path_to_m5.md
@@ -424,10 +424,21 @@ Broken into nine sub-phases (M5.0a → M5.0i) so each lands as a tight, separate
 - ✅ DIFFERENTIAL OPERATORS section header documents all four operators with their halo requirements and downstream consumers (single source of truth for the vector-calculus toolkit)
 - ✅ Analytical verification: divergence on `ψ=(x, 2y, 3z)` → 6.000 (max err 3e-5); curl on rigid-rotation `ψ=(−y, x, 0)` → (0, 0, 2) (max err 3e-6); curl on constant field → 0 (1e-9 noise floor); curl-curl identity on Gaussian seed → relative error 2.8e-6
 
-#### M5.0f — Natural-unit kernel scaling 🚧 next
+#### M5.0f — Storage-units decision + natural-units deferral ✅ (decision recorded 2026-05-08)
 
-- [ ] **Inherit `openwave/common/constants.py` scaled SI** (`_am` / `_rs` / `_rHz`) for ALL stored fields and I/O — already in place from M5.0b; this sub-phase is about the *kernel-internal* second scaling
-- [ ] **Add a kernel-internal natural-unit scaling** (`c = 1`, `λ_C(defect-of-interest) = 1`, `ℏ = 1`) for intra-kernel arithmetic only — convert at kernel entry/exit. Required because the electron's `λ_C ≈ 3.86e5 am` is no longer near-1.0 in attometers, which hurts CFL/dispersion math at f32. See [Resolution & Performance Plan § Tier 1](#tier-1--architectural-decisions-fix-before-any-kernel-is-written)
+This sub-phase was originally scoped as "add kernel-internal natural-unit scaling (c=1, λ_C=1, ℏ=1) at kernel entry/exit". After investigating both halves of the question (storage units AND kernel-internal scaling), the conclusion is that **neither change is needed in M5.0**. M5.0f therefore lands as a **decision-record sub-phase** — no code refactor — capturing the rationale so the question isn't re-litigated later.
+
+- ✅ **Storage units stay `_am` / `_rs` / `_rHz`** (no refactor):
+  - The leapfrog kernel is **dimensionally self-balancing**: `(c·dt)²` carries length² and `∇²ψ` carries 1/length², so the product magnitude is `~0.08·ψ` regardless of dx units. f32 stability holds in any (am, fm, pm) storage choice — the precision argument originally motivating a switch turned out not to apply to linear kernels
+  - **No "particle-physics best practice"** justifies a full pair: `fm` is the standard length unit (Fermi), but `ys` is not — particle physicists use either `zs` (zeptosecond) or natural units (ℏ/GeV ≈ 6.6e-25 s) for time. A genuinely standard pair `(fm, zs)` would force `c = 300` instead of `0.3`, propagating into every CFL / dispersion / kernel formula — refactor cost without precision benefit
+  - **Cross-method consistency** with M2/M3/M4 is real value (shared validations, port comparisons, instrumentation)
+  - The "storage values look large" observation (e.g. `dx = 200000 am` at electron scale) is a **dashboard formatting** concern, not a correctness one. Adaptive SI-prefix display in the launcher (planned as a small follow-up: `200000 am` → `200 fm` at render time only) handles it without touching storage
+- ✅ **Kernel-internal natural-unit scaling deferred to M5.2** (where it actually pays off):
+  - The original motivation for `(c=1, λ_C=1, ℏ=1)` scaling was f32 precision in linear kernels at electron scale. As shown above, that's a non-issue
+  - The *real* value of natural units is in **non-linear physics couplings**: Klein-Gordon mass term `−m²·ψ`, Close's Eq. 23 nonlinear terms `−u·∇s + w×s`, LdG biaxial potential — these have explicit dimensional coefficients that read like the published equations only when written in natural units
+  - These kernels first appear in **M5.2**. Apply natural-unit scaling there, locally to those specific kernels (entry/exit conversion). Linear kernels (leapfrog, divergence, curl, Laplacian) **never** need natural units — they're dimensionally self-balancing
+  - This is "lazy natural units": apply only where it helps, skip where it doesn't. Avoids premature complexity (boundary conversion code with no precision win) in M5.0
+- 🚧 (optional follow-up, not blocking) — small UI improvement: adaptive SI-prefix display helper in `_launcher.py` so universe edge / voxel edge / wavelength / amplitude render in the natural prefix for their magnitude (`fm`, `am`, `pm`, etc.) instead of raw scientific notation. Storage stays in `_am` / `_rs` / `_rHz`; only the display formatting changes. ~20 lines of code, can ship anytime as a polish PR
 
 #### M5.0g — Per-voxel Hamiltonian density + force-computation switch
 
@@ -460,6 +471,7 @@ Broken into nine sub-phases (M5.0a → M5.0i) so each lands as a tight, separate
 
 - [ ] Implement time-stepping leapfrog for Close's **Eq. 23** as the particle equation, enforcing `∇·s = 0` at each step (divergence-cleaning projection, or vector-potential `s = ∇×A` formulation that makes zero-div automatic)
 - [ ] Keep Eq. 19 `∂²Q/∂t² = −c²·∇×∇×Q + (optional mass term −m²Q)` as the V=0 linear limit
+- [ ] **Add kernel-internal natural-unit scaling** (`c = 1`, `λ_C(defect-of-interest) = 1`, `ℏ = 1`) for the new nonlinear-physics kernels added in M5.2 only — Klein-Gordon mass term, Close Eq. 23 nonlinear couplings `−u·∇s + w×s`, LdG biaxial potential. Convert at kernel entry/exit. Linear kernels from M5.0 (leapfrog, divergence, curl, Laplacian) are dimensionally self-balancing and stay in storage units (`_am` / `_rs`) — no conversion. Rationale: natural units make the dimensional coefficients in nonlinear couplings read as O(1) (textbook-form), where mismatched powers of `λ_C` in storage units would push f32. This was originally scoped as M5.0f but deferred here because linear kernels don't need it. See [Resolution & Performance Plan § Tier 1](#tier-1--architectural-decisions-fix-before-any-kernel-is-written) and the M5.0f decision-record above
 - [ ] Validate: reproduce Exp 4's Klein-Gordon dispersion on the GPU. FFT-extract ω(k), fit ω² = c²k² + m²
 - [ ] Validate: reproduce Exp 7's transverse wave dispersion (dipole/quadrupole seeds disperse as transverse elastic-solid waves)
 - [ ] Add Close's nonlinear terms `−u·∇s + w×s` (from Eq. 21) as optional runtime flag for comparison
@@ -806,7 +818,7 @@ The applied-technology counterpart of OpenWave's open-source physics work is the
   - ❌ Exp 8 (Smolinski Ψ³ K-selectivity falsified)
 - ✅ **Winning recipe identified**: topology + Klein-Gordon + Close's Eq. 23 + M3 near-field + Skyrme stabilizer
 - ✅ **Group feedback integrated (2026-04-19)** — Jarek, Jeff, and Robert reviewed the sandbox summary; refinements captured in this document (Eq. 23 over Eq. 21, axis-hierarchy for lepton masses, Cornell potential and de Broglie clock added as M5.7/M5.8 targets, resonance-lifetime success criterion)
-- [~] M5.0 — Scaffold 🔶 **7/9 sub-phases complete** (M5.0a–c, M5.0d.1–3, M5.0e ✅ as of 2026-05-08; M5.0f natural-unit kernel scaling 🚧 next; M5.0g–i pending). Leapfrog kernel + full vector-calculus toolkit (Laplacian, divergence, curl, curl-curl) wired and verified analytically; CFL bound + Hamiltonian dashboard + plane-wave seed all working in the GUI; `scale_factor` legacy retired
+- [~] M5.0 — Scaffold 🔶 **8/9 sub-phases complete** (M5.0a–c, M5.0d.1–3, M5.0e, M5.0f ✅ as of 2026-05-08; M5.0g per-voxel Hamiltonian + F=−∇H 🚧 next; M5.0h–i pending). Leapfrog kernel + full vector-calculus toolkit (Laplacian, divergence, curl, curl-curl) wired and verified analytically; CFL bound + Hamiltonian dashboard + plane-wave seed all working in the GUI; `scale_factor` legacy retired; storage units stay `_am` / `_rs` / `_rHz` (decision-record M5.0f); kernel-internal natural-unit scaling deferred to M5.2 alongside the nonlinear physics that benefits from it
 - [ ] M5.1 — Port topology from Exps 2, 3 (`seed_vacuum`, `seed_hedgehog`, Frank energy, winding tracker)
 - [ ] M5.2 — Wave dynamics from **Close's Eq. 23** (with `∇·s = 0` enforced) + Klein-Gordon mass term, validate Exp 4 dispersion, amplitude-sweep resonance hunt
 - [ ] M5.3 — Hamiltonian energy (replaces postulated `E = ρV(fA)²`)
@@ -816,7 +828,7 @@ The applied-technology counterpart of OpenWave's open-source physics work is the
 - [ ] M5.7 — Cornell potential / quark confinement (topological vortex string, `V(r) = −α/r + σ·r`)
 - [ ] M5.8 — De Broglie clock / Zitterbewegung test (`ω = 2mc²/ℏ`) for electron + neutrino
 
-**Next action**: **M5.0f** — kernel-internal natural-unit scaling (`c = 1`, `λ_C(defect-of-interest) = 1`, `ℏ = 1`) for intra-kernel arithmetic only, with conversion at kernel entry/exit. Required because the electron's `λ_C ≈ 3.86e5 am` is no longer near-1.0 in attometers, which hurts CFL/dispersion math at f32. Stored fields stay in the validated `_am` / `_rs` / `_rHz` units. Then M5.0g (per-voxel Hamiltonian + F=−∇H), M5.0h (physics-invariant test gate), M5.0i (profiling + Tier 2 optimizations) close out the scaffold.
+**Next action**: **M5.0g** — add per-voxel Hamiltonian density field `H_density_aJ` to `Trackers`, populated alongside `propagate_psi`; rewrite `xforce_motion.compute_force_vector` from M4's `F = −∇(ρV(fA)²)` to **`F = −∇H`** using the new field; add `V(ψ)` function-call hook so M5.2 can plug in nonlinear potentials (Klein-Gordon mass + Close Eq. 23 + LdG) cleanly. Removes the deprecated `Trackers.energy_local_aJ` once `H_density_aJ` is wired. Then M5.0h (physics-invariant test gate: V=0 must reproduce Exp 4 KG dispersion), M5.0i (profiling + Tier 2 optimizations) close out the scaffold.
 
 ---
 

--- a/research_hub/3d_path_to_m5.md
+++ b/research_hub/3d_path_to_m5.md
@@ -411,7 +411,7 @@ Broken into nine sub-phases (M5.0a → M5.0i) so each lands as a tight, separate
 
 - ✅ Drop `scale_factor`, `ewave_res`, `max_universe_edge_lambda`, `nominal_energy*` from `WaveField` (M2-era constructs that assumed a single fixed reference wavelength — EWT's 28 am energy-wave). M5 has variable λ
 - ✅ `Trackers.__init__` no longer takes `scale_factor`; globals init to zero; EMA + sample_avg_trackers populate them during sim
-- ✅ Introduce `state.wave_res` (xperiment-driven, populated from `WAVE_SEED["VOXELS_PER_WAVELENGTH"]` if a seed exists; else 0.0 / "n/a"). Defect-driven λ from λ_C lands in M5.2
+- ✅ Introduce `state.wave_res` (xperiment-driven, populated from `TEST_SEED["VOXELS_PER_WAVELENGTH"]` if a seed exists; else 0.0 / "n/a"). Defect-driven λ from λ_C lands in M5.2
 - ✅ Strip all `scale_factor` arithmetic from launcher dashboard; `instrumentation.py` cleaned of EWT-scaled axhline references and the broken transverse subplot
 - ✅ `xforce_motion.py` `S²` placeholder (= 1) — kernel is being fully rewritten in M5.0g (F = −∇E), so the placeholder is intentional dead-end code until then
 - ✅ `annihilation_threshold` hardcoded to 6 voxels (M5.2 will replace with per-defect Compton-wavelength threshold); particle shell radius set to fixed 0.02 of normalized universe edge

--- a/research_hub/3d_path_to_m5.md
+++ b/research_hub/3d_path_to_m5.md
@@ -376,52 +376,55 @@ Broken into nine sub-phases (M5.0a → M5.0i) so each lands as a tight, separate
 
 #### M5.0a — Module rename + alias ✅ (commit `bdd96dd` 2026-05-06)
 
-- [x] Create `openwave/xperiments/m5_lagrangian_field/` directory (cloned M4 + M3 features merged)
-- [x] **Rename the engine module**: `wave_engine.py` → `lagrangian_engine.py`. Rationale: M5's core loop integrates a Lagrangian-derived PDE (`∂²_tψ = c²∇²ψ − ∂V/∂ψ`) that simultaneously handles wave propagation *and* preserves topology via the potential `V(ψ)`. "Wave" is only one of the two channels the engine produces, so `lagrangian_engine.py` reflects what the module actually is to a new reader. M1–M4 keep `wave_engine.py`. See [3b § What wave equation does M5 solve?](3b_concept_review.md#what-wave-equation-does-m5-solve-is-force-still-e)
-- [x] Module alias `ewave` → `lagrange` across launcher (the engine evolves the field ψ via the Lagrangian, not "the energy-wave"; alias rename improves call-site readability)
+- ✅ Create `openwave/xperiments/m5_lagrangian_field/` directory (cloned M4 + M3 features merged)
+- ✅ **Rename the engine module**: `wave_engine.py` → `lagrangian_engine.py`. Rationale: M5's core loop integrates a Lagrangian-derived PDE (`∂²_tψ = c²∇²ψ − ∂V/∂ψ`) that simultaneously handles wave propagation *and* preserves topology via the potential `V(ψ)`. "Wave" is only one of the two channels the engine produces, so `lagrangian_engine.py` reflects what the module actually is to a new reader. M1–M4 keep `wave_engine.py`. See [3b § What wave equation does M5 solve?](3b_concept_review.md#what-wave-equation-does-m5-solve-is-force-still-e)
+- ✅ Module alias `ewave` → `lagrange` across launcher (the engine evolves the field ψ via the Lagrangian, not "the energy-wave"; alias rename improves call-site readability)
 
 #### M5.0b — Triple buffer + AMR-ready field-storage abstraction ✅ (commit `c832e90` 2026-05-06)
 
-- [x] Copy M4's `WaveField` / `WaveCenter` / `WaveTrackers` data classes; **extend with `psi_prev_am` and `psi_new_am`** Vector(3) buffers for leapfrog (also rename `displacement_am` → `psi_am`)
-- [x] **Use native `ti.Vector.field(3, ...)`** with single triple buffer — not three independent scalar fields. See Resolution & Performance Plan § Tier 1
-- [x] **`swap_buffers()`** method on WaveField cycles `prev ← curr, curr ← new` after each leapfrog step
-- [x] **AMR-readiness convention**: kernels must read grid dims via `wave_field.nx / .ny / .nz` attributes — never bake fixed `(nx, ny, nz)` constants into kernel signatures. Documented in WaveField docstring; M5.0 ships uniform-grid, M5.6 / M5.8 retrofit AMR without a rewrite
-- [x] Copy M4's flux-mesh visualization, granule rendering, 3-plane sampling (unchanged behavior)
+- ✅ Copy M4's `WaveField` / `WaveCenter` / `WaveTrackers` data classes; **extend with `psi_prev_am` and `psi_new_am`** Vector(3) buffers for leapfrog (also rename `displacement_am` → `psi_am`)
+- ✅ **Use native `ti.Vector.field(3, ...)`** with single triple buffer — not three independent scalar fields. See Resolution & Performance Plan § Tier 1
+- ✅ **`swap_buffers()`** method on WaveField cycles `prev ← curr, curr ← new` after each leapfrog step
+- ✅ **AMR-readiness convention**: kernels must read grid dims via `wave_field.nx / .ny / .nz` attributes — never bake fixed `(nx, ny, nz)` constants into kernel signatures. Documented in WaveField docstring; M5.0 ships uniform-grid, M5.6 / M5.8 retrofit AMR without a rewrite
+- ✅ Copy M4's flux-mesh visualization, granule rendering, 3-plane sampling (unchanged behavior)
 
 #### M5.0c — Vector Laplacian (port + simplify from M2) ✅ (commit `5606dd5` 2026-05-06)
 
-- [x] Port M2's 6-point Laplacian stencil (`compute_laplacianL` at `m2_laplace_propagation/wave_engine.py:527–562`); simplify to a single Vector(3) operator. Taichi handles Vector(3) arithmetic natively, so the stencil applied component-wise IS the vector Laplacian — no need for separate L/T paths like M2 had
+- ✅ Port M2's 6-point Laplacian stencil (`compute_laplacianL` at `m2_laplace_propagation/wave_engine.py:527–562`); simplify to a single Vector(3) operator. Taichi handles Vector(3) arithmetic natively, so the stencil applied component-wise IS the vector Laplacian — no need for separate L/T paths like M2 had
 
 #### M5.0d.1 — Leapfrog kernel + standing-wave eigenmode test ✅ (commit `6df9a1b` 2026-05-06)
 
-- [x] Implement `propagate_psi` kernel: leapfrog/Verlet update `ψ_new = 2·ψ − ψ_prev + (c·dt)²·∇²ψ` (V=0 free wave; V terms land in M5.2)
-- [x] Standing-wave eigenmode test (V=0 reproduces continuum dispersion at low k; 2.26% deviation at 12 voxels/λ matches discrete-stencil prediction)
+- ✅ Implement `propagate_psi` kernel: leapfrog/Verlet update `ψ_new = 2·ψ − ψ_prev + (c·dt)²·∇²ψ` (V=0 free wave; V terms land in M5.2)
+- ✅ Standing-wave eigenmode test (V=0 reproduces continuum dispersion at low k; 2.26% deviation at 12 voxels/λ matches discrete-stencil prediction)
 
 #### M5.0d.2 — CFL eval + plane-wave seed + tracker EMA + Hamiltonian dashboard ✅ (committed 2026-05-07)
 
-- [x] CFL evaluation in `_launcher.compute_timestep()` — mirror M2 pattern; `dt = dx · 0.95 / (c · √3)`; display `cfl_factor` in dashboard with red coloring if `> 1/3`
-- [x] `seed_wave` kernel — Gaussian-windowed wave packet (3-axis envelope, σ = N/6) that satisfies Dirichlet BC by construction. Drives `_test_smoke` xperiment for visual verification in the GUI
-- [x] Switch launcher main loop from M4's analytical `propagate_wave` → leapfrog `propagate_psi` + `swap_buffers()`
-- [x] `update_trackers_psi` kernel — EMA on `|ψ|²` for amplitude; zero-crossing detection on `ψ_z` for frequency
-- [x] `compute_total_hamiltonian` (3-plane-sampled estimator: `H = ½|ψ̇|² + ½c²|∇ψ|² + V(ψ)`, V=0 in M5.0d). Full-grid atomic reduction was the original implementation but stalled the GUI at 100M voxels; switched to 3-plane sampling (codebase-consistent with `sample_avg_trackers`)
-- [x] **Delete legacy code**: M4 analytical `propagate_wave` kernel + module-level EWT base constants
-- [x] First successful UI render of leapfrog-driven wave propagation
+- ✅ CFL evaluation in `_launcher.compute_timestep()` — mirror M2 pattern; `dt = dx · 0.95 / (c · √3)`; display `cfl_factor` in dashboard with red coloring if `> 1/3`
+- ✅ `seed_wave` kernel — Gaussian-windowed wave packet (3-axis envelope, σ = N/6) that satisfies Dirichlet BC by construction. Drives `_test_smoke` xperiment for visual verification in the GUI
+- ✅ Switch launcher main loop from M4's analytical `propagate_wave` → leapfrog `propagate_psi` + `swap_buffers()`
+- ✅ `update_trackers_psi` kernel — EMA on `|ψ|²` for amplitude; zero-crossing detection on `ψ_z` for frequency
+- ✅ `compute_total_hamiltonian` (3-plane-sampled estimator: `H = ½|ψ̇|² + ½c²|∇ψ|² + V(ψ)`, V=0 in M5.0d). Full-grid atomic reduction was the original implementation but stalled the GUI at 100M voxels; switched to 3-plane sampling (codebase-consistent with `sample_avg_trackers`)
+- ✅ **Delete legacy code**: M4 analytical `propagate_wave` kernel + module-level EWT base constants
+- ✅ First successful UI render of leapfrog-driven wave propagation
 
 #### M5.0d.3 — Drop `scale_factor` / `ewave_res` / EWT-default cleanup ✅ (committed 2026-05-07)
 
-- [x] Drop `scale_factor`, `ewave_res`, `max_universe_edge_lambda`, `nominal_energy*` from `WaveField` (M2-era constructs that assumed a single fixed reference wavelength — EWT's 28 am energy-wave). M5 has variable λ
-- [x] `Trackers.__init__` no longer takes `scale_factor`; globals init to zero; EMA + sample_avg_trackers populate them during sim
-- [x] Introduce `state.wave_res` (xperiment-driven, populated from `WAVE_SEED["VOXELS_PER_WAVELENGTH"]` if a seed exists; else 0.0 / "n/a"). Defect-driven λ from λ_C lands in M5.2
-- [x] Strip all `scale_factor` arithmetic from launcher dashboard; `instrumentation.py` cleaned of EWT-scaled axhline references and the broken transverse subplot
-- [x] `xforce_motion.py` `S²` placeholder (= 1) — kernel is being fully rewritten in M5.0g (F = −∇H), so the placeholder is intentional dead-end code until then
-- [x] `annihilation_threshold` hardcoded to 6 voxels (M5.2 will replace with per-defect Compton-wavelength threshold); particle shell radius set to fixed 0.02 of normalized universe edge
+- ✅ Drop `scale_factor`, `ewave_res`, `max_universe_edge_lambda`, `nominal_energy*` from `WaveField` (M2-era constructs that assumed a single fixed reference wavelength — EWT's 28 am energy-wave). M5 has variable λ
+- ✅ `Trackers.__init__` no longer takes `scale_factor`; globals init to zero; EMA + sample_avg_trackers populate them during sim
+- ✅ Introduce `state.wave_res` (xperiment-driven, populated from `WAVE_SEED["VOXELS_PER_WAVELENGTH"]` if a seed exists; else 0.0 / "n/a"). Defect-driven λ from λ_C lands in M5.2
+- ✅ Strip all `scale_factor` arithmetic from launcher dashboard; `instrumentation.py` cleaned of EWT-scaled axhline references and the broken transverse subplot
+- ✅ `xforce_motion.py` `S²` placeholder (= 1) — kernel is being fully rewritten in M5.0g (F = −∇H), so the placeholder is intentional dead-end code until then
+- ✅ `annihilation_threshold` hardcoded to 6 voxels (M5.2 will replace with per-defect Compton-wavelength threshold); particle shell radius set to fixed 0.02 of normalized universe edge
 
-#### M5.0e — Curl, divergence, curl-curl operators 🚧 next
+#### M5.0e — Curl, divergence, curl-curl operators ✅ (committed 2026-05-08)
 
-- [ ] Implement `compute_curl_psi`, `compute_divergence_psi`, `compute_curl_curl_psi` kernels in `lagrangian_engine.py`'s DIFFERENTIAL OPERATORS section (alongside the existing Laplacian). `curl(curl())` via `∇(∇·F) − ∇²F` matches Exp 7's implementation; needed by M5.2 (Close's Eq. 19 linear-limit `∂²_tQ = −c²·∇×∇×Q`) and M5.1 (winding tracker uses divergence on the director field)
-- [ ] Smoke-test each operator against an analytical input (e.g. plane wave, dipole field) before consuming it in M5.2
+- ✅ `compute_divergence_psi` `@ti.func` — central-difference scalar divergence, 1-cell halo. Used by M5.1 winding tracker, M5.2 `∇·s = 0` constraint, and the curl-curl identity below
+- ✅ `compute_curl_psi` `@ti.func` — central-difference Vector(3) curl, 1-cell halo. Foundation for M5.2 Eq. 19 linear limit and spin-density observables
+- ✅ `compute_curl_curl_psi` `@ti.func` — implemented via the vector identity `∇×(∇×ψ) = ∇(∇·ψ) − ∇²ψ` rather than nested curl. Reuses validated Laplacian, only the gradient-of-divergence is new code, 2-cell halo (vs. 4-cell for nested curl), matches Exp 7 v2's implementation
+- ✅ DIFFERENTIAL OPERATORS section header documents all four operators with their halo requirements and downstream consumers (single source of truth for the vector-calculus toolkit)
+- ✅ Analytical verification: divergence on `ψ=(x, 2y, 3z)` → 6.000 (max err 3e-5); curl on rigid-rotation `ψ=(−y, x, 0)` → (0, 0, 2) (max err 3e-6); curl on constant field → 0 (1e-9 noise floor); curl-curl identity on Gaussian seed → relative error 2.8e-6
 
-#### M5.0f — Natural-unit kernel scaling
+#### M5.0f — Natural-unit kernel scaling 🚧 next
 
 - [ ] **Inherit `openwave/common/constants.py` scaled SI** (`_am` / `_rs` / `_rHz`) for ALL stored fields and I/O — already in place from M5.0b; this sub-phase is about the *kernel-internal* second scaling
 - [ ] **Add a kernel-internal natural-unit scaling** (`c = 1`, `λ_C(defect-of-interest) = 1`, `ℏ = 1`) for intra-kernel arithmetic only — convert at kernel entry/exit. Required because the electron's `λ_C ≈ 3.86e5 am` is no longer near-1.0 in attometers, which hurts CFL/dispersion math at f32. See [Resolution & Performance Plan § Tier 1](#tier-1--architectural-decisions-fix-before-any-kernel-is-written)
@@ -796,14 +799,14 @@ The applied-technology counterpart of OpenWave's open-source physics work is the
 
 ## STATUS
 
-- [x] Architecture analysis complete (this document)
-- [x] **All 8 sandbox experiments complete** — see [3a_lagrangian_experiments.md](3a_lagrangian_experiments.md):
+- ✅ Architecture analysis complete (this document)
+- ✅ **All 8 sandbox experiments complete** — see [3a_lagrangian_experiments.md](3a_lagrangian_experiments.md):
   - ✅ Exp 1 (Sine-Gordon kinks), ✅ Exp 2 (Hedgehog Coulomb), ✅ Exp 3 (Winding quantization), ✅ Exp 4 (Klein-Gordon dispersion)
   - ⚠️ Exp 5 (Lagrangian derivation — W-L product form falsified), ⚠️ Exp 6 (lepton mechanism; specific ratios deferred), ⚠️ Exp 7 v2 (Close's actual equations implemented)
   - ❌ Exp 8 (Smolinski Ψ³ K-selectivity falsified)
-- [x] **Winning recipe identified**: topology + Klein-Gordon + Close's Eq. 23 + M3 near-field + Skyrme stabilizer
-- [x] **Group feedback integrated (2026-04-19)** — Jarek, Jeff, and Robert reviewed the sandbox summary; refinements captured in this document (Eq. 23 over Eq. 21, axis-hierarchy for lepton masses, Cornell potential and de Broglie clock added as M5.7/M5.8 targets, resonance-lifetime success criterion)
-- [~] M5.0 — Scaffold 🔶 **6/9 sub-phases complete** (M5.0a–c, M5.0d.1–3 ✅ as of 2026-05-07; M5.0e curl/div/curl-curl operators 🚧 next; M5.0f–i pending). Leapfrog kernel is wired and runs in the GUI; CFL bound + Hamiltonian dashboard + plane-wave seed all working; `scale_factor` legacy retired
+- ✅ **Winning recipe identified**: topology + Klein-Gordon + Close's Eq. 23 + M3 near-field + Skyrme stabilizer
+- ✅ **Group feedback integrated (2026-04-19)** — Jarek, Jeff, and Robert reviewed the sandbox summary; refinements captured in this document (Eq. 23 over Eq. 21, axis-hierarchy for lepton masses, Cornell potential and de Broglie clock added as M5.7/M5.8 targets, resonance-lifetime success criterion)
+- [~] M5.0 — Scaffold 🔶 **7/9 sub-phases complete** (M5.0a–c, M5.0d.1–3, M5.0e ✅ as of 2026-05-08; M5.0f natural-unit kernel scaling 🚧 next; M5.0g–i pending). Leapfrog kernel + full vector-calculus toolkit (Laplacian, divergence, curl, curl-curl) wired and verified analytically; CFL bound + Hamiltonian dashboard + plane-wave seed all working in the GUI; `scale_factor` legacy retired
 - [ ] M5.1 — Port topology from Exps 2, 3 (`seed_vacuum`, `seed_hedgehog`, Frank energy, winding tracker)
 - [ ] M5.2 — Wave dynamics from **Close's Eq. 23** (with `∇·s = 0` enforced) + Klein-Gordon mass term, validate Exp 4 dispersion, amplitude-sweep resonance hunt
 - [ ] M5.3 — Hamiltonian energy (replaces postulated `E = ρV(fA)²`)
@@ -813,7 +816,7 @@ The applied-technology counterpart of OpenWave's open-source physics work is the
 - [ ] M5.7 — Cornell potential / quark confinement (topological vortex string, `V(r) = −α/r + σ·r`)
 - [ ] M5.8 — De Broglie clock / Zitterbewegung test (`ω = 2mc²/ℏ`) for electron + neutrino
 
-**Next action**: **M5.0e** — implement curl, divergence, and curl-curl vector operators in `lagrangian_engine.py`. These are the last differential operators needed before M5.2 (Close's Eq. 19 linear limit `∂²_tQ = −c²·∇×∇×Q`) and M5.1 (winding tracker uses divergence on the director field). Then M5.0f (natural-unit kernel scaling), M5.0g (per-voxel Hamiltonian + F=−∇H), M5.0h (physics-invariant test gate), M5.0i (profiling + Tier 2 optimizations) close out the scaffold.
+**Next action**: **M5.0f** — kernel-internal natural-unit scaling (`c = 1`, `λ_C(defect-of-interest) = 1`, `ℏ = 1`) for intra-kernel arithmetic only, with conversion at kernel entry/exit. Required because the electron's `λ_C ≈ 3.86e5 am` is no longer near-1.0 in attometers, which hurts CFL/dispersion math at f32. Stored fields stay in the validated `_am` / `_rs` / `_rHz` units. Then M5.0g (per-voxel Hamiltonian + F=−∇H), M5.0h (physics-invariant test gate), M5.0i (profiling + Tier 2 optimizations) close out the scaffold.
 
 ---
 


### PR DESCRIPTION
This pull request focuses on improving the clarity, accuracy, and physical consistency of energy-related variable naming and documentation in the Laplace and Lagrangian field experiment modules. It also updates the force and motion module to reflect the new Hamiltonian-based energy computation, removes deprecated code, and enhances in-code documentation for maintainability and correctness.

**Energy variable renaming and documentation improvements:**

* Standardized energy variable names in `m2_laplace_propagation/_launcher.py` from `energy_global` to `energy_total` for clarity and consistency across initialization, reset, computation, and display logic. [[1]](diffhunk://#diff-e766d23dc2c7bdbc63d520bfd40f7ce2d9a3b9edf0b1b988d2e1007f6d14f9acL124-R124) [[2]](diffhunk://#diff-e766d23dc2c7bdbc63d520bfd40f7ce2d9a3b9edf0b1b988d2e1007f6d14f9acL229-R229) [[3]](diffhunk://#diff-e766d23dc2c7bdbc63d520bfd40f7ce2d9a3b9edf0b1b988d2e1007f6d14f9acL376-R376) [[4]](diffhunk://#diff-e766d23dc2c7bdbc63d520bfd40f7ce2d9a3b9edf0b1b988d2e1007f6d14f9acL523-R529)
* In `m5_lagrangian_field/_launcher.py`, replaced ambiguous or deprecated energy variables (`hamiltonian_total_aJ`) with clearly documented and physically accurate alternatives (`energy_global_H_avg`, `energy_total_H`), including detailed comments about their units and scaling. [[1]](diffhunk://#diff-5f2c0244ef3374ff1b185355a8deb9963461aae12b065371d060771738071d22L118-R131) [[2]](diffhunk://#diff-5f2c0244ef3374ff1b185355a8deb9963461aae12b065371d060771738071d22L276-R286) [[3]](diffhunk://#diff-5f2c0244ef3374ff1b185355a8deb9963461aae12b065371d060771738071d22L352-R362) [[4]](diffhunk://#diff-5f2c0244ef3374ff1b185355a8deb9963461aae12b065371d060771738071d22L368-R386) [[5]](diffhunk://#diff-5f2c0244ef3374ff1b185355a8deb9963461aae12b065371d060771738071d22L419-R440) [[6]](diffhunk://#diff-5f2c0244ef3374ff1b185355a8deb9963461aae12b065371d060771738071d22L439) [[7]](diffhunk://#diff-5f2c0244ef3374ff1b185355a8deb9963461aae12b065371d060771738071d22R520-R540)
* Updated dashboard and UI text to reflect new variable names and clarify units (e.g., "rel." for relative units, pending physical scaling in future versions). [[1]](diffhunk://#diff-5f2c0244ef3374ff1b185355a8deb9963461aae12b065371d060771738071d22L419-R440) [[2]](diffhunk://#diff-5f2c0244ef3374ff1b185355a8deb9963461aae12b065371d060771738071d22L439)

**Seed variable renaming and propagation:**

* Renamed all occurrences of `WAVE_SEED` to `TEST_SEED` in `m5_lagrangian_field/_launcher.py` and related logic, including parameter application, grid initialization, and experiment setup, for better semantic clarity. [[1]](diffhunk://#diff-5f2c0244ef3374ff1b185355a8deb9963461aae12b065371d060771738071d22L161-R170) [[2]](diffhunk://#diff-5f2c0244ef3374ff1b185355a8deb9963461aae12b065371d060771738071d22L210-R219) [[3]](diffhunk://#diff-5f2c0244ef3374ff1b185355a8deb9963461aae12b065371d060771738071d22L221-R234) [[4]](diffhunk://#diff-5f2c0244ef3374ff1b185355a8deb9963461aae12b065371d060771738071d22L471-R492)
* Updated references in `medium.py` to match the new seed naming convention.

**Energy density and tracker improvements:**

* Added and documented a new per-voxel energy density field `energy_density_H_aJ` and global average `energy_global_H_avg_aJ` in `medium.py`, replacing deprecated fields and aligning with the Hamiltonian formalism.
* Updated kernel calls and comments to clarify the computation and use of these new energy observables.

**Force and motion module modernization:**

* Overhauled `xforce_motion.py` to remove legacy EWT-based energy and force formulas, updating all documentation and implementation to use the Hamiltonian-based energy density (`H`) and its gradient for force calculations. [[1]](diffhunk://#diff-ae6bfb40599aa1204cfb80bb874993ea34b7b6020dd07e3564ee9f773a4d94e8L4-L30) [[2]](diffhunk://#diff-ae6bfb40599aa1204cfb80bb874993ea34b7b6020dd07e3564ee9f773a4d94e8L40-R59)
* Improved comments and explanations for units and physical meaning, and removed unused constants and functions related to deprecated approaches. [[1]](diffhunk://#diff-ae6bfb40599aa1204cfb80bb874993ea34b7b6020dd07e3564ee9f773a4d94e8L4-L30) [[2]](diffhunk://#diff-ae6bfb40599aa1204cfb80bb874993ea34b7b6020dd07e3564ee9f773a4d94e8L40-R59)

These changes collectively improve code clarity, physical correctness, and maintainability, and lay the groundwork for future enhancements involving nonlinear couplings and proper physical scaling.