### PR TITLE
Docs: update M6 roadmap & question tracker

### DIFF
--- a/openwave/common/colormap.py
+++ b/openwave/common/colormap.py
@@ -129,7 +129,7 @@ ironbow_palette = [
 # Blueprint Gradient: PALETTE [used in get_blueprint_color()]
 # ================================================================
 blueprint_palette = [
-    ["#0D1A46", (0.051, 0.102, 0.271)],  # dark blue
+    ["#182962", (0.094, 0.161, 0.384)],  # dark blue
     ["#667DC0", (0.400, 0.490, 0.753)],  # medium blue
     ["#8CA1CF", (0.549, 0.631, 0.812)],  # blue
     ["#BDCAE7", (0.741, 0.792, 0.906)],  # light blue

--- a/openwave/xperiments/m6_ouroboros/research/0b_M6_roadmap.md
+++ b/openwave/xperiments/m6_ouroboros/research/0b_M6_roadmap.md
@@ -1,8 +1,8 @@
 # M6 / Ouroboros — Roadmap
 
-**Status:** ✅ **NEUTRAL CHAOITON GROUND STATE FOUND.** v9 continued: Paul/DeepSeek replied 2026-05-22 ~9:53 AM CONFIRMING BOTH Q43 (sign: `-m_J²β` minus) and Q44 (geometry: 3D spherical l=1 p-wave). DeepSeek sent template `neutral_bvp_solver.py`. Template verbatim collapses to trivial β≡0 (origin BC β'(R_MIN)=0 is the wrong regularity class for l=1). **Modified to proper l=1 origin BC (β ~ B0·r) + B0 fixed + m_J as free eigenvalue → TRUE NONLINEAR GROUND STATE.** At g=1.0, B0=0.5: m_J = +0.5145, peak β = 0.70 @ r = 1.78, **tail/peak = 1.1×10⁻⁵ (clean K_1 decay), sign changes = 0 (zero nodes — true ground state).** 1-parameter family in B0 ∈ [0.4, 0.6] all give clean ground states (m_J ∈ [0.46, 0.56]); transition to excited branch (1 node, m_J<0) at B0 between 0.6 and 0.7. Email v13 sent + committed + PR'd, with Q45 (how to pin canonical point in family for DM paper) + Q46 (H/Q normalization between cylindrical charged and spherical neutral). G2 status: BVP-EXHAUSTED → GROUND-STATE-FOUND-PENDING-CALIBRATION-POINT. M5 path foreground per cardinal rule; M6 paused on Q45/Q46 reply.
+**Status:** ✅ **NEUTRAL CHAOITON GROUND STATE FOUND.** v9 continued: Paul/DeepSeek replied 2026-05-22 ~9:53 AM CONFIRMING BOTH Q43 (sign: `-m_J²β` minus) and Q44 (geometry: 3D spherical l=1 p-wave). DeepSeek sent template `neutral_bvp_solver.py`. Template verbatim collapses to trivial β≡0 (origin BC β'(R_MIN)=0 is the wrong regularity class for l=1). **Modified to proper l=1 origin BC (β ~ B0·r) + B0 fixed + m_J as free eigenvalue → TRUE NONLINEAR GROUND STATE.** At g=1.0, B0=0.5: m_J = +0.5145, peak β = 0.70 @ r = 1.78, **tail/peak = 1.1×10⁻⁵ (clean K_1 decay), sign changes = 0 (zero nodes — true ground state).** 1-parameter family in B0 ∈ [0.4, 0.6] all give clean ground states (m_J ∈ [0.46, 0.56]); transition to excited branch (1 node, m_J<0) at B0 between 0.6 and 0.7. Email v13 sent + committed + PR'd, with Q45 (how to pin canonical point in family for DM paper) + Q46 (H/Q normalization between cylindrical charged and spherical neutral). **Email v14 SENT 2026-05-22 PM** — v13 content resent verbatim + Acknowledgments-update ask bundled (Paul's PM reply ack'd arxiv endorsement news but didn't forward v13 to DeepSeek; resend gives DeepSeek the substance). G2 status: BVP-EXHAUSTED → GROUND-STATE-FOUND-PENDING-CALIBRATION-POINT. M5 path foreground per cardinal rule; M6 paused on Q45/Q46 reply.
 
-Last updated: 2026-05-22 mid-morning (post DeepSeek Q43+Q44 confirmation + neutral ground state found + email v13 sent — Q43/Q44 RESOLVED, Q45/Q46 NEW).
+Last updated: 2026-05-22 PM (post email v14 sent — v13 content resent + Acknowledgments-update ask bundled; Pending plan section now SENT).
 
 See `0b_model_gates.md` for the G1/G2/G3 production criteria.
 See `0b_question_tracker.md` for the live question + hardest-pieces tracker.
@@ -347,11 +347,24 @@ characterization + asks two follow-up questions:
 | Q45 | The BVP delivers a continuous 1-parameter family (B0 ↦ m_J). To extract definite (m_χ, m_J, C) for the DM paper, we need an additional constraint. Three options: (a) match m_J to electron-calibrated value m_J=1 (requires g-scan); (b) pick lightest (B0=0.40, m_χ ≈ 0.866 MeV); (c) self-consistency with charged sector. Which is canonical? |
 | Q46 | Sonnet's charged H/Q uses cylindrical (r·dr) integration; our neutral 3D spherical uses r²·dr. Does the H/Q × m_e mass formula apply directly across geometries, or is there a renormalization factor? |
 
-### Pending plan — Acknowledgments-update ask on next email (v14)
+### Acknowledgments-update ask — SENT 2026-05-22 PM (email v14)
 
-**To be bundled with the reply to Paul's Q45/Q46 answers — NOT a
-standalone ask, NOT personal-interest, business-positioning driven,
-AND honest about role separation.**
+**Status:** ✅ SENT 2026-05-22 PM as email v14 (v13 content resent
+verbatim + this Acknowledgments-update ask bundled at the end, before
+the closing line). Trigger: Paul's PM reply ack'd the arxiv quant-ph
+endorsement news but didn't forward v13's ground-state results to
+DeepSeek; sending v14 gives DeepSeek the substance AND lands the
+Acknowledgments ask while the concrete contribution (BVP demonstration
+of the neutral chaoiton ground state with clean K_1 decay) is fresh.
+NOT a standalone ask, NOT personal-interest, business-positioning
+driven, AND honest about role separation.
+
+**Awaiting:** Paul + DeepSeek's reply on Q45/Q46 + reaction to the
+Acknowledgments wording. If accepted as-is or with edits, the next
+DM paper revision will reflect the three-tier credit (OpenWave Labs +
+Griesi + Anthropic Claude Code).
+
+**Reference (the language sent in v14):**
 
 ### Role honesty (the key constraint)
 
@@ -459,25 +472,34 @@ critique.
 | Painting Griesi as "lone founder" | False; physics advisors (Yee, Duda, Close, Werbos) and AI agents are real contributors |
 | Hiding that Claude Code did the numerical analysis | Eventually surfaces and damages trust; honesty is cheaper |
 
-### When to apply
+### When sent — UPDATED 2026-05-22 PM
 
-When Paul replies to Q45 + Q46, the v14 email reply should include:
-(1) the requested (m_χ, m_J, C) numbers under whichever canonical
-point Paul picks; (2) the proposed Acknowledgments-update language
-above as a low-friction one-paragraph suggestion. NOT as a separate
-standalone ask; bundled with the deliverable.
+Originally planned to bundle with Paul's reply to Q45 + Q46 (carrying
+the requested (m_χ, m_J, C) numbers). Plan changed when Paul's PM reply
+came back without forwarding v13 to DeepSeek — the more useful move
+was to resend v13's substance verbatim AND bundle the Acknowledgments-
+update ask in the same email, so DeepSeek sees the ground-state results
+AND the language proposal in one shot. v14 sent 2026-05-22 PM with
+both pieces. The (m_χ, m_J, C) numbers themselves remain pending
+Paul's answer on Q45 (canonical point in family) + Q46 (H/Q
+normalization across geometries).
 
 ---
 
-## Current state (2026-05-22 morning, post sandbox v9 complete)
+## Current state (2026-05-22 PM, post email v14 sent)
 
 | Item | Status |
 | --- | --- |
-| Werbos collaboration | ✅ Active — Sonnet's canonical script `ouroboros_benchmark.py` received via Paul 2026-05-21 PM (3:05 PM). v9 LoE paper acknowledges Griesi + Anthropic AI by name; Reference [17] = our GitHub repo. Paul mentioned 9a Zenodo revision possible after our Q36/Q37 input. |
-| Email v8 (out, sent earlier 2026-05-21 PM) — ansatz question | ✅ Sent. Q34 answered same afternoon by DeepSeek (2:19 PM) + Sonnet's script (3:05 PM). |
-| Email v9 (out, sent earlier 2026-05-21 PM) — v1 citation softening | ✅ Sent. Paul replied: forwarded to DeepSeek; 9a may incorporate. |
-| **Email v10 (drafted, ready to send)** — v8 findings | 🚧 Drafted. Covers tighter g=1.0000 calibration, muon/tau independent reproduction, Q36 reinforcement via geometric distinction (cylindrical vs spherical), Q37 (0.508 MeV provenance), 2L/Q algebraic identity, pion+ feature/coincidence question. |
-| **Sonnet's canonical script** — `ouroboros_benchmark.py` | ✅ Runnable first try. 2-function (α, β) reduction, vector cylindrical Laplacian, slope BCs. Five-step v8 work program complete (steps 1-5). |
+| Werbos collaboration | ✅ Active — Sonnet's canonical script `ouroboros_benchmark.py` received via Paul 2026-05-21 PM. v9 LoE paper acknowledges Griesi + Anthropic AI by name; Reference [17] = our GitHub repo. 9b deposited at Zenodo 20330894 (2026-05-21 PM later). 9c (DeepSeek's revision) incorporates all 5 push-back items + 3 bonuses from email v10. ApJ DM paper submission held by Paul pending v9 phase 2 ground-state output. 2026-05-22 PM: arxiv top quant-ph endorsement reached Paul's submission queue. |
+| Email v8 — ansatz question (Q34) | ✅ Sent + RESOLVED 2026-05-21 PM via DeepSeek + Sonnet's canonical script. |
+| Email v9 — v1 citation softening (Q36) | ✅ Sent + RESOLVED via 9c §9 criterion 9 wording change. |
+| Email v10 — v8 findings (Q36-Q40 push-back) | ✅ Sent + ALL 5 RESOLVED via 9c (single round-trip). |
+| Email v11 — DM inputs + Q41/Q42 paths | ✅ Sent. Q41 (writing role) declined. Q42 (β non-localization) accepted; Paul agreed to delay-for-BVP path. |
+| Email v12 — v9 phase 1 BVP exhausted + Q43/Q44 | ✅ Sent. Both Q43 + Q44 confirmed by DeepSeek 2026-05-22 ~9:53 AM. |
+| Email v13 — neutral chaoiton GROUND STATE FOUND + Q45/Q46 | ✅ Sent + committed + PR'd 2026-05-22 mid-morning. |
+| Email v14 — v13 content resent + Acknowledgments-update ask bundled | ✅ Sent 2026-05-22 PM. Resend triggered because Paul's PM reply ack'd arxiv endorsement news but didn't forward v13 to DeepSeek. v14 lands ground-state substance AND multi-contributor Acknowledgments wording in one shot. |
+| **Sonnet's canonical script** — `ouroboros_benchmark.py` | ✅ Runnable first try. 2-function (α, β) reduction, vector cylindrical Laplacian, slope BCs. v8 5-step work program complete. |
+| **`neutral_bvp_solver_mJ_free.py`** — v9 phase 2 ground-state solver | ✅ True nonlinear localized soliton: sign-changes=0, tail/peak=10⁻⁵, clean K_1 decay. 1-parameter family in B0 ∈ [0.4, 0.6]. |
 | Q34 (ansatz canonical form) | ✅ **RESOLVED by DeepSeek + Sonnet's script.** Canonical electron production = 2-function reduction with vector cylindrical Laplacian. Sonnet's script is the runnable reference. |
 | **Q35 (active neutrinos)** | 🔶 OPEN. v9 framework positions Q_CS=0 chaoiton as DM candidate (heavy + neutral); active neutrinos (ν_e, ν_μ, ν_τ) are very light + neutral. Where do they fit? Sterile-neutrino interpretation possible but unmapped. |
 | Q36 (v1 citation language) | 🔶 **STRENGTHENED OPEN** — sandbox v8 step 3 paper-math comparison showed v1 (spherical r² dr, scalar Laplacian) vs Sonnet's canonical (cylindrical r dr, vector Laplacian) are **genuinely different field theories**, not reductions. v1's 1.6918 was numerical coincidence in different geometry. Email v10 reinforces v9's gentle push-back with this evidence. |
@@ -510,60 +532,77 @@ standalone ask; bundled with the deliverable.
 
 ## Next steps
 
-### Immediate — emails v10 + v11 sent; awaiting Paul's reply on Q42
+### Immediate — emails v12 + v13 + v14 sent; awaiting Paul's reply on Q45/Q46
 
-Email v10 (Q36/Q37/Q38/Q39/Q40 push-back) → ALL 5 incorporated in 9c.
-Email v11 (DM paper inputs + Q41 writing-role declined + Q42 caveat)
-sent 2026-05-21 PM. Awaiting Paul's call on Q42 path (DM submission with
-caveat-as-is OR delay-for-BVP). M5 path proceeds in foreground per
-cardinal rule.
+Email v12 (v9 phase 1 BVP exhausted + Q43/Q44 structural Qs) → both Q43+Q44
+confirmed by DeepSeek 2026-05-22 ~9:53 AM. Email v13 (neutral chaoiton
+ground state found + Q45/Q46) sent 2026-05-22 mid-morning. Email v14 (v13
+content resent verbatim + Acknowledgments-update ask bundled) sent
+2026-05-22 PM. Paul's PM reply ack'd arxiv quant-ph endorsement news
+but didn't forward v13 to DeepSeek — v14 ensures DeepSeek sees the
+ground-state substance. M5 path proceeds in foreground per cardinal
+rule while we wait on Q45 (canonical point in family) + Q46 (H/Q
+normalization across geometries).
 
-### Branches after Paul's reply on Q42 (DM submission path)
+### Branches after Paul's reply on Q45/Q46
 
-| Paul's reply | We do |
+| Paul's reply on Q45 | We do |
 | --- | --- |
-| Accepts caveat-as-is (DM submission with windowed-integration m_χ) | Acknowledge, return fully to M5. M6 v8 work is functionally complete; no further M6 sandbox work needed. |
-| Requests BVP variant for clean ground-state m_χ + reliable C | 1-2 days focused work: build neutral-sector BVP solver with β(∞)=0 (or Robin-decay BC); deliver clean numbers; then return to M5. |
-| No reply within 1-2 weeks | M5 continues. Email v11 already documents our position; no further escalation needed. |
+| (a) Match m_J to electron-calibrated λ=1 | Run g-scan via `neutral_bvp_solver_mJ_free.py` until m_J=1 lands at some (g, B0); deliver definite (m_χ, m_J, C). |
+| (b) Pick lightest in family (B0=0.40, m_χ ≈ 0.866 MeV) | Report lightest directly; deliver (m_χ, m_J, C) under Q46 normalization. |
+| (c) Self-consistency with charged sector | Solve over-determined system: same (g, m_J) as charged, find which B0 lands. ~few hours. |
+| (d) Some other constraint (Paul/DeepSeek custom) | Implement on receipt; deliver under whatever constraint they specify. |
 
-### Production scan status (v8 already executed)
+| Paul's reply on Q46 | We do |
+| --- | --- |
+| Same H/Q × m_e formula across geometries | Apply directly to v9 phase 2 family; report m_χ in MeV. |
+| Renormalization factor needed | Apply factor; report m_χ in MeV under corrected convention. |
+
+| No reply within 1-2 weeks | M5 continues. v14 already documents our position; no further escalation needed. |
+
+### Production scan status (post-v9 phase 2)
 
 | Step | Action | Gate | Status |
 | --- | --- | --- | --- |
 | 1 | Lepton scan ω ∈ [1, 80] | G1 | ✅ DONE — muon 0.80%, tau 6.47%, pion+ 3.25% gaps. PDG-level reproduction. Incorporated in 9c §8. |
-| 2 | Neutral chaoiton scan (g, λ, B0) | G2 | ✅ DONE — 448 localized solutions. Lightest at λ=1.0 = 0.998 MeV. Incorporated in 9c §8 + §9 criterion 7. |
+| 2 | Neutral chaoiton IVP scan (g, λ, B0) | G2 | ⚠️ SUPERSEDED — 448 IVP solutions, lightest at λ=1.0 = 0.998 MeV (windowed-integration value cited in 9c §8 + §9 criterion 7). Q42 caveat revealed this is not a true ground state. Superseded by step 6 BVP. |
 | 3 | Three-system geometric mapping | — | ✅ DONE — v1 spherical ≠ Sonnet cylindrical ≠ v9 §5.1 toroidal. v1's 1.6918 was numerical coincidence; led to 9c §9 criterion 9 softening. |
-| 4 | DM paper inputs (m_χ, m_J, C) | — | ✅ DONE — `sandbox_v8/extract_mJ_C_mchi.py` delivered m_χ=0.998 MeV, m_J=1.033 MeV, C=6.7×10⁻⁴ MeV·fm via email v11. |
-| 5 | Gelfand-Fomin conjugate-point stability | G3 | 🚧 Not yet run on Sonnet's converged points. ~30 min if needed. (G3 already empirically validated via step 1.) |
-| 6 | BVP variant for clean neutral ground state (Q42) | — | 🚧 Conditional — only if Paul requests delay-for-BVP path. |
+| 4 | DM paper inputs (m_χ, m_J, C) v8-era | — | ⚠️ SUPERSEDED — v8 numbers (m_χ=0.998 MeV, m_J=1.033 MeV, C=6.7×10⁻⁴ MeV·fm) delivered via email v11 with Q42 caveat. Now superseded by v9 phase 2 ground state. Definite numbers awaiting Q45/Q46 reply. |
+| 5 | Gelfand-Fomin conjugate-point stability | G3 | 🚧 Not yet run on Sonnet's charged-sector converged points. ~30 min if needed. (G3 already empirically validated via step 1; v9 phase 2 neutral ground state has sign-changes=0 empirically — equivalent stability check passed.) |
+| 6 | BVP variant for clean neutral ground state (per Q42 path) | G2 | ✅ DONE via v9 phase 2 — `neutral_bvp_solver_mJ_free.py` (3D spherical l=1 p-wave, B0 fixed + m_J free eigenvalue): true nonlinear soliton, sign-changes=0, tail/peak=10⁻⁵, clean K_1 decay. 1-parameter family in B0 ∈ [0.4, 0.6]. |
+| 7 | Definite (m_χ, m_J, C) extraction under canonical point | — | 🚧 Awaiting Q45/Q46 reply. ~1 hour targeted run once Paul picks the canonical point. |
 
-### M5 return after v8 deliverables land
+### M5 return — already foreground per cardinal rule
 
 Cardinal rule: SABER is the primary engineering goal, M5 is its substrate.
-v8 work is functionally complete (G1 + G3 empirically passed; G2 partial
-pending Q42 path). M6 stays parallel-research and primary focus returns
-to M5.
+M6 v9 phase 2 is functionally complete (G1 + G3 empirically PASSED; G2
+GROUND-STATE-FOUND-PENDING-CALIBRATION-POINT awaiting Q45/Q46 reply).
+M6 stays parallel-research; primary focus is M5.
 
 | Step | Action | Notes |
 | --- | --- | --- |
-| 1 | M5.4 — matrix-field substrate migration | Queued; primary focus once Paul replies on Q42 (or 24-48h pass without reply) |
-| 2 | M5.5 — Paper Lagrangian + V(M) | Per M5 roadmap |
-| 3 | M5.6 — Biaxial twist + KG emergence | Per M5 roadmap |
-| 4 | M5.7 — Resonance hunt (Close protocol) | Per M5 roadmap |
-| 5 | M5.8 — 4D Zitterbewegung clock | M5 group-headline milestone; aligns with SABER engineering primitive |
+| 1 | M5.3 — Direction review | In progress; pick up where left off |
+| 2 | M5.4 — matrix-field substrate migration | Queued next; primary focus while Paul's Q45/Q46 reply pending |
+| 3 | M5.5 — Paper Lagrangian + V(M) | Per M5 roadmap |
+| 4 | M5.6 — Biaxial twist + KG emergence | Per M5 roadmap |
+| 5 | M5.7 — Resonance hunt (Close protocol) | Per M5 roadmap |
+| 6 | M5.8 — 4D Zitterbewegung clock | M5 group-headline milestone; aligns with SABER engineering primitive |
 
-### M6 Taichi production decision (post-v8 G1+G3 PASS)
+### M6 Taichi production decision (post-v9 G1+G3 PASS, G2 GROUND-STATE-FOUND-PENDING)
 
-G1 and G3 empirically passed via Sonnet's canonical script in v8.
-Taichi-port decision still deferred per cardinal rule (M5 first), but
-the path is clearer now that the canonical 2-function (α, β) reduction
-is settled.
+G1 and G3 empirically passed via Sonnet's canonical script in v8. G2
+neutral chaoiton ground state found in v9 phase 2 via
+`neutral_bvp_solver_mJ_free.py` (true nonlinear soliton, clean K_1
+decay, 1-parameter family). Taichi-port decision still deferred per
+cardinal rule (M5 first), but the path is clearer now that BOTH the
+canonical 2-function (α, β) reduction (charged) AND the 3D spherical
+l=1 p-wave BVP (neutral) are settled.
 
 | Step | Action | ETA |
 | --- | --- | --- |
-| 1 | Scaffold M6 in Taichi: 2-function (α, β) substrate with vector cylindrical Laplacian; slope BCs at r→0; lepton spectrum scan as built-in test | post-M5.4 |
+| 1 | Scaffold M6 in Taichi: 2-function (α, β) substrate (charged) with vector cylindrical Laplacian + slope BCs at r→0; 3D spherical l=1 p-wave substrate (neutral) with proper l=1 origin BC + Robin decay BC; lepton spectrum + neutral chaoiton family scans as built-in tests | post-M5.4 |
 | 2 | Gate 1 Taichi: reproduce muon ω=12.82 (0.80% gap) and tau ω=50.0 (6.47%) on Taichi GPU | Week 1 of M6 build |
-| 3 | Gate 2 Taichi: neutral chaoiton mass scan (g, λ, B0); reproduce 0.998 MeV at λ=1 OR clean BVP ground state if Paul chose that path | Week 2 |
+| 3 | Gate 2 Taichi: neutral chaoiton ground state via BVP-equivalent on GPU (B0 fixed + m_J free eigenvalue, 3D spherical l=1); reproduce 1-parameter family in B0 ∈ [0.4, 0.6] with sign-changes=0 and clean K_1 decay | Week 2 |
 | 4 | Gate 3 Taichi: Yukawa-tail measurement of inter-chaoiton potential — independent verify of m_J and C | Weeks 3-4 |
 
 ### Parked (post-9c future work)
@@ -581,14 +620,15 @@ is settled.
 
 Both trackers (per-question status and the long-running hardest-pieces
 board) now live in `0b_question_tracker.md` as a single source of truth
-across all sandbox iterations. Active count as of 2026-05-22 mid-morning
-(post-v9 ground state found + email v13 sent): **2 IMMEDIATE (Q45
-canonical point in family, Q46 H/Q normalization across geometries) + 5 OPEN (Q2, Q3, Q6, Q19, Q35) + 4 RESOLVED-this-session (Q41 writing
-role declined, Q42 superseded, Q43 sign + Q44 geometry confirmed) + 2 DEMOTED (Q26, Q27) + 3 ARCHIVED (Q31, Q32, Q33 — moot via Q34)
-= 16 active questions.** Highest-leverage closure path: Paul's Q45/Q46
-reply lets us extract definite (m_χ, m_J, C) for the DM paper. M5
-path foreground while we wait. M6 data drop already at github.com/
-openwave-labs/openwave (Reference [17] in 9c).
+across all sandbox iterations. Active count as of 2026-05-22 PM
+(post-v9 phase 2 ground state found + emails v13/v14 sent): **2 IMMEDIATE
+(Q45 canonical point in family, Q46 H/Q normalization across geometries) + 5 OPEN (Q2, Q3, Q6, Q19, Q35) + 4 RESOLVED-this-session (Q41 writing
+role declined, Q42 superseded by Q43+Q44, Q43 sign + Q44 geometry confirmed
+by DeepSeek) + 2 DEMOTED (Q26, Q27) + 3 ARCHIVED (Q31, Q32, Q33 — moot
+via Q34) = 16 active questions.** Highest-leverage closure path: Paul's
+Q45/Q46 reply lets us extract definite (m_χ, m_J, C) for the DM paper.
+M5 path foreground while we wait. M6 data drop already at
+github.com/openwave-labs/openwave (Reference [17] in 9c).
 
 ---
 
@@ -607,7 +647,7 @@ openwave-labs/openwave (Reference [17] in 9c).
 | `0c_sandbox_v6.md` | v6: DeepSeek normalizations, step (8/11/4/2) diagnostics, drop-quartic finding, email v6 + Q28/Q29/Q30 |
 | `0c_sandbox_v7.md` | v7: Paul's Q28/Q29/Q30 answers, mode-selector attempts (7 variants), Phase 1 reassessment, email v7 + Q31/Q32/Q33, Paul-script variant test, v9 paper revelation, email v8 + Q34 |
 | `0c_sandbox_v8.md` | v8: Sonnet's canonical 2-function script, 5-step work program (electron sweep + paper-math + lepton scan + neutral scan), 9b/9c paper reviews, email v10 (Q36-Q40 push-back) + 9c outcome (all 5 incorporated), DM paper inputs extraction (m_χ, m_J, C), email v11 (Q41/Q42) |
-| `0c_sandbox_v9.md` | v9 (current): neutral chaoiton BVP per Paul's Q42 delay-for-BVP reply. Two interpretations of "same ODEs as charged case" both empirically exhausted: A (4-fn, Q_CS=0, asymmetric helicity) → excited modes only; B (2-fn Sonnet's neutral_ode + Dirichlet/Robin decay BC) → trivial amplitude → 0 (2D Townes-soliton pathology). Email v12 (drafted) asks Q43 sign convention + Q44 geometry + takes up DeepSeek's template offer. |
+| `0c_sandbox_v9.md` | v9 (current): neutral chaoiton BVP. **Phase 1** (per Paul's Q42 delay-for-BVP reply): two interpretations of "same ODEs as charged case" both empirically exhausted — A (4-fn, Q_CS=0, asymmetric helicity) → excited modes only; B (2-fn Sonnet's neutral_ode + Dirichlet/Robin decay BC) → trivial amplitude → 0 (2D Townes-soliton pathology). Email v12 sent with Q43 sign + Q44 geometry. **Phase 2** (post DeepSeek Q43+Q44 confirmation): proper l=1 BC + B0 fixed + m_J free eigenvalue → **NEUTRAL CHAOITON GROUND STATE FOUND** via `neutral_bvp_solver_mJ_free.py` (sign-changes=0, tail/peak=10⁻⁵, clean K_1 decay, 1-parameter family in B0 ∈ [0.4, 0.6]). Email v13 sent (ground state + Q45/Q46) + email v14 sent (resend + Acks-update ask bundled). |
 | `0b_M6_roadmap.md` | This file |
 | `0b_model_gates.md` | G1/G2/G3 production decision criteria |
 | `0b_question_tracker.md` | Live question + hardest-pieces tracker (single source of truth across all sandbox iterations) |

