### PR TITLE
Review engine organization

### DIFF
--- a/openwave/xperiments/m5_liquid_crystal/_launcher.py
+++ b/openwave/xperiments/m5_liquid_crystal/_launcher.py
@@ -646,29 +646,6 @@ def initialize_xperiment(state):
         print("=" * 64)
 
 
-def compute_propagation(state):
-    """Step ψ one timestep via leapfrog, then update trackers.
-
-    Dynamics-only: runs the wave propagation + buffer swap + per-voxel
-    amp/freq EMA. Per-voxel ENERGY DENSITIES (H, F) and the global aggregates
-    are computed by `compute_field_observables`, which runs every frame
-    regardless of pause state so visualization reflects the current ψ
-    (including the static seeded state when PAUSED=True).
-    """
-
-    # ψ PROPAGATION =======================================
-    # Leapfrog/Verlet step: ψ_new = 2·ψ − ψ_prev + (c·dt)²·∇²ψ
-    lagrange.evolve_psi(
-        state.wave_field, state.c_amrs, state.dt_rs, state.m_freq_kg_rs, state.lambda_phi4
-    )
-    # Cycle the triple buffer: psi_prev ← psi, psi ← psi_new
-    state.wave_field.swap_buffers()
-
-    # TRACKERS (per-voxel amp / freq from ψ) ==============
-    # Time-dependent EMA — only meaningful during dynamics, so kept here.
-    lagrange.update_trackers(state.wave_field, state.trackers, state.dt_rs, state.elapsed_t_rs)
-
-
 def relax_field(state, n_steps):
     """Run N gradient-descent relaxation steps on the director field (M5.1 task 6).
 
@@ -700,6 +677,29 @@ def relax_field(state, n_steps):
         wf.psi_prev_am.copy_from(wf.psi_new_am)
     # Refresh observables so dashboard + flux mesh reflect the relaxed field
     compute_field_observables(state)
+
+
+def compute_propagation(state):
+    """Step ψ one timestep via leapfrog, then update trackers.
+
+    Dynamics-only: runs the wave propagation + buffer swap + per-voxel
+    amp/freq EMA. Per-voxel ENERGY DENSITIES (H, F) and the global aggregates
+    are computed by `compute_field_observables`, which runs every frame
+    regardless of pause state so visualization reflects the current ψ
+    (including the static seeded state when PAUSED=True).
+    """
+
+    # ψ PROPAGATION =======================================
+    # Leapfrog/Verlet step: ψ_new = 2·ψ − ψ_prev + (c·dt)²·∇²ψ
+    lagrange.evolve_psi(
+        state.wave_field, state.c_amrs, state.dt_rs, state.m_freq_kg_rs, state.lambda_phi4
+    )
+    # Cycle the triple buffer: psi_prev ← psi, psi ← psi_new
+    state.wave_field.swap_buffers()
+
+    # TRACKERS (per-voxel amp / freq from ψ) ==============
+    # Time-dependent EMA — only meaningful during dynamics, so kept here.
+    lagrange.update_trackers(state.wave_field, state.trackers, state.dt_rs, state.elapsed_t_rs)
 
 
 def compute_field_observables(state):
@@ -902,7 +902,7 @@ def main():
     state = SimulationState()
 
     # Load xperiment from CLI argument or default
-    default_xperiment = selected_xperiment_arg or "_test4_topology"
+    default_xperiment = selected_xperiment_arg or "_topology1"
     if default_xperiment not in xperiment_mgr.available_xperiments:
         print(f"Error: Xperiment '{default_xperiment}' not found!")
         return

--- a/openwave/xperiments/m5_liquid_crystal/lagrangian_engine.py
+++ b/openwave/xperiments/m5_liquid_crystal/lagrangian_engine.py
@@ -11,25 +11,28 @@ zero (free-wave); M5.2 plugs in Klein-Gordon mass + Close Eq. 23 + LdG.
 Module layout (top-to-bottom):
     INITIAL-CONDITION SEEDING — seed_gaussian, seed_dispersion_modes,
                                 seed_vacuum, seed_hedgehog
+    GRADIENT-DESCENT RELAX    — relax_director_step (one step of gradient
+                                descent on Frank energy w/ tangent projection
+                                + unit-length renorm + soft core pin; M5.1
+                                task 6 — port from Exp 2)
+    ------------------------------
     DIFFERENTIAL OPERATORS    — Laplacian, divergence, curl, curl-curl
     ψ EVOLVING ENGINE         — evolve_psi (leapfrog/Verlet)
+    ------------------------------
     WAVE TRACKERS             — update_trackers_psi (amp / freq EMA — writes
                                 to Trackers; stateful, dynamics-gated)
     FIELD OBSERVABLES         — compute_energyH_density (Hamiltonian),
                                 compute_energyF_density (Frank elastic);
                                 both write to FieldObservables (stateless,
                                 always-on per-frame measurements)
-    GRADIENT-DESCENT RELAX    — relax_director_step (one step of gradient
-                                descent on Frank energy w/ tangent projection
-                                + unit-length renorm + soft core pin; M5.1
-                                task 6 — port from Exp 2)
     WINDING-NUMBER DIAGNOSTIC — compute_winding_number (Q on a sphere
                                 around a defect; CPU numpy; M5.1 task 8 —
                                 port from Exp 3; diagnostic only)
-    POSITION RENDER           — sample_position_to_render (granule viz)
     3-PLANE SAMPLING          — sample_avg_trackers   (amp / freq globals)
                                 sample_avg_observables (energyH / energyF
                                 globals; separate pass for SoC, 2026-05-11)
+    ------------------------------
+    POSITION RENDER           — sample_position_to_render (granule viz)
     FLUX MESH UPDATING        — update_flux_mesh_values (color mapping;
                                 reads both Trackers and FieldObservables)
     DIRECTOR GLYPHS           — update_director_glyphs (M5.1 director viz)
@@ -366,6 +369,101 @@ def seed_hedgehog(
         wave_field.psi_prev_am[i, j, k] = n_unit
         # BC consistency: write psi_new_am too. See evolve_psi docstring.
         wave_field.psi_new_am[i, j, k] = n_unit
+
+
+# ================================================================
+# GRADIENT-DESCENT RELAXATION (M5.1 task 6)
+# ================================================================
+# Direct port of Exp 2's relax() inner loop to Taichi:
+#     dn = ∇²n − (n·∇²n) n         (tangent projection onto unit sphere)
+#     n_new = n + τ · dn           (gradient-descent step)
+#     n_new ← n_new / |n_new|       (unit-length constraint)
+#     n_new[defect_core] = ±ẑ      (soft Dirichlet pin)
+#
+# Stability: τ < dx²/(2·dim·K) by the standard heat-equation CFL condition.
+# For dim=3 in 3D the bound is τ < dx²/(6·K). Use ~50% of the bound for
+# headroom; the launcher computes this from wave_field.dx_am at runtime.
+#
+# Output buffer convention: writes to psi_new_am (same buffer leapfrog uses).
+# The caller copies psi_new_am to BOTH psi_am AND psi_prev_am so that
+# subsequent leapfrog steps see ψ̇ = 0 (no spurious time-derivative from the
+# relaxation update — relaxation is a STATIC operation, not a dynamics step).
+# This is different from swap_buffers, which rotates buffers for time evolution.
+#
+# Boundary handling: psi_new_am boundary voxels are copied from psi_am (no
+# update) — preserves the fixed-value Dirichlet BC (e.g. ẑ at the universe
+# edge from seed_vacuum).
+#
+# Core pin: soft Dirichlet at the SINGLE closest voxel to each defect center.
+# Without this, gradient descent can numerically dissolve the defect on a
+# discrete grid (topology is not strictly preserved by discretization).
+#
+# M7 FORWARD-LINK: this kernel is mathematically the γ → ∞ limit of a damped
+# wave equation `∂²_t ψ = c²∇²ψ − γ·∂_t ψ`. Although the relaxation use is
+# purely numerical (no physics interpretation in M5.1), the same primitives
+# — Laplacian stencil, tangent projection, soft-core pin — will be reused
+# in M7 thermal-modulation kernels where γ becomes a PHYSICAL damping
+# coefficient (radiation loss, phonon coupling, EM-load impedance). See
+# `research/2a_path_to_m5.md § Beyond M6 — thermal mechanics pathway`
+# for the infrastructure-foundation discussion.
+
+
+@ti.kernel
+def relax_director_step(
+    wave_field: ti.template(),  # type: ignore
+    tau: ti.f32,  # type: ignore
+    pin_centers: ti.template(),  # type: ignore
+    pin_signs: ti.template(),  # type: ignore
+    n_defects: ti.i32,  # type: ignore
+):
+    """
+    One gradient-descent step on the Frank elastic energy `H_F = (K/2)·|∇n̂|²`.
+
+    Reads:  wave_field.psi_am
+    Writes: wave_field.psi_new_am  (caller copies → psi_am AND psi_prev_am)
+
+    Args:
+        wave_field: WaveField with the director field in psi_am
+        tau: step size (must satisfy τ < dx²/(6·K) for stability)
+        pin_centers: ti.field shape (n_defects, 3) i32 — defect centers in voxel coords
+        pin_signs: ti.field shape (n_defects,) i32 — ±1 per defect (pin direction)
+        n_defects: number of active defects in pin_centers/signs
+
+    Note: K_frank is implicit in `tau`'s CFL derivation — the kernel itself
+    doesn't multiply by K because gradient descent on `(K/2)·|∇n̂|²` gives
+    `∂n/∂τ = K·∇²n` and the K can be absorbed into the step size (τ_eff = K·τ).
+    For K=1 (M5.1 default) this is τ_eff = τ.
+    """
+    nx, ny, nz = wave_field.nx, wave_field.ny, wave_field.nz
+
+    # ---- Interior: tangent-projected gradient step + renormalization ----
+    for i, j, k in ti.ndrange((1, nx - 1), (1, ny - 1), (1, nz - 1)):
+        n = wave_field.psi_am[i, j, k]
+        lap = compute_laplacian(wave_field, i, j, k)
+        n_dot_lap = n.dot(lap)
+        dn = lap - n_dot_lap * n  # tangent projection (remove component along n)
+        n_new = n + tau * dn
+        norm = n_new.norm() + 1e-12
+        wave_field.psi_new_am[i, j, k] = n_new / norm
+
+    # ---- Boundary: preserve Dirichlet BC by copying from current ψ ----
+    for j, k in ti.ndrange(ny, nz):
+        wave_field.psi_new_am[0, j, k] = wave_field.psi_am[0, j, k]
+        wave_field.psi_new_am[nx - 1, j, k] = wave_field.psi_am[nx - 1, j, k]
+    for i, k in ti.ndrange(nx, nz):
+        wave_field.psi_new_am[i, 0, k] = wave_field.psi_am[i, 0, k]
+        wave_field.psi_new_am[i, ny - 1, k] = wave_field.psi_am[i, ny - 1, k]
+    for i, j in ti.ndrange(nx, ny):
+        wave_field.psi_new_am[i, j, 0] = wave_field.psi_am[i, j, 0]
+        wave_field.psi_new_am[i, j, nz - 1] = wave_field.psi_am[i, j, nz - 1]
+
+    # ---- Pin defect cores (soft Dirichlet at single closest voxel) ----
+    for d in range(n_defects):
+        ci = pin_centers[d, 0]
+        cj = pin_centers[d, 1]
+        ck = pin_centers[d, 2]
+        sgn = ti.cast(pin_signs[d], ti.f32)
+        wave_field.psi_new_am[ci, cj, ck] = ti.Vector([0.0, 0.0, sgn])
 
 
 # ================================================================
@@ -1003,101 +1101,6 @@ def compute_energyF_density(
 
 
 # ================================================================
-# GRADIENT-DESCENT RELAXATION (M5.1 task 6)
-# ================================================================
-# Direct port of Exp 2's relax() inner loop to Taichi:
-#     dn = ∇²n − (n·∇²n) n         (tangent projection onto unit sphere)
-#     n_new = n + τ · dn           (gradient-descent step)
-#     n_new ← n_new / |n_new|       (unit-length constraint)
-#     n_new[defect_core] = ±ẑ      (soft Dirichlet pin)
-#
-# Stability: τ < dx²/(2·dim·K) by the standard heat-equation CFL condition.
-# For dim=3 in 3D the bound is τ < dx²/(6·K). Use ~50% of the bound for
-# headroom; the launcher computes this from wave_field.dx_am at runtime.
-#
-# Output buffer convention: writes to psi_new_am (same buffer leapfrog uses).
-# The caller copies psi_new_am to BOTH psi_am AND psi_prev_am so that
-# subsequent leapfrog steps see ψ̇ = 0 (no spurious time-derivative from the
-# relaxation update — relaxation is a STATIC operation, not a dynamics step).
-# This is different from swap_buffers, which rotates buffers for time evolution.
-#
-# Boundary handling: psi_new_am boundary voxels are copied from psi_am (no
-# update) — preserves the fixed-value Dirichlet BC (e.g. ẑ at the universe
-# edge from seed_vacuum).
-#
-# Core pin: soft Dirichlet at the SINGLE closest voxel to each defect center.
-# Without this, gradient descent can numerically dissolve the defect on a
-# discrete grid (topology is not strictly preserved by discretization).
-#
-# M7 FORWARD-LINK: this kernel is mathematically the γ → ∞ limit of a damped
-# wave equation `∂²_t ψ = c²∇²ψ − γ·∂_t ψ`. Although the relaxation use is
-# purely numerical (no physics interpretation in M5.1), the same primitives
-# — Laplacian stencil, tangent projection, soft-core pin — will be reused
-# in M7 thermal-modulation kernels where γ becomes a PHYSICAL damping
-# coefficient (radiation loss, phonon coupling, EM-load impedance). See
-# `research/2a_path_to_m5.md § Beyond M6 — thermal mechanics pathway`
-# for the infrastructure-foundation discussion.
-
-
-@ti.kernel
-def relax_director_step(
-    wave_field: ti.template(),  # type: ignore
-    tau: ti.f32,  # type: ignore
-    pin_centers: ti.template(),  # type: ignore
-    pin_signs: ti.template(),  # type: ignore
-    n_defects: ti.i32,  # type: ignore
-):
-    """
-    One gradient-descent step on the Frank elastic energy `H_F = (K/2)·|∇n̂|²`.
-
-    Reads:  wave_field.psi_am
-    Writes: wave_field.psi_new_am  (caller copies → psi_am AND psi_prev_am)
-
-    Args:
-        wave_field: WaveField with the director field in psi_am
-        tau: step size (must satisfy τ < dx²/(6·K) for stability)
-        pin_centers: ti.field shape (n_defects, 3) i32 — defect centers in voxel coords
-        pin_signs: ti.field shape (n_defects,) i32 — ±1 per defect (pin direction)
-        n_defects: number of active defects in pin_centers/signs
-
-    Note: K_frank is implicit in `tau`'s CFL derivation — the kernel itself
-    doesn't multiply by K because gradient descent on `(K/2)·|∇n̂|²` gives
-    `∂n/∂τ = K·∇²n` and the K can be absorbed into the step size (τ_eff = K·τ).
-    For K=1 (M5.1 default) this is τ_eff = τ.
-    """
-    nx, ny, nz = wave_field.nx, wave_field.ny, wave_field.nz
-
-    # ---- Interior: tangent-projected gradient step + renormalization ----
-    for i, j, k in ti.ndrange((1, nx - 1), (1, ny - 1), (1, nz - 1)):
-        n = wave_field.psi_am[i, j, k]
-        lap = compute_laplacian(wave_field, i, j, k)
-        n_dot_lap = n.dot(lap)
-        dn = lap - n_dot_lap * n  # tangent projection (remove component along n)
-        n_new = n + tau * dn
-        norm = n_new.norm() + 1e-12
-        wave_field.psi_new_am[i, j, k] = n_new / norm
-
-    # ---- Boundary: preserve Dirichlet BC by copying from current ψ ----
-    for j, k in ti.ndrange(ny, nz):
-        wave_field.psi_new_am[0, j, k] = wave_field.psi_am[0, j, k]
-        wave_field.psi_new_am[nx - 1, j, k] = wave_field.psi_am[nx - 1, j, k]
-    for i, k in ti.ndrange(nx, nz):
-        wave_field.psi_new_am[i, 0, k] = wave_field.psi_am[i, 0, k]
-        wave_field.psi_new_am[i, ny - 1, k] = wave_field.psi_am[i, ny - 1, k]
-    for i, j in ti.ndrange(nx, ny):
-        wave_field.psi_new_am[i, j, 0] = wave_field.psi_am[i, j, 0]
-        wave_field.psi_new_am[i, j, nz - 1] = wave_field.psi_am[i, j, nz - 1]
-
-    # ---- Pin defect cores (soft Dirichlet at single closest voxel) ----
-    for d in range(n_defects):
-        ci = pin_centers[d, 0]
-        cj = pin_centers[d, 1]
-        ck = pin_centers[d, 2]
-        sgn = ti.cast(pin_signs[d], ti.f32)
-        wave_field.psi_new_am[ci, cj, ck] = ti.Vector([0.0, 0.0, sgn])
-
-
-# ================================================================
 # WINDING-NUMBER DIAGNOSTIC (M5.1 task 8)
 # ================================================================
 # Compute the topological charge Q of a director field on a sphere around
@@ -1182,38 +1185,6 @@ def compute_winding_number(
     cross = np.cross(dn_dtheta, dn_dphi, axis=-1)
     integrand = (n_s * cross).sum(axis=-1)
     return float(integrand.sum() * dth * dph / (4.0 * np.pi))
-
-
-# ================================================================
-# POSITION RENDER
-# ================================================================
-
-
-@ti.kernel
-def sample_position_to_render(
-    wave_field: ti.template(),  # type: ignore
-    amp_boost: ti.f32,  # type: ignore
-    stride: ti.i32,  # type: ignore
-    num_render: ti.i32,  # type: ignore
-):
-    """Sample granule positions from z flux_mesh plane with stride, writing to 1D position_render.
-
-    Samples every `stride`-th voxel from the XY plane at the z flux mesh index,
-    capping output at `num_render` particles for performance.
-    """
-    k = int(wave_field.flux_mesh_planes[2] * wave_field.grid_size[2])
-    max_dim = ti.cast(wave_field.max_grid_size, ti.f32)
-    sampled_ny = (wave_field.ny + stride - 1) // stride  # cols per sampled row
-
-    for render_idx in range(num_render):
-        si = render_idx // sampled_ny  # sampled row index
-        sj = render_idx % sampled_ny  # sampled col index
-        i = si * stride
-        j = sj * stride
-        displaced = amp_boost * wave_field.psi_am[i, j, k] / wave_field.dx_am + ti.Vector(
-            [ti.cast(i, ti.f32), ti.cast(j, ti.f32), ti.cast(k, ti.f32)]
-        )
-        wave_field.position_render[render_idx] = displaced / max_dim
 
 
 # ================================================================
@@ -1467,6 +1438,38 @@ def sample_avg_observables(
     # Plain mean for Frank elastic energy density F (per voxel).
     total_energyF = xy_energyF.sum() + xz_energyF.sum() + yz_energyF.sum()
     observables.energyF_global_avg_aJ[None] = float(total_energyF / n_samples)
+
+
+# ================================================================
+# POSITION RENDER
+# ================================================================
+
+
+@ti.kernel
+def sample_position_to_render(
+    wave_field: ti.template(),  # type: ignore
+    amp_boost: ti.f32,  # type: ignore
+    stride: ti.i32,  # type: ignore
+    num_render: ti.i32,  # type: ignore
+):
+    """Sample granule positions from z flux_mesh plane with stride, writing to 1D position_render.
+
+    Samples every `stride`-th voxel from the XY plane at the z flux mesh index,
+    capping output at `num_render` particles for performance.
+    """
+    k = int(wave_field.flux_mesh_planes[2] * wave_field.grid_size[2])
+    max_dim = ti.cast(wave_field.max_grid_size, ti.f32)
+    sampled_ny = (wave_field.ny + stride - 1) // stride  # cols per sampled row
+
+    for render_idx in range(num_render):
+        si = render_idx // sampled_ny  # sampled row index
+        sj = render_idx % sampled_ny  # sampled col index
+        i = si * stride
+        j = sj * stride
+        displaced = amp_boost * wave_field.psi_am[i, j, k] / wave_field.dx_am + ti.Vector(
+            [ti.cast(i, ti.f32), ti.cast(j, ti.f32), ti.cast(k, ti.f32)]
+        )
+        wave_field.position_render[render_idx] = displaced / max_dim
 
 
 # ================================================================

--- a/openwave/xperiments/m5_liquid_crystal/research/1b_topological_defect.md
+++ b/openwave/xperiments/m5_liquid_crystal/research/1b_topological_defect.md
@@ -107,9 +107,11 @@ The same field plays both roles in M5: *topology* describes how it's CONFIGURED;
 
 Reading the map: if the question is about *what exists or what's protected*, the answer is topology. If the question is about *what changes or what propagates*, the answer is waves. The interesting cases are where both apply — annihilation events, accelerated defects, and the intrinsic Zitterbewegung — because those are where M5's unified field-as-particle-and-medium picture pays the most explanatory dividends.
 
-### Alternative stabilization — oscillation (Werbos chaoitons)
+### Alternative stabilization — oscillation (time-periodicity)
 
-Topology is *one* mechanism that evades Derrick's theorem. Werbos's 2026 Ouroboros paper (`theory/Werbos_Chaoitons_Ouroboros_2025_with_far_field.pdf`) proposes an alternative: **time-periodicity** as the stabilizer. A *chaoiton* is a localized, time-periodic solution of a coupled-vector-field Lagrangian — stable because it oscillates, not because it's topologically protected. M5 uses topology as the default (winding number, hedgehog/skyrmion), but the M5.2+ dynamics may *also* exhibit oscillation-stabilization (Wilczek time-crystal preview in [§ Intrinsic oscillation](#intrinsic-oscillation--the-time-crystal-mechanism-preview)), so the two mechanisms are not mutually exclusive — they could co-occur in the same defect. Werbos's framework also cites the **Sawada `v(r) ~ -C/r⁶`** long-range nuclear-force anomaly (Sawada 1989, 2003) as an empirical anchor; that's a candidate M5.4+ falsifiability target for any field theory that produces composite hadron-like solitons.
+Topology is *one* mechanism that evades Derrick's theorem. A second route is **time-periodicity** — energy stored in oscillation rather than in a static gradient — instantiated as Werbos's *chaoiton* (a localized, time-periodic solution of a coupled-vector-field Lagrangian). M6 develops this framework in full; see [M6 / Ouroboros — 0a_background.md § What's a chaoiton](../../m6_ouroboros/research/0a_background.md).
+
+**Relevance to M5:** the two mechanisms are not mutually exclusive. M5 uses topology as the default (winding number, hedgehog/skyrmion), but the M5.2+ dynamics may *also* exhibit oscillation-stabilization (Wilczek time-crystal preview in [§ Intrinsic oscillation](#intrinsic-oscillation--the-time-crystal-mechanism-preview)) — both could co-occur in the same defect. The Werbos framework also cites the **Sawada `v(r) ~ -C/r⁶`** long-range nuclear-force anomaly (Sawada 1989, 2003) as an empirical anchor; that's a candidate M5.4+ falsifiability target for any field theory that produces composite hadron-like solitons.
 
 ### Alternative stabilization — compact manifold (Haldane-sphere BEC analog)
 

--- a/openwave/xperiments/m5_liquid_crystal/xparameters/_topology1.py
+++ b/openwave/xperiments/m5_liquid_crystal/xparameters/_topology1.py
@@ -1,0 +1,115 @@
+"""
+XPERIMENT PARAMETERS — Topology Smoke Test (M5.1)
+
+Seeds either a uniform vacuum or one/two hedgehog defects via M5.1's
+`seed_vacuum` / `seed_hedgehog` kernels (validated port from Exp 2),
+then auto-relaxes the seeded field into a minimum-Frank-energy
+configuration via M5.1 task 6's gradient-descent kernel. The simulator
+runs PAUSED — this xperiment exists to *visually verify* the seeded +
+relaxed director field; the director-glyph renderer (task 4) makes the
+topology visible on the 3 orthogonal planes.
+
+Three configurations selectable via TOPOLOGY_MODE below:
+- "vacuum"        : uniform n = ẑ everywhere (sanity check)
+- "hedgehog_1"  : single +1 hedgehog at the domain center
+- "hedgehog_2" : +1 / −1 pair offset along x (M5.4 prelude)
+
+Visual check (without director-glyph renderer): flux_mesh with WAVE_MENU=1
+shows |ψ| ≈ 1 everywhere (since seeds are unit-length); director structure
+is invisible to magnitude rendering. This xperiment is mainly a
+correctness gate — it confirms the kernels run, fields are populated
+without NaN/inf, and the simulator boots cleanly with the new seed paths.
+
+The director structure becomes visible once M5.1 task 4 (director-glyph
+renderer per `../research/2b_director_glyph_rendering.md`) lands.
+"""
+
+UNIVERSE_EDGE = 1e-15  # m
+TARGET_VOXELS = 64**3  # ~262k voxels — small for fast smoke-test
+
+# Switch the mode here:
+# TOPOLOGY_MODE = "vacuum"
+TOPOLOGY_MODE = "hedgehog_1"
+# TOPOLOGY_MODE = "hedgehog_2"
+
+# M5.1 task 6 — auto-relax steps on seed. Relaxation is the numerical
+# ground-state finder for the Frank elastic energy; always run after seeding
+# to drop the blend-zone artifacts into a minimum-energy configuration
+# before the user sees the field. 60 matches Exp 2's default; bump higher
+# (200-300) for tighter convergence. 0 disables auto-relax (e.g. when
+# inspecting the raw seed state for debugging).
+AUTO_RELAX_STEPS = 60
+
+if TOPOLOGY_MODE == "vacuum":
+    TOPOLOGY_SEED = {
+        "MODE": "vacuum",
+        "AUTO_RELAX_STEPS": 0,  # no defects → nothing to relax
+    }
+elif TOPOLOGY_MODE == "hedgehog_1":
+    TOPOLOGY_SEED = {
+        "MODE": "hedgehog",
+        "DEFECTS": [
+            {"CENTER": [0.50, 0.50, 0.50], "SIGN": +1},
+        ],
+        "DOMAIN_QUARTER_FRACTION": 0.25,  # w_vac falloff at ~D/4
+        "AUTO_RELAX_STEPS": AUTO_RELAX_STEPS,
+    }
+elif TOPOLOGY_MODE == "hedgehog_2":
+    TOPOLOGY_SEED = {
+        "MODE": "hedgehog",
+        "DEFECTS": [
+            {"CENTER": [0.40, 0.50, 0.50], "SIGN": +1},  # left, outward
+            {"CENTER": [0.60, 0.50, 0.50], "SIGN": -1},  # right, inward
+        ],
+        "DOMAIN_QUARTER_FRACTION": 0.20,  # tighter blend so pair stays distinct
+        "AUTO_RELAX_STEPS": AUTO_RELAX_STEPS,
+    }
+else:
+    raise ValueError(f"Unknown TOPOLOGY_MODE: {TOPOLOGY_MODE}")
+
+
+XPARAMETERS = {
+    "meta": {
+        "X_NAME": f"Topology ({TOPOLOGY_MODE})",
+        "DESCRIPTION": "Seeded director field — visual verification of seed_vacuum / seed_hedgehog",
+    },
+    "camera": {
+        "INITIAL_POSITION": [1.10, 1.46, 0.81],
+    },
+    "universe": {
+        "SIZE": [UNIVERSE_EDGE, UNIVERSE_EDGE, UNIVERSE_EDGE],
+        "TARGET_VOXELS": TARGET_VOXELS,
+    },
+    "wave_centers": {
+        "COUNT": 1,
+        "POSITION": [[0.50, 0.50, 0.50]],
+        "PHASE_OFFSETS_DEG": [0],
+        "INIT_VELOCITY": [[0.0, 0.0, 0.0]],
+        "APPLY_MOTION": False,
+    },
+    "ui_defaults": {
+        "SHOW_AXIS": False,
+        "TICK_SPACING": 0.25,
+        "SHOW_GRID": False,
+        "SHOW_EDGES": False,
+        "FLUX_MESH_PLANES": [0.5, 0.5, 0.5],
+        "SHOW_FLUX_MESH": 1,  # off by default — directors are the primary view in M5.1
+        "WARP_MESH": 0,  # no Z-warp — director field has |n|=1 uniformly, warp would be misleading
+        "SHOW_DIRECTORS": 2,  # M5.1: 0=off, 1=XY, 2=+XZ, 3=all three planes
+        "VIZ_STRIDE": 1,  # shared every-Nth-voxel sampling stride for directors AND granules
+        "PARTICLE_SHELL": False,
+        "SHOW_GRANULES": False,
+        "SIM_SPEED": 1.0,
+        "PAUSED": True,  # static field, no time evolution in M5.1
+    },
+    "color_defaults": {
+        "COLOR_THEME": "OCEAN",
+        "WAVE_MENU": 5,
+    },
+    "analytics": {
+        "INSTRUMENTATION": False,
+        "EXPORT_VIDEO": False,
+        "VIDEO_FRAMES": 24,
+    },
+    "topology_seed": TOPOLOGY_SEED,
+}

--- a/openwave/xperiments/m5_liquid_crystal/xparameters/_topology2.py
+++ b/openwave/xperiments/m5_liquid_crystal/xparameters/_topology2.py
@@ -29,8 +29,8 @@ TARGET_VOXELS = 64**3  # ~262k voxels — small for fast smoke-test
 
 # Switch the mode here:
 # TOPOLOGY_MODE = "vacuum"
+# TOPOLOGY_MODE = "hedgehog_1"
 TOPOLOGY_MODE = "hedgehog_2"
-# TOPOLOGY_MODE = "hedgehog_2"
 
 # M5.1 task 6 — auto-relax steps on seed. Relaxation is the numerical
 # ground-state finder for the Frank elastic energy; always run after seeding
@@ -70,7 +70,7 @@ else:
 
 XPARAMETERS = {
     "meta": {
-        "X_NAME": f"Topo Test ({TOPOLOGY_MODE})",
+        "X_NAME": f"Topology ({TOPOLOGY_MODE})",
         "DESCRIPTION": "Seeded director field — visual verification of seed_vacuum / seed_hedgehog",
     },
     "camera": {


### PR DESCRIPTION
This pull request primarily reorganizes and refines the codebase for the M5 liquid crystal experiment, focusing on code clarity, module structure, and default experiment selection. The main changes include moving the gradient-descent relaxation kernel and position render kernel to more logical locations within the code, updating the default experiment and its configuration, and improving documentation for alternative stabilization mechanisms.

**Codebase organization and kernel relocation:**

* Moved the `relax_director_step` gradient-descent relaxation kernel and its documentation to a new, thematically appropriate section earlier in `lagrangian_engine.py`, clarifying its purpose and future use in thermal-modulation kernels. [[1]](diffhunk://#diff-e68abd9fc5540b1b1961baec951019438bd83b9d7b73fc4fa46972122224d864R374-R468) [[2]](diffhunk://#diff-e68abd9fc5540b1b1961baec951019438bd83b9d7b73fc4fa46972122224d864L1005-L1099)
* Relocated the `sample_position_to_render` kernel and its documentation to a dedicated "POSITION RENDER" section, improving logical module flow. [[1]](diffhunk://#diff-e68abd9fc5540b1b1961baec951019438bd83b9d7b73fc4fa46972122224d864L1187-L1218) [[2]](diffhunk://#diff-e68abd9fc5540b1b1961baec951019438bd83b9d7b73fc4fa46972122224d864R1443-R1474)
* Updated the module layout comment at the top of `lagrangian_engine.py` to reflect the new organization and clarify the grouping of related functionality.

**Experiment defaults and configuration:**

* Changed the default experiment loaded by the launcher from `_test4_topology` to `_topology1`, and updated the topology mode from `"hedgehog_2"` to `"hedgehog_1"` for consistency and clarity. Also renamed the xparameter file to `_topology1.py` and updated the experiment name in its metadata. [[1]](diffhunk://#diff-21368569c07cd0c4beefe99312b37cafbfe1493a816cb35685f8b2653f7915b6L32-R32) [[2]](diffhunk://#diff-21368569c07cd0c4beefe99312b37cafbfe1493a816cb35685f8b2653f7915b6L73-R73) [[3]](diffhunk://#diff-3366f7a5ea7b594578d5547bd432f95b5b22041bf5131168356f64406df636b3L905-R905)

**Documentation improvements:**

* Improved the explanation of alternative stabilization mechanisms in the research notes, clarifying the distinction between topological and time-periodic (oscillation) stabilization, and referencing the relevant sections in the M6 documentation.

**Code movement for clarity:**

* Moved the `compute_propagation` function in `_launcher.py` to a more logical location after `relax_field`, improving code readability and organization. [[1]](diffhunk://#diff-3366f7a5ea7b594578d5547bd432f95b5b22041bf5131168356f64406df636b3L649-L671) [[2]](diffhunk://#diff-3366f7a5ea7b594578d5547bd432f95b5b22041bf5131168356f64406df636b3R682-R704)