### PR TITLE
Bump version to 1.1.1 and shorten descriptions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,9 @@ See `/dev_docs` for coding standards and development guidelines
 
 # Install OpenWave & Dependencies for Development (-e = edit mode)
    pip install -e .  # installs dependencies from pyproject.toml
+
+# Activate the auto-DCO-sign-off git hook (one-time per clone)
+   git config core.hooksPath .githooks
    ```
 
 - **Create a Branch to Develop Your Feature**

--- a/openwave/__init__.py
+++ b/openwave/__init__.py
@@ -1,11 +1,8 @@
 """Core package for the OpenWave project.
 
-OpenWave is an open-source subatomic wave simulator that supports exploration
-of fundamental physics theories.
-
-It's built as a computational physics toolkit applying classical wave mechanics
-for modeling matter and energy phenomena using wave-field dynamics.
+Open-source subatomic simulator using classical wave-field methods with topology
+and nonlinear potentials to study particle and force emergence. GPU-accelerated.
 
 """
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,11 @@ name = "OPENWAVE"
 # - MAJOR: Breaking changes (incompatible API changes)
 # - MINOR: New features (backward-compatible)
 # - PATCH: Bug fixes (backward-compatible)
-version = "1.1.0"
+version = "1.1.1"
 
 requires-python = ">=3.12"
 
-description = "Open-source subatomic simulator using classical wave-field methods with topology and nonlinear potentials to study particle and force emergence. GPU-accelerated."
+description = "Open-source subatomic simulator."
 readme = "README.md"
 keywords = [
   "Energy Wave Theory", "Subatomic Simulation", "Quantum Mechanics",


### PR DESCRIPTION
Update package version to 1.1.1 and simplify package metadata and module docstring. The module docstring in openwave/__init__.py was condensed to a shorter summary emphasizing topology, nonlinear potentials, and GPU acceleration; pyproject.toml version and package description were likewise updated for more concise metadata.

<!-- Thank you for contributing to OpenWave! -->

## Summary

<!-- What does this PR change? 1-3 bullet points. -->

-

## Motivation

<!-- Why is this change needed? Link to issue if applicable. -->

## Test Plan

<!-- How did you verify this change works? -->

- [x] Tested locally
- [x] Added or updated tests (if applicable)
- [x] Updated documentation (if applicable)

## Developer Certificate of Origin (DCO)

OpenWave uses the [Developer Certificate of Origin v1.1](https://developercertificate.org/) — every commit in this PR must include a `Signed-off-by:` line.

- [x] All commits are signed off (`git commit -s`)

If any commit is missing sign-off, the DCO check will fail. To fix:

```bash
# Sign off the last commit:
git commit --amend --signoff

# Sign off all commits in this branch:
git rebase --signoff main
git push --force-with-lease
```

See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
