### PR TITLE
Adjust GUI subwindow positions and palette scales

### DIFF
--- a/openwave/i_o/render.py
+++ b/openwave/i_o/render.py
@@ -215,7 +215,7 @@ def handle_camera():
 def display_cam_instructions():
     """Display camera movement instructions."""
     global cam_x, cam_y, cam_z
-    with gui.sub_window("CAMERA MOVEMENT", 0.00, 0.88, 0.14, 0.12) as sub:
+    with gui.sub_window("CAMERA MOVEMENT", 0.87, 0.88, 0.13, 0.12) as sub:
         sub.text("Orbit: RMB or Shift+LMB")
         sub.text("Pan: Arrow keys")
         sub.text("Zoom: Q/Z keys")

--- a/openwave/xperiments/m1_granule_motion/_launcher.py
+++ b/openwave/xperiments/m1_granule_motion/_launcher.py
@@ -220,7 +220,7 @@ def display_xperiment_launcher(xperiment_mgr, state):
     """
     selected_xperiment = None
 
-    with render.gui.sub_window("XPERIMENT LAUNCHER", 0.00, 0.00, 0.14, 0.32) as sub:
+    with render.gui.sub_window("XPERIMENT LAUNCHER", 0.00, 0.00, 0.14, 0.35) as sub:
         sub.text("(needs window reload)", color=colormap.LIGHT_BLUE[1])
         for xp_name in xperiment_mgr.available_xperiments:
             display_name = xperiment_mgr.get_xperiment_display_name(xp_name)
@@ -237,7 +237,7 @@ def display_xperiment_launcher(xperiment_mgr, state):
 
 def display_controls(state):
     """Display the controls UI overlay."""
-    with render.gui.sub_window("CONTROLS", 0.00, 0.33, 0.16, 0.30) as sub:
+    with render.gui.sub_window("CONTROLS", 0.00, 0.35, 0.16, 0.33) as sub:
         state.SHOW_AXIS = sub.checkbox(f"Axis (ticks: {state.TICK_SPACING})", state.SHOW_AXIS)
         state.BLOCK_SLICE = sub.checkbox("Block Slice", state.BLOCK_SLICE)
         state.SHOW_SOURCES = sub.checkbox("Show Wave Centers (sources)", state.SHOW_SOURCES)
@@ -257,7 +257,7 @@ def display_controls(state):
 
 def display_wave_menu(state):
     """Display wave properties selection menu."""
-    with render.gui.sub_window("WAVE MENU", 0.00, 0.73, 0.14, 0.14) as sub:
+    with render.gui.sub_window("WAVE MENU", 0.00, 0.80, 0.15, 0.20) as sub:
         if sub.checkbox("Displacement (Granule)", state.WAVE_MENU == 1):
             state.WAVE_MENU = 1
         if sub.checkbox("Amplitude (Peak)", state.WAVE_MENU == 2):
@@ -268,11 +268,11 @@ def display_wave_menu(state):
             state.WAVE_MENU = 4
         if state.WAVE_MENU == 1:  # Display orange gradient palette
             render.canvas.triangles(og_palette_vertices, per_vertex_color=og_palette_colors)
-            with render.gui.sub_window("displacement", 0.00, 0.67, 0.08, 0.06) as sub:
+            with render.gui.sub_window("displacement", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.peak_amplitude:.0e}m")
         if state.WAVE_MENU == 2:  # Display ironbow gradient palette
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
-            with render.gui.sub_window("amplitude", 0.00, 0.67, 0.08, 0.06) as sub:
+            with render.gui.sub_window("amplitude", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.peak_amplitude:.0e}m")
 
 
@@ -293,7 +293,7 @@ def display_level_specs(state, level_bar_vertices):
 
 def display_data_dashboard(state):
     """Display simulation data dashboard."""
-    with render.gui.sub_window("DATA-DASHBOARD", 0.84, 0.43, 0.16, 0.57) as sub:
+    with render.gui.sub_window("DATA-DASHBOARD", 0.84, 0.17, 0.16, 0.57) as sub:
         state.INSTRUMENTATION = sub.checkbox("Instrumentation ON/OFF", state.INSTRUMENTATION)
         sub.text("--- SPACETIME ---", color=colormap.LIGHT_BLUE[1])
         sub.text(f"Medium Density: {constants.MEDIUM_DENSITY:.1e} kg/m³")
@@ -351,10 +351,10 @@ def initialize_xperiment(state):
 
     # Initialize color palettes for gradient rendering and level indicator
     og_palette_vertices, og_palette_colors = colormap.get_palette_scale(
-        colormap.orange, 0.00, 0.66, 0.079, 0.01
+        colormap.orange, 0.00, 0.73, 0.079, 0.01
     )
     ib_palette_vertices, ib_palette_colors = colormap.get_palette_scale(
-        colormap.ironbow, 0.00, 0.66, 0.079, 0.01
+        colormap.ironbow, 0.00, 0.73, 0.079, 0.01
     )
     level_bar_vertices = colormap.get_level_bar_geometry(0.84, 0.00, 0.159, 0.01)
 

--- a/openwave/xperiments/m2_laplace_propagation/_launcher.py
+++ b/openwave/xperiments/m2_laplace_propagation/_launcher.py
@@ -252,7 +252,7 @@ def display_xperiment_launcher(xperiment_mgr, state):
     """
     selected_xperiment = None
 