--- a/openwave/xperiments/m6_ouroboros/research/0b_model_gates.md
+++ b/openwave/xperiments/m6_ouroboros/research/0b_model_gates.md
@@ -4,7 +4,7 @@ Three gates must pass before committing M6 to full Taichi production. The
 model is a credible scientific candidate; these gates determine whether it is
 a credible *engineering* candidate alongside M5.
 
-Last updated: 2026-05-22 mid-morning (post DeepSeek Q43+Q44 confirmation + v9 continued with proper l=1 BC — **NEUTRAL CHAOITON GROUND STATE FOUND**. DeepSeek confirmed Q43 (sign: `-m_J²β` with minus) and Q44 (3D spherical l=1 p-wave, subcritical, supports stable solitons). DeepSeek's verbatim template `neutral_bvp_solver.py` collapses to trivial (wrong l=1 origin BC). Modified to proper l=1 (β ~ B0·r at origin) + B0 fixed + m_J as free eigenvalue → **TRUE NONLINEAR GROUND STATE: sign-changes=0, tail/peak=10⁻⁵, clean K_1 decay, m_J=+0.5145 at B0=0.5, g=1.0**. Continuous 1-parameter family in B0 ∈ [0.4, 0.6]; transition to excited branch (1 node) at B0 between 0.6 and 0.7. G2 status: BVP-EXHAUSTED → **GROUND-STATE-FOUND-PENDING-CALIBRATION-POINT**. Q43/Q44 RESOLVED; Q45 (canonical point in family) + Q46 (H/Q normalization across geometries) NEW. Email v13 sent. G1 + G3 remain PASSED. M5 path in foreground per cardinal rule.
+Last updated: 2026-05-22 PM (post email v14 sent — v13 content resent verbatim + Acknowledgments-update ask bundled. Paul's PM reply ack'd arxiv quant-ph endorsement news but didn't forward v13 to DeepSeek; v14 gives DeepSeek the ground-state substance AND lands the Acknowledgments-update wording in one shot. G1/G2/G3 unchanged: G1 + G3 PASSED; G2 GROUND-STATE-FOUND-PENDING-CALIBRATION-POINT awaiting Q45/Q46 reply. Earlier today: DeepSeek Q43+Q44 confirmation + neutral chaoiton GROUND STATE FOUND via `neutral_bvp_solver_mJ_free.py` (proper l=1 BC + B0 fixed + m_J as free eigenvalue → true nonlinear soliton: sign-changes=0, tail/peak=10⁻⁵, clean K_1 decay, m_J=+0.5145 at B0=0.5, g=1.0; continuous 1-parameter family in B0 ∈ [0.4, 0.6]; transition to excited branch at B0 between 0.6 and 0.7). M5 path foreground per cardinal rule.
 
 ---
 
@@ -28,24 +28,27 @@ Last updated: 2026-05-22 mid-morning (post DeepSeek Q43+Q44 confirmation + v9 co
 
 ---
 
-## Gate dependencies (post-v8)
+## Gate dependencies (post-v9 phase 2)
 
 | Gate | Status | Resolution path |
 | --- | --- | --- |
 | G1 (lepton scan) | ✅ **PASSED via v8 step 4** | Sonnet's `lepton_spectrum_scan()` produces muon at 0.80% gap, tau at 6.47% gap. PDG-level reproduction. |
-| G2 (neutral m_χ) | ⚠️ **PARTIAL via v8 step 5** | Scan produces 448 localized solutions. Lightest at λ=1.0 is 0.998 MeV (NOT 0.508 MeV). Q37 attribution provenance pending Paul's reply on email v10. |
+| G2 (neutral m_χ) | 🚧 **GROUND-STATE-FOUND-PENDING-CALIBRATION-POINT via v9 phase 2** | `neutral_bvp_solver_mJ_free.py` (proper l=1 BC + B0 fixed + m_J free eigenvalue) produces true nonlinear soliton: sign-changes=0, tail/peak=10⁻⁵, clean K_1 decay, m_J=+0.5145 at B0=0.5/g=1.0. 1-parameter family in B0 ∈ [0.4, 0.6]. Definite (m_χ, m_J, C) handoff awaiting Paul's Q45 (canonical point in family) + Q46 (H/Q normalization) reply via email v14. |
 | G3 (discrete ω mechanism) | ✅ **EMPIRICALLY VALIDATED via v8 step 4** | Three lowest stable Q=1 modes empirically match electron / muon / tau. Analytic proof still deferred per Werbos's own admission. |
 
-**v5 → v8 progression:**
+**v5 → v9 progression:**
 
-| Sandbox | Code | H/Q | Gap | Geometry | Mode |
+| Sandbox | Code | H/Q (charged) or m_J (neutral) | Gap | Geometry | Mode |
 | --- | --- | --- | --- | --- | --- |
-| v5 attempt 4 | 4-function BVP (Werbos algorithm) | 52.64 | 31× off | spherical (toroidal R) | excited (17-node A) |
-| v6.6 (DeepSeek quartic in H) | 4-function BVP + DeepSeek normalizations | 1.778 | 4.8% over | spherical | excited (5-node V/Q) |
-| v6.6 + drop quartic (step 8) | 4-function BVP + drop quartic | 1.7112 | 0.84% off | spherical | excited (5-node V/Q) |
+| v5 attempt 4 | 4-function BVP (Werbos algorithm) | H/Q = 52.64 | 31× off | spherical (toroidal R) | excited (17-node A) |
+| v6.6 (DeepSeek quartic in H) | 4-function BVP + DeepSeek normalizations | H/Q = 1.778 | 4.8% over | spherical | excited (5-node V/Q) |
+| v6.6 + drop quartic (step 8) | 4-function BVP + drop quartic | H/Q = 1.7112 | 0.84% off | spherical | excited (5-node V/Q) |
 | v7 (7 mode-selector variants) | 4-function BVP + anchors | — | — | spherical | all wrong-sign basins |
-| **v8 Sonnet's script (g=1.0625)** | 2-function `solve_ivp` cylindrical | **1.6969** | **0.56%** | **cylindrical** | ground |
-| **v8 scan minimum (g=1.0000)** | 2-function `solve_ivp` cylindrical | **1.6890** | **0.090%** | cylindrical | ground |
+| **v8 Sonnet's script (g=1.0625)** | 2-function `solve_ivp` cylindrical | H/Q = **1.6969** | **0.56%** | **cylindrical** | ground (charged) |
+| **v8 scan minimum (g=1.0000)** | 2-function `solve_ivp` cylindrical | H/Q = **1.6890** | **0.090%** | cylindrical | ground (charged) |
+| v9 phase 1 — 2-fn neutral BVP | `m6_v9_neutral_2fn_bvp.py` | — | trivial collapse | 2D cylindrical | none (Townes-critical) |
+| v9 phase 1 — 4-fn neutral BVP | `m6_v9_neutral_4fn_bvp.py` (Q_CS=0) | — | excited only (6-22 nodes) | spherical (toroidal R) | excited |
+| **v9 phase 2 — neutral ground state** | `neutral_bvp_solver_mJ_free.py` | m_J = **+0.5145** @ B0=0.5/g=1.0 | tail/peak 10⁻⁵ | **3D spherical l=1 p-wave** | **ground (neutral, 0 nodes)** |
 
 **Critical insight from v8 step 3 paper-math:** the 4-function (V, A, Q, J)
 BVP system used in v4-v7 was a **different field theory** from the canonical
@@ -65,12 +68,14 @@ construction.
 | 4 — Lepton spectrum scan | ✅ muon 0.80%, tau 6.47%, pion+ 3.25% |
 | 5 — Neutral chaoiton scan | ⚠️ 448 solutions; lightest at λ=1.0 = 0.998 MeV (NOT 0.508 MeV per Q37) |
 
-**Currently awaiting:** Paul's reply on email v10 (Q36 reinforcement +
-Q37 0.508 MeV provenance + Q38 2L/Q identity observation).
+**Currently awaiting:** Paul's reply on email v14 (Q45 canonical point
+in 1-parameter family + Q46 H/Q normalization across geometries +
+Acknowledgments-update ask bundled).
 
 **Parallel work while waiting:** M5 proceeds in foreground per cardinal
-rule. M6 v8 is empirically complete; G1 and G3 passed, G2 partial pending
-Q37 clarification.
+rule. M6 v9 phase 2 is empirically complete; G1 and G3 PASSED, G2
+GROUND-STATE-FOUND-PENDING-CALIBRATION-POINT awaiting Q45/Q46 to extract
+definite (m_χ, m_J, C) for the DM paper.
 
 ---
 
@@ -84,11 +89,13 @@ Q37 clarification.
 | G3 PASS (discrete mechanism) | Upgrade to STRONG GO at any stage. |
 | G3 FAIL (mechanism absent) | Lepton masses are fitted inputs. M6 is valid as alternative substrate; weaker claim than Werbos markets. |
 
-**Current state (2026-05-21 PM later):** G1 PASS + G2 PARTIAL + G3 PASS
-empirically. We're in **CONDITIONAL GO / STRONG GO** territory — but
-Taichi-port decision is still deferred per cardinal rule (M5 is SABER's
-primary engineering substrate; M5.4 substrate migration is the next
-foreground work). M6 Taichi port queued for post-M5.4.
+**Current state (2026-05-22 PM, post v9 phase 2 + v14 sent):** G1 PASS +
+G2 GROUND-STATE-FOUND-PENDING-CALIBRATION-POINT + G3 PASS empirically.
+We're in **STRONG GO** territory once Paul's Q45/Q46 reply lands the
+definite (m_χ, m_J, C). Taichi-port decision still deferred per cardinal
+rule (M5 is SABER's primary engineering substrate; M5.4 substrate
+migration is the next foreground work). M6 Taichi port queued for
+post-M5.4.
 
 ---
 
@@ -107,6 +114,57 @@ structural facts that don't depend on the current empirical pass.
 - A collaboration anchor with Paul Werbos (9c LoE Reference [17] = our GitHub repo; cover-page byline lists Claude Code Opus 4.7 as AI contributor)
 
 These justify maintaining M6 as a sandbox/research track even if production is deferred per cardinal rule.
+
+---
+
+## Current status (2026-05-22 PM, post sandbox v9 phase 2 + email v14 sent)
+
+Sandbox v9 phase 2 produced the **neutral chaoiton ground state** via
+`neutral_bvp_solver_mJ_free.py` after DeepSeek confirmed Q43 (sign:
+`-m_J²β`) + Q44 (3D spherical l=1 p-wave) on 2026-05-22 ~9:53 AM. Email
+v13 sent the result + Q45 (canonical point in 1-parameter family) +
+Q46 (H/Q normalization across geometries). Email v14 resent v13 content + Acknowledgments-update ask bundled (Paul's PM reply didn't forward
+v13 to DeepSeek; v14 ensures the substance lands). G1 (lepton scan) and
+G3 (discrete ω mechanism) both passed empirically via v8. G2 (neutral
+m_χ) is now GROUND-STATE-FOUND-PENDING-CALIBRATION-POINT awaiting
+Q45/Q46 reply.
+
+| Gate | Was (post-v8, 2026-05-21 PM) | Is (post-v9 phase 2 + v14, 2026-05-22 PM) |
+| --- | --- | --- |
+| G1 (lepton scan) | ✅ **PASSED via v8 step 4 — muon 0.80%, tau 6.47% gaps.** | ✅ Same — PASSED unchanged. |
+| G2 (neutral m_χ) | ⚠️ **PARTIAL via v8 step 5** — 448 IVP solutions, lightest at λ=1.0 = 0.998 MeV (windowed-integration value). | 🚧 **GROUND-STATE-FOUND-PENDING-CALIBRATION-POINT via v9 phase 2** — true nonlinear soliton with sign-changes=0 and clean K_1 decay. 1-parameter family in B0 ∈ [0.4, 0.6]. Definite (m_χ, m_J, C) awaiting Q45/Q46 reply. |
+| G3 (discrete ω) | ✅ **EMPIRICALLY VALIDATED via v8 step 4** — three lowest stable Q=1 modes = e/μ/τ. | ✅ Same — empirically validated unchanged. |
+
+**The v8 unlocking finding:** Sonnet's 2-function (α, β) reduction with
+vector cylindrical Laplacian + slope BCs bypasses the entire v4-v7
+mode-selector wall. The 4-function (V, A, Q, J) BVP work was solving a
+generalized system that admits excited modes the electron doesn't
+occupy. Different ansatz space, different field theory.
+
+**v8 documented findings:**
+
+| Finding | Implication |
+| --- | --- |
+| Sonnet's α,β cylindrical ≠ v1's α,γ spherical ≠ v9 §5.1 toroidal | Three genuinely different physics in numerical neighborhood ~1.69. v1's 1.6918 was coincidence. |
+| Tighter electron calibration at g=1.0000 (0.090% gap) | 6× tighter than Sonnet's reference g=1.0625. Offer for 9a. |
+| Lepton spectrum reproduces independently at PDG precision | Strong M6 validation result. |
+| Pion+ matches at 3.25% gap in lepton-targeted ansatz | Either model captures mesons or coincidence. Worth flagging. |
+| 2L/Q = 2.0 is algebraic identity (L = ω·Q_J by definition) | "g_e ≈ 2 reproduced" is artifact of definition, not derived prediction (Q38). |
+| Neutral chaoiton lightest at λ=1.0 is 0.998 MeV, not 0.508 | Line 235 "Griesi 2026, independent" attribution wrong on both counts (Q37). |
+
+### Post-v9 phase 2 unblock paths
+
+| Path | Trigger | Resolves |
+| --- | --- | --- |
+| A | Paul's Q45/Q46 reply (already asked via v14) | Definite (m_χ, m_J, C) extraction under chosen canonical point + geometry normalization. ApJ DM paper unblocked. |
+| B | Targeted extraction via `neutral_bvp_solver_mJ_free.py` g-scan or family-evaluation | Run on receipt of Q45 answer; ~1 hour. Hand off via GitHub URL per Publishing stance. |
+| C | Gelfand-Fomin conjugate-point stability check on v9 phase 2 ground state | Confirm ground-state vs excited at given B0. ~30 min. Already showed sign-changes=0 empirically on family. |
+
+Paul's DM paper submission is the live trigger for our involvement.
+Email v14 documents our position; awaiting Q45/Q46 reply. M5 foreground
+per cardinal rule. **OpenWave itself does NOT deposit M6 work** — the
+GitHub repo IS the deliverable; Paul's Ref [14] / [17] resolves to a
+stable repo URL. See `0b_M6_roadmap.md` Publishing stance.
 
 ---
 
@@ -185,55 +243,8 @@ These justify maintaining M6 as a sandbox/research track even if production is d
 | 2026-05-22 mid-morning | G2 | **GROUND STATE FOUND via `neutral_bvp_solver_mJ_free.py`.** Modified DeepSeek's template: proper l=1 origin BC (β ~ B0·r so β(R_MIN) = B0·R_MIN, β'(R_MIN) = B0) + B0 fixed + m_J as free eigenvalue. At g=1.0, B0=0.5: m_J=+0.5145, peak β=0.70 @ r=1.78, tail/peak=1.1×10⁻⁵, sign-changes=0. True nonlinear localized soliton. Continuous family in B0 ∈ [0.4, 0.6]; transition to excited branch (1 node, m_J<0) at B0 between 0.6 and 0.7. The 3D spherical l=1 cubic NLS IS subcritical (as DeepSeek predicted). |
 | 2026-05-22 mid-morning | NEW Q45 + Q46 | Q45 (canonical point): BVP gives 1-parameter family (B0 ↦ m_J); need extra constraint to pin THE canonical neutral chaoiton for DM paper. Three options: (a) match m_J to electron's λ=1; (b) pick lightest (B0=0.40, m_χ ≈ 0.866 MeV); (c) self-consistency with charged sector. Q46 (H/Q normalization): Sonnet's charged uses cylindrical r·dr; our neutral uses spherical r²·dr — does H/Q × m_e apply directly across geometries, or renormalization needed? |
 | 2026-05-22 mid-morning | EMAIL OUT v13 | Email v13 sent + committed + PR'd. Reports ground-state breakthrough + family characterization + asks Q45 (canonical point) + Q46 (H/Q normalization). |
