### PR TITLE
Use direct index for menu selection

### DIFF
--- a/openwave/i_o/cli.py
+++ b/openwave/i_o/cli.py
@@ -225,9 +225,7 @@ def show_menu_interactive(experiments):
         print("Exiting...")
         sys.exit(0)
 
-    # Map from spaced menu index back to experiments index
-    experiment_idx = choice_idx // 2
-    return experiments[experiment_idx]
+    return experiments[choice_idx]
 
 
 def run_experiment(display_name, file_path):


### PR DESCRIPTION
Simplify show_menu_interactive by removing the spaced-index mapping (choice_idx // 2) and returning experiments[choice_idx] directly. This fixes incorrect experiment lookup caused by the previous integer-division mapping and simplifies the selection logic.