-    with render.gui.sub_window("XPERIMENT LAUNCHER", 0.00, 0.00, 0.14, 0.32) as sub:
+    with render.gui.sub_window("XPERIMENT LAUNCHER", 0.00, 0.00, 0.14, 0.35) as sub:
         sub.text("(needs window reload)", color=colormap.LIGHT_BLUE[1])
         for xp_name in xperiment_mgr.available_xperiments:
             display_name = xperiment_mgr.get_xperiment_display_name(xp_name)
@@ -269,7 +269,7 @@ def display_xperiment_launcher(xperiment_mgr, state):
 
 def display_controls(state):
     """Display the controls UI overlay."""
-    with render.gui.sub_window("CONTROLS", 0.00, 0.33, 0.16, 0.25) as sub:
+    with render.gui.sub_window("CONTROLS", 0.00, 0.35, 0.16, 0.33) as sub:
         state.SHOW_AXIS = sub.checkbox(f"Axis (ticks: {state.TICK_SPACING})", state.SHOW_AXIS)
         state.SHOW_EDGES = sub.checkbox("Sim Universe Edges", state.SHOW_EDGES)
         state.SHOW_FLUX_MESH = sub.slider_int("Flux Mesh", state.SHOW_FLUX_MESH, 0, 3)
@@ -287,7 +287,7 @@ def display_controls(state):
 
 def display_wave_menu(state):
     """Display wave properties selection menu."""
-    with render.gui.sub_window("WAVE MENU", 0.00, 0.70, 0.15, 0.17) as sub:
+    with render.gui.sub_window("WAVE MENU", 0.00, 0.80, 0.15, 0.20) as sub:
         if sub.checkbox("Displacement (Longitudinal)", state.WAVE_MENU == 1):
             state.WAVE_MENU = 1
         if sub.checkbox("Displacement (Transverse)", state.WAVE_MENU == 2):
@@ -301,27 +301,27 @@ def display_wave_menu(state):
         # Display gradient palette with 2× average range for headroom (allows peak visualization)
         if state.WAVE_MENU == 1:  # Displacement (Longitudinal) on greenyellow gradient
             render.canvas.triangles(gy_palette_vertices, per_vertex_color=gy_palette_colors)