-
----
-
-## Current status (2026-05-21 PM, post sandbox v8 — Q34 resolved, G1+G3 passed, G2 partial)
-
-Sandbox v8 received Sonnet's canonical `ouroboros_benchmark.py` script
-on 2026-05-21 PM. **5-step work program complete in one afternoon:**
-quick demo + electron sweep + paper-math + lepton spectrum + neutral
-chaoiton. G1 (lepton scan) and G3 (discrete ω mechanism) both passed
-empirically. G2 (neutral m_χ) partial pending Q37 attribution
-resolution.
-
-| Gate | Was (post-v7 wall, 2026-05-21 morning) | Is (post-v8, 2026-05-21 PM) |
-| --- | --- | --- |
-| G1 (lepton scan) | BLOCKED on v7 ground state. | ✅ **PASSED via v8 step 4 — muon 0.80%, tau 6.47% gaps.** |
-| G2 (neutral m_χ) | BLOCKED on v7 ground state. | ⚠️ **PARTIAL via v8 step 5 — 448 solutions, lightest at λ=1.0 is 0.998 MeV (NOT 0.508 MeV per Q37).** |
-| G3 (discrete ω) | BLOCKED on G1. | ✅ **EMPIRICALLY VALIDATED via v8 step 4** — three lowest stable Q=1 modes = e/μ/τ. |
-
-**The v8 unlocking finding:** Sonnet's 2-function (α, β) reduction with
-vector cylindrical Laplacian + slope BCs bypasses the entire v4-v7
-mode-selector wall. The 4-function (V, A, Q, J) BVP work was solving a
-generalized system that admits excited modes the electron doesn't
-occupy. Different ansatz space, different field theory.
-
-**v8 documented findings:**
-
-| Finding | Implication |
-| --- | --- |
-| Sonnet's α,β cylindrical ≠ v1's α,γ spherical ≠ v9 §5.1 toroidal | Three genuinely different physics in numerical neighborhood ~1.69. v1's 1.6918 was coincidence. |
-| Tighter electron calibration at g=1.0000 (0.090% gap) | 6× tighter than Sonnet's reference g=1.0625. Offer for 9a. |
-| Lepton spectrum reproduces independently at PDG precision | Strong M6 validation result. |
-| Pion+ matches at 3.25% gap in lepton-targeted ansatz | Either model captures mesons or coincidence. Worth flagging. |
-| 2L/Q = 2.0 is algebraic identity (L = ω·Q_J by definition) | "g_e ≈ 2 reproduced" is artifact of definition, not derived prediction (Q38). |
-| Neutral chaoiton lightest at λ=1.0 is 0.998 MeV, not 0.508 | Line 235 "Griesi 2026, independent" attribution wrong on both counts (Q37). |
-
-### Post-v8 unblock paths
-
-| Path | Trigger | Resolves |
-| --- | --- | --- |
-| A | Send email v10 (drafted) | Q36 reinforcement + Q37 provenance + Q38 identity. Cheapest. |
-| B | Run targeted Q_A≈0 sub-scan | Hand off specific (m_χ, m_J, σ/m) numbers per Paul's §9.1 Open Q#2 ask, IF Q37 reply confirms his 0.508 MeV is somewhere reproducible |
-| C | Gelfand-Fomin conjugate-point stability check on Sonnet's converged points | Confirm ground-state vs excited-state for the canonical 2-function reduction. ~30 min. |
-
-Paul's 9a Zenodo revision is the live trigger for our involvement. Email
-v10 documents our position; once sent, M6 work pauses pending Paul's
-reply and M5 foreground resumes per cardinal rule. **OpenWave itself
-does NOT deposit M6 work** — the GitHub repo IS the deliverable; Paul's
-Ref [14] / [17] resolves to a stable repo URL. See `0b_M6_roadmap.md`
-Publishing stance.
+| 2026-05-22 PM | REPLY (Paul, brief) | Paul replied to v13 thread but DID NOT forward v13's results to DeepSeek. His note quoted v13 in the body but the ask was about general arxiv-endorsement news ("top quant-ph contributor reached arxiv, 9b/9c approval probability up") + DeepSeek's note "send Rodrigo a short note reminding him of the neutral_bvp_solver.py script and asking for his results." → DeepSeek hadn't been shown v13's substance. Workflow blip, not a content concern. |
+| 2026-05-22 PM | EMAIL OUT v14 | Email v14 sent. v13 content resent verbatim + Acknowledgments-update ask bundled at the end (three-tier credit language: OpenWave Labs + Griesi + Anthropic Claude Code on Opus 4.7). Resend ensures DeepSeek sees the ground-state results; Acknowledgments-update ask lands while concrete contribution (BVP demonstration of neutral chaoiton ground state with clean K_1 decay) is fresh. Pending plan section in `0b_M6_roadmap.md` now marked SENT. |
 
 ---
 