-            with render.gui.sub_window("displacement", 0.00, 0.64, 0.08, 0.06) as sub:
+            with render.gui.sub_window("displacement", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(
                     f"{-state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}m"
                 )
         if state.WAVE_MENU == 2:  # Displacement (Transverse) on bluered gradient
             render.canvas.triangles(br_palette_vertices, per_vertex_color=br_palette_colors)
-            with render.gui.sub_window("displacement", 0.00, 0.64, 0.08, 0.06) as sub:
+            with render.gui.sub_window("displacement", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(
                     f"{-state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}  {state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}m"
                 )
         if state.WAVE_MENU == 3:  # Amplitude (Longitudinal) on viridis gradient
             render.canvas.triangles(vr_palette_vertices, per_vertex_color=vr_palette_colors)
-            with render.gui.sub_window("amplitude", 0.00, 0.64, 0.08, 0.06) as sub:
+            with render.gui.sub_window("amplitude", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.ampL_global_rms*2/state.wave_field.scale_factor:.0e}m")
         if state.WAVE_MENU == 4:  # Amplitude (Transverse) on ironbow gradient
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
-            with render.gui.sub_window("amplitude", 0.00, 0.64, 0.08, 0.06) as sub:
+            with render.gui.sub_window("amplitude", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.ampT_global_rms*2/state.wave_field.scale_factor:.0e}m")
         if state.WAVE_MENU == 5:  # Frequency (L&T) on blueprint gradient
             render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
-            with render.gui.sub_window("frequency", 0.00, 0.64, 0.08, 0.06) as sub:
+            with render.gui.sub_window("frequency", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.freq_global_avg*2*state.wave_field.scale_factor:.0e}Hz")
 
 
@@ -345,7 +345,7 @@ def display_data_dashboard(state):
     clock_time = time.time() - state.clock_start_time
     sim_time_years = clock_time / (state.elapsed_t_rs * constants.RONTOSECOND or 1) / 31_536_000
 
-    with render.gui.sub_window("DATA-DASHBOARD", 0.84, 0.34, 0.16, 0.66) as sub:
+    with render.gui.sub_window("DATA-DASHBOARD", 0.84, 0.17, 0.16, 0.66) as sub:
         state.INSTRUMENTATION = sub.checkbox("Instrumentation ON/OFF", state.INSTRUMENTATION)
         sub.text("--- SPACETIME ---", color=colormap.LIGHT_BLUE[1])
         sub.text(f"Medium Density: {constants.MEDIUM_DENSITY:.1e} kg/m³")
@@ -427,19 +427,19 @@ def initialize_xperiment(state):
 
     # Initialize color palette scales for gradient rendering and level indicator
     gy_palette_vertices, gy_palette_colors = colormap.get_palette_scale(
-        colormap.greenyellow, 0.00, 0.63, 0.079, 0.01
+        colormap.greenyellow, 0.00, 0.73, 0.079, 0.01
     )
     br_palette_vertices, br_palette_colors = colormap.get_palette_scale(
-        colormap.bluered, 0.00, 0.63, 0.079, 0.01
+        colormap.bluered, 0.00, 0.73, 0.079, 0.01
     )
     vr_palette_vertices, vr_palette_colors = colormap.get_palette_scale(
-        colormap.viridis, 0.00, 0.63, 0.079, 0.01
+        colormap.viridis, 0.00, 0.73, 0.079, 0.01
     )
     ib_palette_vertices, ib_palette_colors = colormap.get_palette_scale(
-        colormap.ironbow, 0.00, 0.63, 0.079, 0.01
+        colormap.ironbow, 0.00, 0.73, 0.079, 0.01
     )
     bp_palette_vertices, bp_palette_colors = colormap.get_palette_scale(
-        colormap.blueprint, 0.00, 0.63, 0.079, 0.01
+        colormap.blueprint, 0.00, 0.73, 0.079, 0.01
     )
     level_bar_vertices = colormap.get_level_bar_geometry(0.84, 0.00, 0.159, 0.01)
 

--- a/openwave/xperiments/m3_wolff_lafreniere/_launcher.py
+++ b/openwave/xperiments/m3_wolff_lafreniere/_launcher.py
@@ -257,7 +257,7 @@ def display_xperiment_launcher(xperiment_mgr, state):
 
 def display_controls(state):
     """Display the controls UI overlay."""
-    with render.gui.sub_window("CONTROLS", 0.00, 0.35, 0.16, 0.27) as sub:
+    with render.gui.sub_window("CONTROLS", 0.00, 0.35, 0.16, 0.33) as sub:
         state.SHOW_AXIS = sub.checkbox(f"Axis (ticks: {state.TICK_SPACING})", state.SHOW_AXIS)
         state.SHOW_EDGES = sub.checkbox("Sim Universe Edges", state.SHOW_EDGES)
         state.SHOW_FLUX_MESH = sub.slider_int("Flux Mesh", state.SHOW_FLUX_MESH, 0, 3)
@@ -277,7 +277,7 @@ def display_controls(state):
 
 def display_wave_menu(state):
     """Display wave properties selection menu."""
-    with render.gui.sub_window("WAVE MENU", 0.00, 0.70, 0.15, 0.18) as sub:
+    with render.gui.sub_window("WAVE MENU", 0.00, 0.80, 0.15, 0.20) as sub:
         if sub.checkbox("Displacement (Scalar)", state.WAVE_MENU == 1):
             state.WAVE_MENU = 1
         if sub.checkbox("Amplitude (EMA RMS)", state.WAVE_MENU == 2):
@@ -291,27 +291,27 @@ def display_wave_menu(state):
         # Display gradient palette with 2× average range for headroom (allows peak visualization)
         if state.WAVE_MENU == 1:  # Displacement on greenyellow gradient
             render.canvas.triangles(gy_palette_vertices, per_vertex_color=gy_palette_colors)
-            with render.gui.sub_window("displacement", 0.00, 0.64, 0.08, 0.06) as sub:
+            with render.gui.sub_window("displacement", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(
                     f"{-state.amp_global_rms*2/state.wave_field.scale_factor:.0e}  {state.amp_global_rms*2/state.wave_field.scale_factor:.0e}m"
                 )
         if state.WAVE_MENU == 2:  # Amplitude (EMA RMS) on viridis gradient
             render.canvas.triangles(vr_palette_vertices, per_vertex_color=vr_palette_colors)
-            with render.gui.sub_window("amplitude", 0.00, 0.64, 0.08, 0.06) as sub:
+            with render.gui.sub_window("amplitude", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.amp_global_rms*2/state.wave_field.scale_factor:.0e}m")
         if state.WAVE_MENU == 3:  # Amplitude (Phasor RMS) on viridis gradient
             render.canvas.triangles(vr_palette_vertices, per_vertex_color=vr_palette_colors)
-            with render.gui.sub_window("amplitude", 0.00, 0.64, 0.08, 0.06) as sub:
+            with render.gui.sub_window("amplitude", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.amp_global_rms*2/state.wave_field.scale_factor:.0e}m")
         if state.WAVE_MENU == 4:  # Envelope (Signed) on greenyellow gradient
             render.canvas.triangles(gy_palette_vertices, per_vertex_color=gy_palette_colors)
-            with render.gui.sub_window("envelope", 0.00, 0.64, 0.08, 0.06) as sub:
+            with render.gui.sub_window("envelope", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(
                     f"{-state.amp_global_rms*2/state.wave_field.scale_factor:.0e}  {state.amp_global_rms*2/state.wave_field.scale_factor:.0e}m"
                 )
         if state.WAVE_MENU == 5:  # Energy on ironbow gradient
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
-            with render.gui.sub_window("energy", 0.00, 0.64, 0.08, 0.06) as sub:
+            with render.gui.sub_window("energy", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.energy_global_avg*2:.0e}J")
 
 
@@ -335,7 +335,7 @@ def display_data_dashboard(state):
     clock_time = time.time() - state.clock_start_time
     sim_time_years = clock_time / (state.elapsed_t_rs * constants.RONTOSECOND or 1) / 31_536_000
 
-    with render.gui.sub_window("DATA-DASHBOARD", 0.84, 0.47, 0.16, 0.53) as sub:
+    with render.gui.sub_window("DATA-DASHBOARD", 0.84, 0.17, 0.16, 0.53) as sub:
         state.INSTRUMENTATION = sub.checkbox("Instrumentation ON/OFF", state.INSTRUMENTATION)
         sub.text("--- SPACETIME ---", color=colormap.LIGHT_BLUE[1])
         sub.text(f"Medium Density: {constants.MEDIUM_DENSITY:.1e} kg/m³")
@@ -388,13 +388,13 @@ def initialize_xperiment(state):
 
     # Initialize color palette scales for gradient rendering and level indicator
     gy_palette_vertices, gy_palette_colors = colormap.get_palette_scale(
-        colormap.greenyellow, 0.00, 0.63, 0.079, 0.01
+        colormap.greenyellow, 0.00, 0.73, 0.079, 0.01
     )
     vr_palette_vertices, vr_palette_colors = colormap.get_palette_scale(
-        colormap.viridis, 0.00, 0.63, 0.079, 0.01
+        colormap.viridis, 0.00, 0.73, 0.079, 0.01
     )
     ib_palette_vertices, ib_palette_colors = colormap.get_palette_scale(
-        colormap.ironbow, 0.00, 0.63, 0.079, 0.01
+        colormap.ironbow, 0.00, 0.73, 0.079, 0.01
     )
     level_bar_vertices = colormap.get_level_bar_geometry(0.84, 0.00, 0.159, 0.01)
 

--- a/openwave/xperiments/m4_vector_wave/_launcher.py
+++ b/openwave/xperiments/m4_vector_wave/_launcher.py
@@ -259,7 +259,7 @@ def display_xperiment_launcher(xperiment_mgr, state):
 
 def display_controls(state):
     """Display the controls UI overlay."""
-    with render.gui.sub_window("CONTROLS", 0.00, 0.35, 0.16, 0.30) as sub:
+    with render.gui.sub_window("CONTROLS", 0.00, 0.35, 0.16, 0.33) as sub:
         state.SHOW_AXIS = sub.checkbox(f"Axis (ticks: {state.TICK_SPACING})", state.SHOW_AXIS)
         state.SHOW_EDGES = sub.checkbox("Sim Universe Edges", state.SHOW_EDGES)
         state.SHOW_FLUX_MESH = sub.slider_int("Flux Mesh", state.SHOW_FLUX_MESH, 0, 3)
@@ -280,7 +280,7 @@ def display_controls(state):
 
 def display_wave_menu(state):
     """Display wave properties selection menu."""
-    with render.gui.sub_window("WAVE MENU", 0.00, 0.73, 0.15, 0.15) as sub:
+    with render.gui.sub_window("WAVE MENU", 0.00, 0.80, 0.15, 0.20) as sub:
         if sub.checkbox("Displacement (Magnitude)", state.WAVE_MENU == 1):
             state.WAVE_MENU = 1
         if sub.checkbox("Amplitude (EMA RMS)", state.WAVE_MENU == 2):
@@ -292,19 +292,19 @@ def display_wave_menu(state):
         # Display gradient palette with 2× average range for headroom (allows peak visualization)
         if state.WAVE_MENU == 1:  # Displacement on orange gradient
             render.canvas.triangles(og_palette_vertices, per_vertex_color=og_palette_colors)
-            with render.gui.sub_window("displacement", 0.00, 0.67, 0.08, 0.06) as sub:
+            with render.gui.sub_window("displacement", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.amp_global_rms*2/state.wave_field.scale_factor:.0e}m")
         if state.WAVE_MENU == 2:  # Amplitude (EMA RMS) on ironbow gradient
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
-            with render.gui.sub_window("amplitude", 0.00, 0.67, 0.08, 0.06) as sub:
+            with render.gui.sub_window("amplitude", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.amp_global_rms*2/state.wave_field.scale_factor:.0e}m")
         if state.WAVE_MENU == 3:  # Frequency (L&T) on blueprint gradient
             render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
-            with render.gui.sub_window("frequency", 0.00, 0.67, 0.08, 0.06) as sub:
+            with render.gui.sub_window("frequency", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.freq_global_avg*2*state.wave_field.scale_factor:.0e}Hz")
         if state.WAVE_MENU == 4:  # Energy on ironbow gradient
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
-            with render.gui.sub_window("energy", 0.00, 0.67, 0.08, 0.06) as sub:
+            with render.gui.sub_window("energy", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.energy_global_avg*2:.0e}J")
 
 
@@ -328,7 +328,7 @@ def display_data_dashboard(state):
     clock_time = time.time() - state.clock_start_time
     sim_time_years = clock_time / (state.elapsed_t_rs * constants.RONTOSECOND or 1) / 31_536_000
 
-    with render.gui.sub_window("DATA-DASHBOARD", 0.84, 0.45, 0.16, 0.55) as sub:
+    with render.gui.sub_window("DATA-DASHBOARD", 0.84, 0.17, 0.16, 0.55) as sub:
         state.INSTRUMENTATION = sub.checkbox("Instrumentation ON/OFF", state.INSTRUMENTATION)
         sub.text("--- SPACETIME ---", color=colormap.LIGHT_BLUE[1])
         sub.text(f"Medium Density: {constants.MEDIUM_DENSITY:.1e} kg/m³")
@@ -381,13 +381,13 @@ def initialize_xperiment(state):
 
     # Initialize color palette scales for gradient rendering and level indicator
     og_palette_vertices, og_palette_colors = colormap.get_palette_scale(
-        colormap.orange, 0.00, 0.66, 0.079, 0.01
+        colormap.orange, 0.00, 0.73, 0.079, 0.01
     )
     ib_palette_vertices, ib_palette_colors = colormap.get_palette_scale(
-        colormap.ironbow, 0.00, 0.66, 0.079, 0.01
+        colormap.ironbow, 0.00, 0.73, 0.079, 0.01
     )
     bp_palette_vertices, bp_palette_colors = colormap.get_palette_scale(
-        colormap.blueprint, 0.00, 0.66, 0.079, 0.01
+        colormap.blueprint, 0.00, 0.73, 0.079, 0.01
     )
     level_bar_vertices = colormap.get_level_bar_geometry(0.84, 0.00, 0.159, 0.01)
 

--- a/openwave/xperiments/m5_lagrangian_field/_launcher.py
+++ b/openwave/xperiments/m5_lagrangian_field/_launcher.py
@@ -320,7 +320,7 @@ def display_xperiment_launcher(xperiment_mgr, state):
     """
     selected_xperiment = None
 
-    with render.gui.sub_window("XPERIMENT LAUNCHER", 0.00, 0.00, 0.14, 0.33) as sub:
+    with render.gui.sub_window("XPERIMENT LAUNCHER", 0.00, 0.00, 0.14, 0.35) as sub:
         sub.text("(needs window reload)", color=colormap.LIGHT_BLUE[1])
         for xp_name in xperiment_mgr.available_xperiments:
             display_name = xperiment_mgr.get_xperiment_display_name(xp_name)
@@ -341,7 +341,7 @@ def display_xperiment_launcher(xperiment_mgr, state):
 
 def display_controls(state):
     """Display the controls UI overlay."""
-    with render.gui.sub_window("CONTROLS", 0.00, 0.33, 0.16, 0.33) as sub:
+    with render.gui.sub_window("CONTROLS", 0.00, 0.35, 0.16, 0.33) as sub:
         state.SHOW_AXIS = sub.checkbox(f"Axis (ticks: {state.TICK_SPACING})", state.SHOW_AXIS)
         state.SHOW_EDGES = sub.checkbox("Sim Universe Edges", state.SHOW_EDGES)
         state.SHOW_FLUX_MESH = sub.slider_int("Flux Mesh", state.SHOW_FLUX_MESH, 0, 3)
@@ -363,7 +363,7 @@ def display_controls(state):
 
 def display_wave_menu(state):
     """Display wave properties selection menu."""
-    with render.gui.sub_window("WAVE MENU", 0.00, 0.73, 0.15, 0.15) as sub:
+    with render.gui.sub_window("WAVE MENU", 0.00, 0.80, 0.15, 0.20) as sub:
         if sub.checkbox("Displacement (Magnitude)", state.WAVE_MENU == 1):
             state.WAVE_MENU = 1
             state.wave_field.create_flux_mesh()
@@ -379,19 +379,19 @@ def display_wave_menu(state):
         # Display gradient palette with 2× average range for headroom (allows peak visualization)
         if state.WAVE_MENU == 1:  # Displacement on orange gradient
             render.canvas.triangles(og_palette_vertices, per_vertex_color=og_palette_colors)
-            with render.gui.sub_window("displacement", 0.00, 0.67, 0.08, 0.06) as sub:
+            with render.gui.sub_window("displacement", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.amp_global_rms*2:.0e}m")
         if state.WAVE_MENU == 2:  # Amplitude (EMA RMS) on ironbow gradient
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
-            with render.gui.sub_window("amplitude", 0.00, 0.67, 0.08, 0.06) as sub:
+            with render.gui.sub_window("amplitude", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.amp_global_rms*2:.0e}m")
         if state.WAVE_MENU == 3:  # Frequency (L&T) on blueprint gradient
             render.canvas.triangles(bp_palette_vertices, per_vertex_color=bp_palette_colors)
-            with render.gui.sub_window("frequency", 0.00, 0.67, 0.08, 0.06) as sub:
+            with render.gui.sub_window("frequency", 0.00, 0.74, 0.08, 0.06) as sub:
                 sub.text(f"0       {state.freq_global_avg*2:.0e}Hz")
         if state.WAVE_MENU == 4:  # Energy density (Hamiltonian) on ironbow gradient
             render.canvas.triangles(ib_palette_vertices, per_vertex_color=ib_palette_colors)
-            with render.gui.sub_window("energy", 0.00, 0.67, 0.08, 0.06) as sub:
+            with render.gui.sub_window("energy", 0.00, 0.74, 0.08, 0.06) as sub:
                 # Unit label "rel." — value is per-voxel mean × 4 (matches the
                 # colormap range max in update_flux_mesh_values). Underlying field
                 # is in scaled (am/rs)² units, not physical J/m³ — REVIEW IN M5.2
@@ -420,7 +420,7 @@ def display_data_dashboard(state):
     clock_time = time.time() - state.clock_start_time
     sim_time_years = clock_time / (state.elapsed_t_rs * constants.RONTOSECOND or 1) / 31_536_000
 
-    with render.gui.sub_window("DATA-DASHBOARD", 0.84, 0.40, 0.16, 0.60) as sub:
+    with render.gui.sub_window("DATA-DASHBOARD", 0.84, 0.17, 0.16, 0.60) as sub:
         state.INSTRUMENTATION = sub.checkbox("Instrumentation ON/OFF", state.INSTRUMENTATION)
         sub.text("--- SPACETIME ---", color=colormap.LIGHT_BLUE[1])
         sub.text(f"Medium Density: {constants.MEDIUM_DENSITY:.1e} kg/m³")
@@ -489,13 +489,13 @@ def initialize_xperiment(state):
 
     # Initialize color palette scales for gradient rendering and level indicator
     og_palette_vertices, og_palette_colors = colormap.get_palette_scale(
-        colormap.orange, 0.00, 0.66, 0.079, 0.01
+        colormap.orange, 0.00, 0.73, 0.079, 0.01
     )
     ib_palette_vertices, ib_palette_colors = colormap.get_palette_scale(
-        colormap.ironbow, 0.00, 0.66, 0.079, 0.01
+        colormap.ironbow, 0.00, 0.73, 0.079, 0.01
     )
     bp_palette_vertices, bp_palette_colors = colormap.get_palette_scale(
-        colormap.blueprint, 0.00, 0.66, 0.079, 0.01
+        colormap.blueprint, 0.00, 0.73, 0.079, 0.01
     )
     level_bar_vertices = colormap.get_level_bar_geometry(0.84, 0.00, 0.159, 0.01)
 


### PR DESCRIPTION
Tweak UI layout across render and experiment launchers: move the camera instructions window to the right, enlarge/raise the XPERIMENT LAUNCHER and CONTROLS panels, move WAVE MENU and its small palette label windows upward, and standardize DATA-DASHBOARD Y position to 0.17. Also update palette scale parameters (previous 0.63/0.66 -> 0.73) for multiple colormaps to adjust gradient placement. These changes harmonize overlay placement and visual palette alignment across experiments.