--- a/openwave/xperiments/m6_ouroboros/research/0b_question_tracker.md
+++ b/openwave/xperiments/m6_ouroboros/research/0b_question_tracker.md
@@ -14,7 +14,7 @@ answered, or gets demoted.
 | `0b_M6_roadmap.md` | Sandbox sequence + current state + next steps |
 | `0c_sandbox_v*.md` | Per-iteration work log (the questions tracker here lives outside any single sandbox) |
 
-**Last updated:** 2026-05-22 mid-morning (post DeepSeek Q43+Q44 confirmation + neutral chaoiton GROUND STATE FOUND. DeepSeek confirmed Q43 (sign: `-m_J²β`) + Q44 (3D spherical l=1 p-wave). DeepSeek's verbatim template collapses to trivial (wrong l=1 BC); modified to proper l=1 + B0 fixed + m_J free eigenvalue → **true nonlinear soliton with sign-changes=0, tail/peak=10⁻⁵, clean K_1 decay**. 1-parameter family in B0 ∈ [0.4, 0.6]. Email v13 sent asking Q45 (canonical point in family) + Q46 (H/Q normalization across geometries)).
+**Last updated:** 2026-05-22 PM (post email v14 sent — v13 content resent verbatim + Acknowledgments-update ask bundled. Trigger: Paul's PM reply ack'd the arxiv quant-ph endorsement news but didn't forward v13's ground-state results to DeepSeek; v14 gives DeepSeek the substance AND lands the Acknowledgments wording in one shot. Q45/Q46 still IMMEDIATE; Acknowledgments-update ask now SENT — awaiting Paul + DeepSeek reaction in next DM paper revision. Earlier today: DeepSeek Q43+Q44 confirmation + neutral chaoiton GROUND STATE FOUND via `neutral_bvp_solver_mJ_free.py` — true nonlinear soliton with sign-changes=0, tail/peak=10⁻⁵, clean K_1 decay; 1-parameter family in B0 ∈ [0.4, 0.6]).
 
 ---
 
@@ -104,28 +104,31 @@ Q34=2-scalar)Q33 sign-pinning constraint vs continuation method
                  have similar quantum numbers (mass + zero charge).
                  Active light neutrinos remain unaccounted for.
 
-Total: 12 active questions (2 immediate Q41/Q42, 10 background).
+Total: 16 active questions (2 immediate Q45/Q46, 10 background, 4 resolved-this-session).
 
-Highest-leverage closure: Paul's reply on email v11 (DM path
-decision: caveat-as-is vs delay-for-BVP). If caveat-as-is: M6 v8
-work is functionally complete; M5 returns to foreground. If
-delay-for-BVP: 1-2 days of focused BVP-variant work to deliver
-clean ground-state m_χ + reliable C, then return to M5. M6 data
-drop is at github.com/openwave-labs/openwave (Reference [17] in
-9b paper; 9c retains it).
+Highest-leverage closure: Paul's reply on email v14 (Q45 canonical
+point in 1-parameter family + Q46 H/Q normalization across geometries
++ Acknowledgments-update ask bundled). Reply unlocks definite
+(m_χ, m_J, C) extraction for the DM paper via targeted run of
+`neutral_bvp_solver_mJ_free.py` (~1 hour). M6 v9 phase 2 is
+functionally complete; M5 returns to foreground per cardinal rule
+while we wait. M6 data drop is at github.com/openwave-labs/openwave
+(Reference [17] in 9c paper).
 ```
 
 ---
 
-## IMMEDIATE-QUESTIONS (post-9c — both new; in email v11)
+## IMMEDIATE-QUESTIONS (post-v9 phase 2 + email v14 — both new; in email v13/v14)
 
-Q36-Q40 all RESOLVED in 9c — see RESOLVED section below. Q41 and Q42
-surfaced from email v11 work today.
+Q36-Q40 all RESOLVED in 9c — see RESOLVED section below. Q41/Q42 RESOLVED
+this session — see RESOLVED section. Q43/Q44 RESOLVED 2026-05-22 ~9:53 AM
+by DeepSeek confirmation. Q45 and Q46 surfaced from v9 phase 2 ground-state
+discovery and are now the only IMMEDIATE items.
 
 | ID | Question | Surfaced | Why it matters |
 | --- | --- | --- | --- |
-| Q41 (NEW) | Paul asked *"I wonder whether your Claude does writing. Mine said it had a table to add to the universe paper... but timed out before it could show it to me!"* Should Claude Code on Opus 4.7 take on a full writing role like Sonnet 4.6 and DeepSeek do? Decision: **DECLINED** full writing role. Staying in numerical verification + edits + tables/data lane per cardinal-rule scope. Offered narrow help if Sonnet's table needs a numerical contribution. | Paul's reply 4:10 PM (2026-05-21) | Defines our scope of contribution to Paul's papers going forward. Cover-page byline + Acknowledgments + Reference [17] (GitHub repo) remain unchanged — we're listed as AI contributor for "sustained technical collaboration on the radial ODE implementation, the BVP/shooting formulations, and the manuscript review process." Writing role is the boundary we don't cross. |
-| Q42 (NEW) | Forward `solve_ivp` with slope BC β'(0)=B0 in Sonnet's canonical script does NOT yield a true localized neutral chaoiton. Inspection of β(r) at electron-calibrated (λ=1, g=1.0) with B0=0.05 shows internal sign changes at r=3.5 and r=7, plus growing oscillating tail past r~10. β/K_1(m_J·r) ratio grows 10 orders of magnitude in tail instead of staying constant — definitive evidence the tail is not pure Bessel decay. Consequences: m_χ via H/Q × m_e is window-dependent (r_max=12 → 0.998 MeV; r_max=30 → 1.040 MeV); K_1 far-field fit fails (rel_resid > 1 everywhere); C extraction from far-field amplitude unreliable. **The 9c-cited m_χ = 0.998 MeV at λ=1 is a windowed-integration value, not a true ground state.** Proper BVP with β(∞)=0 (or Robin-decay BC at R_max) needed for clean ground state. | v8 DM paper input extraction (2026-05-21 PM later) | Affects DM paper accuracy. Email v11 offers Paul two paths: (a) submit ApJ with "order-of-magnitude pending true ground state" caveat — faster; (b) delay submission while we build BVP variant — slower but cleaner ground-state m_χ + reliable C. Paul's call. |
+| Q45 (NEW) | The 3D spherical l=1 BVP (per Q43+Q44 confirmed) delivers a CONTINUOUS 1-parameter family of ground states parameterized by B0 ∈ [0.4, 0.6] with m_J ∈ [0.46, 0.56] (all sign-changes=0, clean K_1 decay). To extract definite (m_χ, m_J, C) for the DM paper, we need an additional constraint. Three options: (a) match m_J to electron-calibrated value m_J=1 (requires g-scan); (b) pick lightest (B0=0.40, m_χ ≈ 0.866 MeV); (c) self-consistency with charged sector. | v9 phase 2 ground state found (2026-05-22 mid-morning) | Gates the ApJ DM paper submission. Paul holds DM paper pending our (m_χ, m_J, C) deliverable. Once Paul picks the canonical point, the targeted extraction script runs in ~1 hour and delivers definite numbers. Sent in email v13 + v14. |
+| Q46 (NEW) | H/Q normalization across geometries. Sonnet's charged sector uses cylindrical r·dr; our neutral 3D spherical uses r²·dr. The H/Q × m_e mass formula was calibrated on charged cylindrical. Does it apply directly across geometries, or is there a renormalization factor between cylindrical-charged-electron and spherical-neutral-DM? | v9 phase 2 ground state found (2026-05-22 mid-morning) | Affects DM paper m_χ in MeV. If renormalization factor needed, the 0.866-MeV-or-similar numbers shift. Smaller question than Q45 but needed for clean physical-units handoff. Sent in email v13 + v14. |
 
 ---
 
@@ -203,19 +206,19 @@ None of these block SABER engineering trigger either.
 ## HARDEST-PIECES TRACKER
 
 Long-running status board for the structural challenges in the M6 model.
-Tracks how each piece moves across sandbox iterations. Updated 2026-05-21
-PM later (post 9c outcome + email v11 + Q41/Q42; all Q36-Q40 resolved
-in 9c).
+Tracks how each piece moves across sandbox iterations. Updated 2026-05-22
+PM (post v9 phase 2 ground state found + emails v13/v14 sent; Q43/Q44
+resolved by DeepSeek; Q45/Q46 NEW IMMEDIATE).
 
-### ACTIVE hardest pieces (5 — still in motion post-v8)
+### ACTIVE hardest pieces (5 — still in motion post-v9 phase 2)
 
-| Hardest piece | Status post-v6 (2026-05-20 evening) | Status post-v7 (2026-05-21 morning) | Status post-v8 step 5 (2026-05-21 PM) |
+| Hardest piece | Status post-v7 (2026-05-21 morning) | Status post-v8 step 5 (2026-05-21 PM) | Status post-v9 phase 2 (2026-05-22 PM) |
 | --- | --- | --- | --- |
-| Electron H/Q calibration | NEARLY CLOSED in 4-function. v6.6 H/Q=1.778 (4.8%); step (8) drop-quartic 1.7112 (0.84%). | v6.6 best 4-function result. v7 mode-selector wall. | ✅ **EFFECTIVELY ACHIEVED via Sonnet's canonical 2-function script.** Best calibration: g=1.0000, H/Q=1.6890, gap **0.090%** (v8 step 2). Sonnet's reference g=1.0625, gap 0.56%. v1's 1.6918 cited in v9 but Q36 caveat applies (different geometry, search-not-derivation). |
-| V(M) potential form | UNRESOLVED. Shared bottleneck with M5. | Unchanged. | Unchanged for M5 (separate track); for M6, Sonnet's script settles the canonical form for chaoiton dynamics. |
-| ω quantization mechanism | OPEN (Q2). | Unchanged. | ✅ **Empirically validated via v8 step 4** — three lowest stable Q=1 modes match e/μ/τ within 0.80%/6.47%. Analytic proof still deferred per Werbos's §9.1 Open Q#1. |
-| Neutral m_χ true ground state | BLOCKED on v6. | BLOCKED on v7 ground state. | ⚠️ **PARTIAL via v8 step 5** — 448 solutions across (g, λ, B0). Lightest at λ=1.0 = 0.998 MeV (NOT 0.508 MeV as line 235 claims). Mass scaling closer to m ≈ 2λ·m_e at small B0. v9 §9.1 Open Q#2 attribution provenance unresolved (Q37). |
-| Algebraic 2L/Q identity (Q38 NEW) | Not tracked. | Not tracked. | ⚠️ NEW OPEN. Sonnet's script defines L = ω·Q_J directly, so 2L/Q = 2ω is trivially exact. The "g_e ≈ 2 reproduced" calibration item is artifact of definition. Worth flagging to Paul for 9a unless v9 §9 separately derives L = ω·Q_J from dynamics. |
+| Electron H/Q calibration | v6.6 best 4-function result. v7 mode-selector wall. | ✅ **EFFECTIVELY ACHIEVED via Sonnet's canonical 2-function script.** Best calibration: g=1.0000, H/Q=1.6890, gap **0.090%** (v8 step 2). | ✅ Unchanged — Sonnet's 2-function reduction remains canonical for charged sector. |
+| V(M) potential form | Unchanged. | Unchanged for M5 (separate track); for M6, Sonnet's script settles the canonical form for chaoiton dynamics (charged). | ✅ Neutral sector settled too — 3D spherical l=1 p-wave ODE `β'' + (2/r)β' - (2/r²)β - m_J²β + 4gβ³ = 0`. |
+| ω quantization mechanism | Unchanged. | ✅ **Empirically validated via v8 step 4** — three lowest stable Q=1 modes match e/μ/τ within 0.80%/6.47%. Analytic proof still deferred. | ✅ Unchanged. |
+| Neutral m_χ true ground state | BLOCKED on v7 ground state. | ⚠️ **PARTIAL via v8 step 5** — 448 IVP solutions, lightest at λ=1.0 = 0.998 MeV (windowed-integration value, not true ground state per Q42). | 🚧 **GROUND-STATE-FOUND-PENDING-CALIBRATION-POINT** via `neutral_bvp_solver_mJ_free.py`. True nonlinear soliton: sign-changes=0, tail/peak=10⁻⁵, clean K_1 decay. 1-parameter family in B0 ∈ [0.4, 0.6] with m_J ∈ [0.46, 0.56]. Definite (m_χ, m_J, C) extraction awaiting Q45 (canonical point) + Q46 (H/Q normalization) reply via email v14. |
+| Algebraic 2L/Q identity (Q38) | Not tracked. | ⚠️ NEW OPEN. Sonnet's script defines L = ω·Q_J directly, so 2L/Q = 2ω is trivially exact. | ✅ RESOLVED in 9c §9 criterion 3 footnote: *"in our numerical implementation L=ωQ_J by construction"*. |
 
 ### RESOLVED hardest pieces (12 — closed post-v8; kept for traceability)
 
@@ -388,37 +391,51 @@ Active count post-9c + email v11 (entering Paul's reply):
 ## Highest-leverage closure path
 
 ```text
-Email v10 sent (Q36 reinforcement + Q37 0.508 MeV + Q38 identity)
+Email v13 + v14 sent (neutral chaoiton GROUND STATE FOUND + Q45/Q46
++ Acknowledgments-update ask bundled)
     ↓
-Paul's reply
+Paul's reply on Q45 + Q46 (via DeepSeek)
     ↓
-    ├── Confirms 9a will soften v1 citation + clarify 0.508 MeV
-    │       → Acknowledge, return fully to M5
-    │       → M6 v8 work documented as functionally complete
+    ├── (Q45a) "Match m_J to electron-calibrated λ=1"
+    │       → Run g-scan via neutral_bvp_solver_mJ_free.py until
+    │         m_J=1 lands at some (g, B0)
+    │       → Deliver definite (m_χ, m_J, C) under Q46 normalization
+    │       → Email v15 with deliverable
     │
-    ├── Asks us for specific (m_χ, m_J, σ/m) numbers for §9.1
-    │       → Run targeted Q_A≈0 sub-scan (~1 hour) on Sonnet's
-    │         canonical 2-function reduction
-    │       → Hand off via GitHub URL per Publishing stance
+    ├── (Q45b) "Pick lightest in family (B0=0.40, m_χ ≈ 0.866 MeV)"
+    │       → Report lightest directly with Q46-corrected normalization
+    │       → Email v15 with deliverable
     │
-    ├── Provides 0.508 MeV provenance — IS reproducible somewhere
-    │       → Verify the path; update Q37 status accordingly
+    ├── (Q45c) "Self-consistency with charged sector"
+    │       → Solve over-determined system: same (g, m_J) as charged,
+    │         find which B0 lands. ~few hours.
+    │       → Email v15 with deliverable
+    │
+    ├── (Q45d) Custom DeepSeek/Paul constraint
+    │       → Implement on receipt; deliver under specified constraint
     │
     └── No reply within 1-2 weeks
-            → M5 continues; email v10 documents our position;
+            → M5 continues; v14 already documents our position;
               no further escalation needed.
 
-Already completed via sandbox v8 (no further M6 work needed):
+Completed via v9 phase 2 (neutral chaoiton ground state):
+  - G2 GROUND-STATE-FOUND-PENDING-CALIBRATION-POINT via
+    neutral_bvp_solver_mJ_free.py: true nonlinear soliton, clean K_1
+    decay, 1-parameter family in B0 ∈ [0.4, 0.6]
+  - Q43 + Q44 resolved by DeepSeek 2026-05-22 ~9:53 AM
+
+Completed via sandbox v8 (already in 9c):
   - G1 lepton scan PASSED (v8 step 4): muon 0.80%, tau 6.47%
   - G3 discrete ω mechanism EMPIRICALLY VALIDATED (same)
-  - G2 neutral m_χ PARTIAL (v8 step 5): 448 solutions, lightest at
-    λ=1.0 = 0.998 MeV — provenance of Sonnet's 0.508 MeV attribution
-    is the only remaining Q37 question
+  - Q36-Q40 all 5 incorporated in 9c (single round-trip)
 
 M6 production decision (Taichi):
-  - Sonnet's canonical script gives reference ODE structure for port
+  - Sonnet's canonical script gives reference ODE for charged sector
+  - neutral_bvp_solver_mJ_free.py gives reference ODE for neutral
+    sector (3D spherical l=1 p-wave)
   - Decision still deferred per cardinal rule (M5 first)
 
 M5 returns as foreground engineering track per cardinal rule:
-  M5 is SABER's primary substrate. M6 v8 is functionally complete.
+  M5 is SABER's primary substrate. M6 v9 phase 2 is functionally
+  complete; awaiting Q45/Q46 reply for definite numbers handoff.
 ```


### PR DESCRIPTION
Update project documentation to reflect v9 phase-2 results and follow-up communication: mark the neutral chaoiton ground state as found (proper l=1 origin BC, B0 fixed, m_J free eigenvalue), note emails v13/v14 sent, and update gate/status tables and next-step instructions in 0b_M6_roadmap.md, 0b_model_gates.md, and 0b_question_tracker.md. Add references to the BVP solver `neutral_bvp_solver_mJ_free.py`, clarify that G2 is GROUND-STATE-FOUND-PENDING-CALIBRATION-POINT awaiting Q45/Q46, and reorganize the sandbox/phase history and immediate action items. Also tweak the blueprint colormap dark-blue entry (hex and RGB) in openwave/common/colormap.py.