### PR TITLE
M5.3 closed, Update M5 roadmap/status; add M5.3 sandbox tests

### DIFF
--- a/openwave/xperiments/m5_liquid_crystal/research/0b_M5_roadmap.md
+++ b/openwave/xperiments/m5_liquid_crystal/research/0b_M5_roadmap.md
@@ -25,14 +25,14 @@ For design rationale, M2/M4 inheritance, code mapping, resolution & performance 
 
 - ✅ **M5.0 Scaffold** — all 11 sub-phases complete as of 2026-05-08
 - ✅ **M5.1 Port topology from Exps 2, 3** — 8 of 8 tasks complete as of 2026-05-11. 1/d Coulomb R² = 0.978 (attractive, monotone, threshold 0.95). Visual confirmation in [3a_coulomb_visual_geometry.md](3a_coulomb_visual_geometry.md)
-- ⚠️ **M5.2 V(ψ) escalation on Vector(3)** — **CLOSED as negative result (2026-05-12)**. Tested 4 V(ψ) recipes (V=0, KG, φ⁴ Mexican-hat, biharmonic); all collapse Q identically at step 4-5. Diagnosis: matrix substrate `M = ODO^T` + time-periodic resonance required (triple-confirmed: Duda paper Fig. 10, Close email, Werbos chaoiton paper). See [3b_lagrangian_roadblocks.md](3b_lagrangian_roadblocks.md)
-- 🔶 **M5.3 Direction review** (started 2026-05-12, substantially complete 2026-05-25). Two hard blockers CLEARED: substrate locked (full `M = ODO^T`, Q5) + Duda reply in (2026-05-14/15); the deep paper + slides reading is captured in [4a_convo_2026.05.12.md](4a_convo_2026.05.12.md), with every 4a input mapped to a phase (see M5.3 § deliverable table). Remaining: the Taichi feasibility spike (matrix ops + eigen-kernel + cost estimate) + optional resonance smoke test. Exit when the spike lands.
-- [ ] **M5.4 Matrix-field substrate migration**. Replace Vector(3) ψ with `M(x) = O(x) D O^T(x)` real symmetric 3×3 matrix field. Storage redesign in Taichi; matrix commutator + antisymmetric operators; reproduce M5.1 Coulomb on the new substrate. Lands deferred-from-M5.0g physical-energy scaling.
-- [ ] **M5.5 Paper Lagrangian + V(M)**. Implement Duda Eq. 18 action `L = Σ ‖F_μ0‖² − Σ ‖F_μν‖² − V(M)` with Eq. 13 Higgs-like `V_LG = a Tr(M²) − b Tr(M³) + c (Tr(M²))²`. Faber regularization integrated to activate V. Subsumes old "Skyrme stabilizer" phase since Eq. 42 4D Skyrme-like kinetic is the same family.
-- [ ] **M5.6 Biaxial twist + KG emergence**. With `Λ = (1, δ, 0)` and `δ ~ ℏ`, reproduce paper Fig. 9 — Klein-Gordon-like equation emerges automatically from twist dynamics (NOT added as V_psi term).
-- [ ] **M5.7 Resonance hunt (Close protocol)**. `l = 1` harmonic seed on biaxial substrate, sweep `A/λ ∈ {0.5, 1, 2}`, measure energy-localization lifetime. First metastable resonance — "first long-lived particle in M5". **UNBLOCKS 5b thermal work.** Literature anchor: BEC vortex kinetics (Duda 2026-05-13 cite, PRA `10.1103/2msv-lk1m`).
-- [ ] **M5.8 4D extension + Zitterbewegung clock** (GROUP HEADLINE — for Duda et al.). Add 0th time axis: `D = diag(g, 1, δ, 0)`, SO(1,3) Lorentz. Negative-energy contributions from spacetime signature auto-propel the clock (Fig. 10 mechanism). Measure de Broglie clock frequency `ω = 2mc²/ℏ` for electron — empirical answer to Duda's standing clock-propulsion question.
-- [ ] **M5.9 3 lepton families + Cornell quarks**. 3 axis-choices of biaxial hedgehog → same Q, different mass; tune `Λ` to match `μ/e ≈ 207`, `τ/e ≈ 3477`. Cornell potential for quark strings via topological vortex (`V(r) = −α/r + σ·r`). Standard Model correspondence section of paper confirmed.
+- ❌ **M5.2 V(ψ) escalation on Vector(3)** — **CLOSED as negative result (2026-05-12)**. Tested 4 V(ψ) recipes (V=0, KG, φ⁴ Mexican-hat, biharmonic); all collapse Q identically at step 4-5. Diagnosis: matrix substrate `M = ODO^T` + time-periodic resonance required (triple-confirmed: Duda paper Fig. 10, Close email, Werbos chaoiton paper). See [3b_lagrangian_roadblocks.md](3b_lagrangian_roadblocks.md)
+- ✅ **M5.3 Direction review** (2026-05-12 → COMPLETE 2026-05-26). Substrate locked (full `M = ODO^T`, Q5); Duda reply in (2026-05-14/15); paper + slides digested ([4a_convo_2026.05.12.md](4a_convo_2026.05.12.md)) with every input mapped to a phase; thermal prerequisites confirmed; resonance smoke test NULL; **feasibility spike PASSED** (`ti.Matrix.field` + commutator + `ti.sym_eig` all work in-kernel on Metal, verified, ~1–2× Vector(3) cost). **Decision: in-place migration → M5.4 unblocked.**
+- 🔶 **M5.4 Matrix-field substrate migration**. Replace Vector(3) ψ with `M(x) = O(x) D O^T(x)` real symmetric 3×3 matrix field. Storage redesign in Taichi; matrix commutator + antisymmetric operators; reproduce M5.1 Coulomb on the new substrate. Lands deferred-from-M5.0g physical-energy scaling.
+- 🚧 **M5.5 Paper Lagrangian + V(M)**. Implement Duda Eq. 18 action `L = Σ ‖F_μ0‖² − Σ ‖F_μν‖² − V(M)` with Eq. 13 Higgs-like `V_LG = a Tr(M²) − b Tr(M³) + c (Tr(M²))²`. Faber regularization integrated to activate V. Subsumes old "Skyrme stabilizer" phase since Eq. 42 4D Skyrme-like kinetic is the same family.
+- 🚧 **M5.6 Biaxial twist + KG emergence**. With `Λ = (1, δ, 0)` and `δ ~ ℏ`, reproduce paper Fig. 9 — Klein-Gordon-like equation emerges automatically from twist dynamics (NOT added as V_psi term).
+- 🚧 **M5.7 Resonance hunt (Close protocol)**. `l = 1` harmonic seed on biaxial substrate, sweep `A/λ ∈ {0.5, 1, 2}`, measure energy-localization lifetime. First metastable resonance — "first long-lived particle in M5". **UNBLOCKS 5b thermal work.** Literature anchor: BEC vortex kinetics (Duda 2026-05-13 cite, PRA `10.1103/2msv-lk1m`).
+- 🚧 **M5.8 4D extension + Zitterbewegung clock** (GROUP HEADLINE — for Duda et al.). Add 0th time axis: `D = diag(g, 1, δ, 0)`, SO(1,3) Lorentz. Negative-energy contributions from spacetime signature auto-propel the clock (Fig. 10 mechanism). Measure de Broglie clock frequency `ω = 2mc²/ℏ` for electron — empirical answer to Duda's standing clock-propulsion question.
+- 🚧 **M5.9 3 lepton families + Cornell quarks**. 3 axis-choices of biaxial hedgehog → same Q, different mass; tune `Λ` to match `μ/e ≈ 207`, `τ/e ≈ 3477`. Cornell potential for quark strings via topological vortex (`V(r) = −α/r + σ·r`). Standard Model correspondence section of paper confirmed.
 
 ### Parallel research stages
 
@@ -47,7 +47,7 @@ Forward-looking research programs in their own files — run alongside / after t
 
 ## DETAILED
 
-### Phase M5.0 — Scaffold
+### ✅ Phase M5.0 — Scaffold
 
 Broken into nine sub-phases (M5.0a → M5.0i) so each lands as a tight, separately-committable unit with its own test gate before progressing.
 
@@ -158,7 +158,7 @@ This sub-phase was originally scoped as "add kernel-internal natural-unit scalin
 
 - 🚧 **Re-profile trigger**: when M5.2's V(ψ) (Klein-Gordon mass + Close Eq. 23 + LdG potential) lands and per-step time grows. If 384³ drops below 20 fps, decide between (1) rotating-pointer refactor for ~35 % win, (2) full fusion for ~50 % win + M2-equivalent step time, (3) BlockLocal Laplacian / dirty-tile mask. The M5.0i baseline numbers above are the comparison reference.
 
-### Phase M5.1 — Port topology (from Exps 2, 3)
+### ✅ Phase M5.1 — Port topology (from Exps 2, 3)
 
 - ✅ `seed_vacuum()` — fills psi_am, psi_prev_am, AND psi_new_am with `n = ẑ` everywhere (writes all three buffers per `feedback_triple_buffer_bc.md` — required for fixed-value Dirichlet BC at vacuum)
 - ✅ `seed_hedgehog(centers, signs, D/4, n_defects)` — N-defect kernel, port of Exp 2's weighted superposition + renormalization (`sandbox_phase3_lagrangian/exp2_hedgehog_energy.py:71-108`). Radial structure concentrated within ~D/4 via `w_vac = 1/(1 + (r/(D/4))⁴)`, smoothly blends to `n = ẑ` at boundary. Multi-defect API supports M5.4 pair tests directly (no kernel refactor needed)
@@ -175,7 +175,7 @@ This sub-phase was originally scoped as "add kernel-internal natural-unit scalin
 >
 > **Frank elastic energy is a measurement, not a dynamics** (same review): the elastic behavior is *already* in the wave equation — the `c²·∇²ψ` term IS the gradient of the Frank density `(K/2)|∇n|²`. Computing the Frank energy as an explicit kernel (task 5) doesn't add new physics; it provides the scalar `E(t)` needed for the downstream tests that *depend on having an E to fit*: task 6 needs `E` falling monotonically as a convergence diagnostic; task 7 needs `E(d)` as a function of pair separation to fit the 1/d Coulomb law; future visualization can colormap the per-voxel elastic density. Parallel to how `compute_energyH_density` (M5.0g) is the measurement scalar that goes with the wave dynamics — same logic, different formula component.
 
-### Phase M5.2 — V(ψ) escalation on Vector(3) — CLOSED as informative negative (2026-05-12)
+### ❌ Phase M5.2 — V(ψ) escalation on Vector(3) — CLOSED as informative negative (2026-05-12)
 
 > **Status**: closed. The four V(ψ) escalations we tested (V=0, KG mass `½m²|ψ|²`, φ⁴ Mexican-hat `¼λ(|ψ|²−1)²`, biharmonic `½κ|∇²ψ|²`) all collapse the topological charge Q identically within 4-5 propagation steps. The result is documented as an informative negative; phase moves out of the critical path. Path forward absorbed into M5.3 (direction review) + M5.4 (matrix-field substrate) + M5.5 (paper Lagrangian).
 >
@@ -195,19 +195,19 @@ This sub-phase was originally scoped as "add kernel-internal natural-unit scalin
 
 ---
 
-### Phase M5.3 — Direction review (active 2026-05-12+) 🔶
+### ✅ Phase M5.3 — Direction review (2026-05-12 → COMPLETE 2026-05-26)
 
-> Study, sandbox, decide, wait. Goal: lock the M5.4 implementation plan with a clear substrate choice before code commitment. **Status (2026-05-25): the two hard blockers are CLEARED** — substrate decision locked (full 3×3 `M = ODO^T`, Q5) and Duda's reply is in (2026-05-14/15). The deep paper + slides reading is done and captured in [`4a_convo_2026.05.12.md`](4a_convo_2026.05.12.md). Remaining before M5.4: the Taichi feasibility spike (which also yields the storage cost estimate) and the optional resonance smoke test.
+> Study, sandbox, decide, wait. Goal: lock the M5.4 implementation plan with a clear substrate choice before code commitment. **COMPLETE (2026-05-26): all legs met — M5.4 is unblocked.** Substrate locked (full 3×3 `M = ODO^T`, Q5); Duda's reply in (2026-05-14/15); paper + slides digested ([`4a_convo_2026.05.12.md`](4a_convo_2026.05.12.md)); thermal prerequisites confirmed; resonance smoke test NULL (no Vector(3) resonance); **feasibility spike PASSED** — `ti.Matrix.field(3,3)` storage + matrix commutator + `ti.sym_eig` eigen-decomposition all work in-kernel on Metal, verified, at ~1–2× the Vector(3) Laplacian cost. **Decision: in-place migration.**
 
 - ✅ **Re-read Duda paper §III-V deeply** — DONE. The annotated reading lives in [`4a_convo_2026.05.12.md`](4a_convo_2026.05.12.md): matrix structure (§3–5), eigenvalue→force map (§8), KG-from-hedgehog closed form + clock toy-model numerics (§11), force unification (§7), the 51-page LdGS slides (§11), and the Couder/walking-droplet deck (§11b). Supersedes the planned `3h_*.md`.
 - ✅ **Wait for Duda reply** — DONE. Duda replied 2026-05-14/15 (`4a §1`); **substrate gate CLOSED** (full M, no Q-tensor pivot — Q5); eigenvalue→physics mapping confirmed (Q6).
-- 🔶 **Taichi storage layout study** — PARTIAL. Recommendation locked in `4a §10`: `ti.Matrix.field` with index-generic operators (makes the 3×3→4×4 M5.8 promotion a type change, not a rewrite). Outstanding: the measured cost estimate at 65³ / 128³ / 256³ — produced by the feasibility spike below.
-- 🔶 **Thermal prerequisites analysis** — PARTIAL. Covered conceptually (`4a §7` force map + [`5b_thermal_energy.md`](5b_thermal_energy.md)): 5b needs M5.7 (metastable resonance) plus the drive/measurement infra that lands inside M5.7. SABER-specific scope items stay in the private repo.
-- 🔶 **Decision document** — SUBSTANTIALLY DONE. `4a_convo` carries the decision substance (substrate locked; refactor strategy §10); the M5.4+ task breakdown lives in the M5.4 phase below + [`4b_rendering_features.md`](4b_rendering_features.md); the 4a-inputs→phase mapping is the table below. Formal cost-estimate finalization pends the spike. (A standalone `3h_m5_substrate_decision.md` is superseded by 4a + this roadmap.)
-- [ ] **Feasibility spike: matrix field in Taichi** — **THE NEXT M5.3 TASK.** Minimal `M(x) = O(x) D O^T(x)` storage + matrix commutator `[M_μ, M_ν]` **+ the eigen-decomposition `@ti.func`** (`M → director_nhat + eigenvalues`). The eigen-kernel is the one genuinely new primitive the entire rendering stack + redefined amp/freq trackers depend on (see [4b_rendering_features.md](4b_rendering_features.md)), so proving it here de-risks physics operators AND visualization in one spike. Verify all three against analytic small-cases; measure cost vs Vector(3) (→ the storage cost estimate). Decide in-place migration vs parallel-track.
-- [ ] **Sandbox: Close's resonance protocol on existing Vector(3)** — OPTIONAL, not gating. `research/scripts/m5_3_resonance_smoke.py`. l=1 harmonic seed at A/λ ∈ {0.5, 1, 2}; measure energy-localization lifetime. Informative — if even Vector(3) shows extended lifetime at specific amplitudes, the resonance mechanism is substrate-agnostic.
+- ✅ **Taichi storage layout study** — DONE (2026-05-26). Layout = `ti.Matrix.field(3,3)` with index-generic operators (3×3→4×4 M5.8 promotion stays a type change). **Measured cost** (spike, vs Vector(3) 6-point Laplacian baseline): matrix `[∂M,∂M]` commutator ~1× and per-voxel `sym_eig` eigen-extraction ~1.1× at 256³ (2.2× at 128³) — eigen is **not** a bottleneck (it runs once/frame for render + trackers, not in the inner loop). **Memory**: production should store the **6** independent symmetric components/voxel (not the full 9), vs 3 for Vector(3) → ~2× memory. Cost is acceptable; no sparse/AMR needed for M5.4.
+- ✅ **Thermal prerequisites analysis** — DONE (2026-05-26). Confirmed: 5b's foundation is **M5.7 (first metastable resonance)** — sufficient, nothing extra must land earlier. The prerequisite chain is already correctly slotted across the M5.x phases: **measurement infra lands EARLY** (the redefined `A = ‖M−D‖_F` amplitude + `ω = O(x) clock-rate` frequency trackers in M5.4); the **KG drive substrate** in M5.6; the **drive infra** (parameterized harmonic forcing + FM/AM modulation primitives) in M5.7's own task list. So 5b.1 *internal* validation unblocks the moment M5.7 lands (per the two-tier table in [`5b_thermal_energy.md`](5b_thermal_energy.md)); full *lab-relevance* follows Phase 4 (EM emergence). SABER-specific engineering scope stays in the private repo per the cardinal rule. **No new early infrastructure required.**
+- ✅ **Decision document** — DONE (2026-05-26). Decision: **in-place migration** (not parallel-track) — the spike proved storage + operators + eigen all work at acceptable cost on the existing grid/engine architecture. Substance is distributed: substrate + refactor strategy in `4a §2,§10`; M5.4+ task breakdown in the M5.4 phase below + [`4b_rendering_features.md`](4b_rendering_features.md); cost estimate in the storage-layout task above; 4a-inputs→phase mapping in the table below. (A standalone `3h_m5_substrate_decision.md` is superseded by 4a + this roadmap.)
+- ✅ **Feasibility spike: matrix field in Taichi** — DONE (2026-05-26), PASSED. `research/sandbox_v2/m5_3_matrix_feasibility.py`. All three primitives proven in-kernel on Metal and verified against analytic cases: **storage** (`ti.Matrix.field(3,3)` round-trip 0 err); **commutator** `[A,B]` (0 err vs hand-computed; + `[∂_xM,∂_yM]` over a field); **eigen-decomposition** via **`ti.sym_eig`** (recovers a known `O·diag(2,1,0.5)·O^T` to ~1e-7; recovers a seeded hedgehog director at mean `|n̂·n|=0.9995`). **Key de-risk: `ti.sym_eig` works in-kernel on Metal for 3×3 — no custom analytic eigensolver needed.** Cost ~1–2× Vector(3) (see storage-layout task). Decision: in-place migration; M5.4 unblocked.
+- ✅ **Sandbox: Close's resonance protocol on existing Vector(3)** — DONE (2026-05-26), NULL result. `research/sandbox_v2/m5_3_resonance_smoke.py`: l=1 dipole packet swept at A/λ ∈ {0.5, 1, 2}, energy-localization lifetime under V=0 / KG-mass / φ⁴. **No substrate-agnostic resonance found.** Linear potentials (V=0, KG mass) disperse at ~40 steps **amplitude-independently** (as a linear PDE must — no amplitude-selected resonance); the only nonlinear potential available (φ⁴ Mexican-hat) is director-scaled (vacuum |ψ|=1) and **diverges** on a displacement-wave amplitude sweep — Vector(3)'s potential toolkit can't even host the test. Reinforces the M5.2 closed-negative: the metastable-resonance hunt belongs on the matrix substrate (M5.4 → M5.7) with LdG V(M)/Skyrme + 4D clock propulsion, not Vector(3).
 
-**Exit criterion**: substrate decision locked ✅ + Duda reply in ✅ + feasibility spike done (cost estimate + eigen-kernel proven). Two of three met; the spike is the remaining gate before M5.4 plan is fully concrete.
+**Exit criterion** — ✅ **MET (2026-05-26)**: substrate decision locked ✅ + Duda reply in ✅ + feasibility spike done (cost estimate measured + commutator & `sym_eig` eigen-kernel proven in-kernel) ✅. M5.4 plan is fully concrete; **M5.3 closes, M5.4 begins.**
 
 #### M5.3 deliverable — every 4a input mapped to a phase
 
@@ -235,7 +235,7 @@ The paper/slides reading task produces this assignment table — confirmation th
 
 ---
 
-### Phase M5.4 — Matrix-field substrate migration
+### 🔶 Phase M5.4 — Matrix-field substrate migration
 
 > Replace Vector(3) ψ with the paper's `M(x) = O(x) D O^T(x)` real symmetric 3×3 matrix field. The architectural shift identified in M5.3.
 
@@ -251,7 +251,7 @@ The paper/slides reading task produces this assignment table — confirmation th
 
 ---
 
-### Phase M5.5 — Paper Lagrangian + Higgs-like V(M)
+### 🚧 Phase M5.5 — Paper Lagrangian + Higgs-like V(M)
 
 > Implement Duda paper Eq. 18: `L = Σ ‖F_μ0‖²_F − Σ ‖F_μν‖²_F − V(M)`. Subsumes the old "Skyrme stabilizer" phase since the Eq. 42 4D Skyrme-like kinetic is part of the same Lagrangian family — there is no separate Skyrme add-on phase in the new structure.
 
@@ -265,7 +265,7 @@ The paper/slides reading task produces this assignment table — confirmation th
 
 ---
 
-### Phase M5.6 — Biaxial twist + KG emergence
+### 🚧 Phase M5.6 — Biaxial twist + KG emergence
 
 > With biaxial axes `Λ = (1, δ, 0)` and `δ ~ ℏ` (small twist), reproduce paper Fig. 9: Klein-Gordon-like equation emerges automatically from twist dynamics, NOT as an added V_psi term. This was the conceptual error in M5.2 Step 2.
 
@@ -278,7 +278,7 @@ The paper/slides reading task produces this assignment table — confirmation th
 
 ---
 
-### Phase M5.7 — Resonance hunt (Close's protocol) — UNBLOCKS 5b
+### 🚧 Phase M5.7 — Resonance hunt (Close's protocol) — UNBLOCKS 5b
 
 > **Refinement from Robert Close (2026-04 email reply)**: "Even including the nonlinear term, I would expect your result of dispersing waves in most cases. But I suspect that certain amplitudes of certain harmonic waves will keep energy localized longer (i.e. as an unstable particle or resonance). My suggestion is to explore a wide range of amplitudes (probably l=1 harmonic wave is the most interesting). A likely criterion is that the maximum displacements should be comparable to the wavelength (or half or twice). Unless you have a good way to model an infinite system, I doubt that you will find completely stable non-radiating solutions."
 >
@@ -293,7 +293,7 @@ The paper/slides reading task produces this assignment table — confirmation th
 
 ---
 
-### Phase M5.8 — 4D extension + Zitterbewegung clock (GROUP HEADLINE)
+### 🚧 Phase M5.8 — 4D extension + Zitterbewegung clock (GROUP HEADLINE)
 
 > **GROUP HEADLINE**: M5.8 passing IS the empirical answer to Duda's standing clock-propulsion question. External-comms framing: "M5.8 complete — Zitterbewegung clock at ω = 2mc²/ℏ confirmed empirically." This is the load-bearing test of clock propulsion (per `project_clock_propulsion` memory).
 >
@@ -330,7 +330,7 @@ The paper/slides reading task produces this assignment table — confirmation th
 
 ---
 
-### Phase M5.9 — 3 lepton families + Cornell quark strings
+### 🚧 Phase M5.9 — 3 lepton families + Cornell quark strings
 
 > Standard Model correspondence. The biaxial Λ = (g, 1, δ, 0) gives 3 axis-choices → 3 lepton families with the same Q but different masses (e/μ/τ). Cornell potential for quark strings via topological vortex.
 

--- a/openwave/xperiments/m5_liquid_crystal/research/0b_question_tracker.md
+++ b/openwave/xperiments/m5_liquid_crystal/research/0b_question_tracker.md
@@ -11,7 +11,7 @@
 | [`4a_convo_2026.05.12.md`](4a_convo_2026.05.12.md) | Duda thread study — substrate decision, eigenvalue map, slides |
 | [`1a_lagrangian_framework.md`](1a_lagrangian_framework.md) | Framework + the full email thread history |
 
-**Last updated:** 2026-05-25 (M5 restart, M6 closed). Substrate-gating question CLOSED (full 3×3 `M = ODO^T`, confirmed by Duda 2026-05-15). M5.3 direction review wrapping; M5.4 matrix-field migration is next. Nothing blocks M5.4 (substrate decision is locked + mechanical). First question that gates forward progress is Q7 (exact V(M) form) at M5.5. **Added this session:** hardest-pieces status board + Duda's stated limitations + M6 → M5 cross-pollination (the closed M6 sandbox's transferable methodology for M5's V(M) search). **Q12 added** (Bell / Kochen-Specker vs M5's definite-orientation defect) from the 2026-05 group threads — foundational note lives in `1b § Foundational stance`.
+**Last updated:** 2026-05-26 (M5.3 COMPLETE — M5.4 active). Substrate-gating question CLOSED (full 3×3 `M = ODO^T`, Duda 2026-05-15); M5.3 feasibility spike PASSED (matrix storage + commutator + `ti.sym_eig` eigen all work in-kernel on Metal, ~1–2× Vector(3) cost) → in-place migration; resonance smoke test NULL; thermal prerequisites confirmed. **M5.4 matrix-field migration is now the active phase.** First *question* that gates forward progress is Q7 (exact V(M) form) at M5.5. **Added this session:** hardest-pieces status board + Duda's stated limitations + M6 → M5 cross-pollination (the closed M6 sandbox's transferable methodology for M5's V(M) search). **Q12 added** (Bell / Kochen-Specker vs M5's definite-orientation defect) from the 2026-05 group threads — foundational note lives in `1b § Foundational stance`.
 
 ---
 
@@ -80,7 +80,7 @@ The long-running hardest-pieces tracker for M5 (mirrors M6's). These are the loa
 
 | Hardest piece | Gates | Status (2026-05-25) | M6 lend? |
 | --- | --- | --- | --- |
-| Matrix substrate migration (Vector(3) ψ → `M = ODO^T`) | M5.4 | 🚧 Green-lit, mechanical, next. Substrate locked (Q5). | — |
+| Matrix substrate migration (Vector(3) ψ → `M = ODO^T`) | M5.4 | 🚧 **De-risked + active.** M5.3 spike (2026-05-26) PASSED: `ti.Matrix.field(3,3)` storage + commutator + `ti.sym_eig` eigen all work in-kernel on Metal (verified), ~1–2× Vector(3) cost. Decision: in-place migration. | — |
 | **V(M) potential form** (Duda's #1 limitation, Q7) | M5.5 | OPEN — the central unknown. Start from Eq.13 LdG + Eq.12 eigenvalue-preference. | ✅ strong (see below) |
 | Regularization (Faber) to activate V(M) + running coupling (Duda #2, Q8) | M5.5 / M5.6 | OPEN — "the hardest part" per Duda. Port + adapt Faber. | 🔶 partial |
 | First metastable resonance (no static soliton) | M5.7 | Design locked (time-periodic per Close); awaiting M5.4–M5.6. | ✅ strong |

--- a/openwave/xperiments/m5_liquid_crystal/research/sandbox_v2/m5_3_matrix_feasibility.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/sandbox_v2/m5_3_matrix_feasibility.py
@@ -1,0 +1,284 @@
+"""
+M5.3 — Matrix-field feasibility spike (the gating M5.3 task; headless)
+
+De-risks the M5.4 substrate migration BEFORE touching the production engine.
+Proves three things in Taichi on a `ti.Matrix.field(3, 3)` storing the paper's
+M = O·D·O^T (Landau-de Gennes order parameter), and measures their cost vs the
+current Vector(3) substrate:
+
+  1. STORAGE      — ti.Matrix.field(3,3) round-trips and seeds from numpy.
+  2. COMMUTATOR   — [A, B] = A·B − B·A, the building block of the paper's
+                    antisymmetric A_μ = [M, ∂_μM] (Eq.19) and curvature F_μν.
+                    Verified against a hand-computed analytic case + the
+                    spatial-derivative commutator [∂_xM, ∂_yM] over a field.
+  3. EIGEN-DECOMP — ti.sym_eig(M) → eigenvalues + principal eigenvector
+                    (`director_nhat`). The lynchpin the whole rendering stack +
+                    redefined amp/freq trackers depend on (4b_rendering_features).
+                    Verified: recovers a known O·D·O^T, and recovers the seeded
+                    hedgehog director from a uniaxial M field.
+
+Then a COST BENCHMARK (matrix commutator + eigen vs Vector(3) Laplacian, at
+65³/128³/256³) → the storage cost estimate that closes M5.3 tasks 3 + 5, and
+the in-place-vs-parallel-track decision.
+
+Finding (pre-run): ti.sym_eig works in-kernel on Metal for 3×3 (probed
+2026-05-26) — no custom analytic eigensolver required.
+
+USAGE:
+    python -m openwave.xperiments.m5_liquid_crystal.research.sandbox_v2.m5_3_matrix_feasibility
+"""
+
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import taichi as ti
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+ti.init(arch=ti.gpu, default_fp=ti.f32)
+
+DELTA = 0.5  # biaxial-ish minor axis (placeholder; real δ~ℏ lands in M5.6)
+
+
+# ================================================================
+# CORE @ti.func PRIMITIVES (the M5.4 candidates)
+# ================================================================
+@ti.func
+def commutator(A, B):
+    """Matrix commutator [A, B] = A·B − B·A."""
+    return A @ B - B @ A
+
+
+@ti.func
+def principal_director(M):
+    """M (3×3 symmetric) → (principal eigenvector n̂, eigenvalues).
+
+    Principal = eigenvector of the largest eigenvalue. ti.sym_eig returns
+    eigenvectors as COLUMNS (eigenvectors[:, i] ↔ eigenvalues[i]).
+    """
+    evals, evecs = ti.sym_eig(M)
+    imax = 0
+    if evals[1] > evals[imax]:
+        imax = 1
+    if evals[2] > evals[imax]:
+        imax = 2
+    n = ti.Vector([evecs[0, imax], evecs[1, imax], evecs[2, imax]])
+    return n, evals
+
+
+# ================================================================
+# VERIFICATION KERNELS (analytic small-cases)
+# ================================================================
+@ti.kernel
+def verify_commutator() -> ti.f32:
+    """[A,B] for A=E01, B=E10 → expect diag(1,-1,0). Return max abs error."""
+    A = ti.Matrix([[0.0, 1.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+    B = ti.Matrix([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+    C = commutator(A, B)
+    expected = ti.Matrix([[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 0.0]])
+    err = 0.0
+    for i, j in ti.static(ti.ndrange(3, 3)):
+        err = ti.max(err, ti.abs(C[i, j] - expected[i, j]))
+    return err
+
+
+@ti.kernel
+def verify_eigen(M: ti.types.matrix(3, 3, ti.f32), n_true: ti.types.vector(3, ti.f32),
+                 lam_max_true: ti.f32) -> ti.types.vector(2, ti.f32):
+    """Returns (eigenvalue error vs lam_max_true, 1−|n̂·n_true|)."""
+    n, evals = principal_director(M)
+    lam_max = ti.max(evals[0], ti.max(evals[1], evals[2]))
+    val_err = ti.abs(lam_max - lam_max_true)
+    dir_err = 1.0 - ti.abs(n.dot(n_true))  # 0 if n̂ ∥ ±n_true (nematic apolar)
+    return ti.Vector([val_err, dir_err])
+
+
+# ================================================================
+# FIELD KERNELS (operate over the whole grid — the M5.4 production shape)
+# ================================================================
+@ti.kernel
+def extract_directors(M: ti.template(), out: ti.template()):
+    """Per-voxel principal eigenvector → director field (the render/tracker lynchpin)."""
+    for i, j, k in M:
+        n, _ = principal_director(M[i, j, k])
+        out[i, j, k] = n
+
+
+@ti.kernel
+def deriv_commutator_norm(M: ti.template(), out: ti.template(), inv_2dx: ti.f32):
+    """[∂_xM, ∂_yM] per interior voxel → store its Frobenius norm (curvature proxy)."""
+    nx, ny, nz = M.shape
+    for i, j, k in M:
+        if 0 < i < nx - 1 and 0 < j < ny - 1 and 0 < k < nz - 1:
+            dMx = (M[i + 1, j, k] - M[i - 1, j, k]) * inv_2dx
+            dMy = (M[i, j + 1, k] - M[i, j - 1, k]) * inv_2dx
+            C = commutator(dMx, dMy)
+            fro = 0.0
+            for a, b in ti.static(ti.ndrange(3, 3)):
+                fro += C[a, b] * C[a, b]
+            out[i, j, k] = ti.sqrt(fro)
+        else:
+            out[i, j, k] = 0.0
+
+
+@ti.kernel
+def vector_laplacian_bench(psi: ti.template(), out: ti.template()):
+    """Vector(3) 6-point Laplacian — the cost baseline (matches engine2_pde)."""
+    nx, ny, nz = psi.shape
+    for i, j, k in psi:
+        if 0 < i < nx - 1 and 0 < j < ny - 1 and 0 < k < nz - 1:
+            out[i, j, k] = (
+                psi[i + 1, j, k] + psi[i - 1, j, k]
+                + psi[i, j + 1, k] + psi[i, j - 1, k]
+                + psi[i, j, k + 1] + psi[i, j, k - 1]
+                - 6.0 * psi[i, j, k]
+            )
+
+
+# ================================================================
+# NUMPY HELPERS
+# ================================================================
+def rotation_zyz(a, b, c):
+    """A generic 3D rotation (ZYZ Euler) for building a known O."""
+    ca, sa, cb, sb, cc, sc = (np.cos(a), np.sin(a), np.cos(b),
+                              np.sin(b), np.cos(c), np.sin(c))
+    Rz1 = np.array([[ca, -sa, 0], [sa, ca, 0], [0, 0, 1.0]])
+    Ry = np.array([[cb, 0, sb], [0, 1.0, 0], [-sb, 0, cb]])
+    Rz2 = np.array([[cc, -sc, 0], [sc, cc, 0], [0, 0, 1.0]])
+    return Rz1 @ Ry @ Rz2
+
+
+def seed_uniaxial_hedgehog_M(nx, ny, nz, delta):
+    """M(x) = δ·I + (1−δ)·(n̂⊗n̂) with n̂ a radial hedgehog (vacuum ẑ blend).
+
+    Eigenvalue 1 along n̂ (principal), δ perpendicular → principal director = n̂.
+    Returns (M_array (nx,ny,nz,3,3), n_array (nx,ny,nz,3)).
+    """
+    cx, cy, cz = nx / 2.0, ny / 2.0, nz / 2.0
+    ii, jj, kk = np.meshgrid(np.arange(nx), np.arange(ny), np.arange(nz), indexing="ij")
+    rx, ry, rz = ii - cx, jj - cy, kk - cz
+    r = np.sqrt(rx**2 + ry**2 + rz**2) + 1e-9
+    # radial director, blended to ẑ vacuum far out (matches seed_hedgehog spirit)
+    D_quarter = 0.25 * max(nx, ny, nz)
+    w = 1.0 / (1.0 + (r / D_quarter) ** 4)
+    n = np.stack([rx / r, ry / r, rz / r], axis=-1)
+    zhat = np.zeros_like(n)
+    zhat[..., 2] = 1.0
+    n = w[..., None] * n + (1.0 - w[..., None]) * zhat
+    n /= (np.linalg.norm(n, axis=-1, keepdims=True) + 1e-12)
+    nn = n[..., :, None] * n[..., None, :]  # outer product n⊗n
+    eye = np.eye(3)[None, None, None, :, :]
+    M = delta * eye + (1.0 - delta) * nn
+    return M.astype(np.float32), n.astype(np.float32)
+
+
+def time_kernel(fn, *args, repeats=5):
+    fn(*args)  # warm-up (compile)
+    ti.sync()
+    t0 = time.perf_counter()
+    for _ in range(repeats):
+        fn(*args)
+    ti.sync()
+    return (time.perf_counter() - t0) / repeats * 1e3  # ms/pass
+
+
+# ================================================================
+# MAIN
+# ================================================================
+def main():
+    print("=" * 78)
+    print("M5.3 — Matrix-field feasibility spike (M = O·D·O^T in Taichi)")
+    print("=" * 78)
+
+    # ---- 1. STORAGE round-trip ----
+    print("\n[1] STORAGE — ti.Matrix.field(3,3) round-trip from numpy")
+    Mf = ti.Matrix.field(3, 3, dtype=ti.f32, shape=(8, 8, 8))
+    Mnp, _ = seed_uniaxial_hedgehog_M(8, 8, 8, DELTA)
+    Mf.from_numpy(Mnp)
+    back = Mf.to_numpy()
+    rt_err = float(np.abs(back - Mnp).max())
+    print(f"    round-trip max err = {rt_err:.2e}  → {'PASS' if rt_err < 1e-6 else 'FAIL'}")
+
+    # ---- 2. COMMUTATOR analytic ----
+    print("\n[2] COMMUTATOR — [E01, E10] == diag(1,-1,0)")
+    cerr = verify_commutator()
+    print(f"    max abs err = {cerr:.2e}  → {'PASS' if cerr < 1e-6 else 'FAIL'}")
+
+    # ---- 3. EIGEN on a known O·D·O^T ----
+    print("\n[3] EIGEN — recover known O·diag(2,1,0.5)·O^T")
+    O = rotation_zyz(0.7, 1.1, -0.4)
+    D = np.diag([2.0, 1.0, 0.5])
+    M_known = (O @ D @ O.T).astype(np.float32)
+    n_true = O[:, 0].astype(np.float32)  # eigenvector of λ_max=2 = first column of O
+    res = verify_eigen(ti.Matrix(M_known.tolist()),
+                       ti.Vector(n_true.tolist()), 2.0)
+    print(f"    λ_max err = {res[0]:.2e}   director err (1−|n̂·n|) = {res[1]:.2e}"
+          f"  → {'PASS' if res[0] < 1e-4 and res[1] < 1e-4 else 'FAIL'}")
+
+    # ---- 4. FIELD eigen — recover seeded hedgehog director ----
+    print("\n[4] FIELD — extract director from a uniaxial hedgehog M field (33³)")
+    Nf = 33
+    Mfield = ti.Matrix.field(3, 3, dtype=ti.f32, shape=(Nf, Nf, Nf))
+    dirfield = ti.Vector.field(3, dtype=ti.f32, shape=(Nf, Nf, Nf))
+    Mnp, n_seed = seed_uniaxial_hedgehog_M(Nf, Nf, Nf, DELTA)
+    Mfield.from_numpy(Mnp)
+    extract_directors(Mfield, dirfield)
+    n_rec = dirfield.to_numpy()
+    align = np.abs((n_rec * n_seed).sum(axis=-1))  # |n̂·n| per voxel (apolar)
+    # ignore the singular core voxel (r≈0, director undefined)
+    c = Nf // 2
+    mask = np.ones((Nf, Nf, Nf), bool)
+    mask[c, c, c] = False
+    mean_align = float(align[mask].mean())
+    frac_ok = float((align[mask] > 0.99).mean())
+    print(f"    mean |n̂·n_seed| = {mean_align:.4f}  (1.0 = perfect)")
+    print(f"    voxels with |n̂·n| > 0.99: {100*frac_ok:.1f}%"
+          f"  → {'PASS' if mean_align > 0.98 else 'FAIL'}")
+
+    # ---- 5. COST BENCHMARK vs Vector(3) ----
+    print("\n[5] COST BENCHMARK — matrix ops vs Vector(3) Laplacian")
+    print(f"    {'grid':>8s}  {'vec ∇² (ms)':>12s}  {'mat [∂M,∂M] (ms)':>17s}"
+          f"  {'mat eigen (ms)':>15s}  {'eigen/∇²':>9s}")
+    for N in (65, 128, 256):
+        psi = ti.Vector.field(3, dtype=ti.f32, shape=(N, N, N))
+        vout = ti.Vector.field(3, dtype=ti.f32, shape=(N, N, N))
+        M = ti.Matrix.field(3, 3, dtype=ti.f32, shape=(N, N, N))
+        mout = ti.field(dtype=ti.f32, shape=(N, N, N))
+        dfield = ti.Vector.field(3, dtype=ti.f32, shape=(N, N, N))
+        Mnp, _ = seed_uniaxial_hedgehog_M(N, N, N, DELTA)
+        M.from_numpy(Mnp)
+        psi.from_numpy(Mnp[..., 2])  # arbitrary Vector(3) data
+
+        t_vec = time_kernel(vector_laplacian_bench, psi, vout)
+        t_comm = time_kernel(deriv_commutator_norm, M, mout, 0.5)
+        t_eig = time_kernel(extract_directors, M, dfield)
+        print(f"    {N}³  {t_vec:>12.2f}  {t_comm:>17.2f}  {t_eig:>15.2f}"
+              f"  {t_eig/max(t_vec,1e-6):>8.1f}×")
+        # free before next size (Taichi fields persist; rely on GC + new alloc)
+        del psi, vout, M, mout, dfield
+
+    # ---- VERDICT ----
+    print("\n" + "=" * 78)
+    print("VERDICT")
+    print("=" * 78)
+    print("  Storage : ti.Matrix.field(3,3) round-trips cleanly.")
+    print("  Ops     : commutator + ti.sym_eig both work in-kernel on Metal,")
+    print("            verified against analytic cases AND a seeded hedgehog field.")
+    print("  Memory  : Vector(3) = 3 f32/voxel; full 3×3 = 9; symmetric needs only 6")
+    print("            (production should store 6 components, not the full 9).")
+    print("  Cost    : eigen-decomposition is the expensive primitive (per-voxel")
+    print("            sym_eig); commutator is cheap (matmul). See ratios above —")
+    print("            eigen runs once/frame for render+trackers, not in the inner loop.")
+    print("  Decision: IN-PLACE migration is viable — the matrix substrate, commutator,")
+    print("            and eigen-director extraction all work. M5.4 can proceed.")
+    print("=" * 78)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openwave/xperiments/m5_liquid_crystal/research/sandbox_v2/m5_3_resonance_smoke.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/sandbox_v2/m5_3_resonance_smoke.py
@@ -1,0 +1,207 @@
+"""
+M5.3 — Resonance smoke test on the EXISTING Vector(3) substrate (headless)
+
+Robert Close's protocol (2026-04 email): "certain amplitudes of certain
+harmonic waves will keep energy localized longer (i.e. as an unstable particle
+or resonance). Probably l=1 harmonic; max displacement comparable to the
+wavelength (or half/twice)." This script seeds an l=1 (dipole) wave packet at
+A/λ ∈ {0.5, 1, 2} and measures how long its energy stays localized, with and
+without the φ⁴ Mexican-hat nonlinearity.
+
+NOT GATING (M5.3 optional task). The question it answers: does even the
+Vector(3) substrate show extended-lifetime localization at a specific
+amplitude? If yes → the resonance mechanism is substrate-agnostic (worth
+knowing before M5.4). If no (expected) → it confirms the matrix substrate +
+true nonlinear stabilizer (M5.4-M5.7) is required; the metastable-resonance
+hunt belongs on the matrix field, per the M5.2 closed-negative result.
+
+Localization metric: L(t) = Σ_{r<R_core} |ψ|²  /  Σ_all |ψ|²  (energy-intensity
+fraction inside a core sphere). Lifetime = first step where L(t) < ½·L(0).
+
+USAGE:
+    python -m openwave.xperiments.m5_liquid_crystal.research.sandbox_v2.m5_3_resonance_smoke
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import taichi as ti
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from openwave.common import constants  # noqa: E402
+from openwave.xperiments.m5_liquid_crystal import medium  # noqa: E402
+from openwave.xperiments.m5_liquid_crystal import engine2_pde as pde  # noqa: E402
+
+# ================================================================
+# CONFIG
+# ================================================================
+N = 65
+UNIVERSE_EDGE_M = 1e-15
+TARGET_VOXELS = N**3
+LAMBDA_VOX = 12.0  # internal wavelength of the harmonic packet, in voxels
+SIGMA_VOX = LAMBDA_VOX  # Gaussian envelope width = one wavelength (localized)
+A_OVER_LAMBDA = [0.5, 1.0, 2.0]  # Close's amplitude-comparable-to-wavelength sweep
+N_PROPAGATE_STEPS = 400
+SAMPLE_EVERY = 20
+CORE_RADIUS_VOX = SIGMA_VOX  # localization core = initial packet scale
+
+
+def seed_l1_dipole(wf, a_over_lambda):
+    """Seed a z-polarized, l=1 (cosθ) dipole Gaussian wave packet at the center.
+
+    Peak displacement amplitude A = (A/λ) · λ. Writes all three leapfrog
+    buffers equal (ψ̇ = 0 rest start; also satisfies the triple-buffer BC rule
+    so the first swap_buffers doesn't clobber the seed).
+    """
+    nx, ny, nz = wf.nx, wf.ny, wf.nz
+    cx, cy, cz = nx / 2.0, ny / 2.0, nz / 2.0
+    lam_am = LAMBDA_VOX * wf.dx_am
+    amp_am = a_over_lambda * lam_am
+
+    ii, jj, kk = np.meshgrid(
+        np.arange(nx), np.arange(ny), np.arange(nz), indexing="ij"
+    )
+    dx_ = ii - cx
+    dy_ = jj - cy
+    dz_ = kk - cz
+    r_vox = np.sqrt(dx_**2 + dy_**2 + dz_**2) + 1e-9
+    cos_theta = dz_ / r_vox  # l=1 dipole angular pattern (Y_1^0 ∝ cosθ)
+    envelope = np.exp(-((r_vox / SIGMA_VOX) ** 2))
+
+    scalar = amp_am * cos_theta * envelope  # (nx,ny,nz)
+    psi = np.zeros((nx, ny, nz, 3), dtype=np.float32)
+    psi[..., 2] = scalar  # ẑ polarization
+
+    wf.psi_am.from_numpy(psi)
+    wf.psi_prev_am.from_numpy(psi)
+    wf.psi_new_am.from_numpy(psi)
+    return float(amp_am), float(lam_am)
+
+
+def localization_fraction(psi_np, core_mask):
+    """Energy-intensity fraction inside the core sphere: Σ_core |ψ|² / Σ_all |ψ|².
+
+    Returns NaN if the field has gone non-finite (numerical divergence).
+    """
+    intensity = (psi_np.astype(np.float64) ** 2).sum(axis=-1)  # |ψ|² per voxel (f64 to dodge overflow)
+    total = intensity.sum()
+    if not np.isfinite(total) or total <= 0.0:
+        return float("nan")
+    return float(intensity[core_mask].sum() / total)
+
+
+def run_one(wf, c_amrs, dt_rs, m_freq_rs, lambda_phi4, a_over_lambda, core_mask):
+    """Returns (samples, L0, lifetime, status). status ∈ {dispersed, diverged, sustained}."""
+    amp_seed, _ = seed_l1_dipole(wf, a_over_lambda)
+    L0 = localization_fraction(wf.psi_am.to_numpy(), core_mask)
+    samples = [(0, L0)]
+    lifetime = None
+    status = "sustained"  # downgraded below if it decays or diverges
+    for step in range(1, N_PROPAGATE_STEPS + 1):
+        pde.evolve_psi(wf, c_amrs, dt_rs, m_freq_rs, lambda_phi4)
+        wf.swap_buffers()
+        if step % SAMPLE_EVERY == 0 or step == N_PROPAGATE_STEPS:
+            psi_np = wf.psi_am.to_numpy()
+            peak = float(np.abs(psi_np).max())
+            # Divergence: non-finite, or field amplitude exploded > 50× the seed peak
+            if not np.isfinite(peak) or peak > 50.0 * amp_seed:
+                samples.append((step, float("nan")))
+                status = "diverged"
+                lifetime = step
+                break
+            L = localization_fraction(psi_np, core_mask)
+            samples.append((step, L))
+            if lifetime is None and L < 0.5 * L0:
+                lifetime = step
+                status = "dispersed"
+    return samples, L0, lifetime, status
+
+
+def main():
+    ti.init(arch=ti.gpu)
+    print("=" * 78)
+    print("M5.3 — Resonance smoke test (l=1 dipole on Vector(3); Close protocol)")
+    print("=" * 78)
+
+    wf = medium.WaveField([UNIVERSE_EDGE_M] * 3, TARGET_VOXELS)
+    c_amrs = constants.WAVE_SPEED / constants.ATTOMETER * constants.RONTOSECOND
+    dt_rs = wf.dx_am * 0.95 / (c_amrs * (3**0.5))
+    m_freq_kg = c_amrs / constants.COMPTON_WAVELENGTH_REDUCED_ELECTRON_AM
+    lambda_phi4 = 0.1 * (c_amrs / wf.dx_am) ** 2  # matches launcher default (stable)
+
+    # Precompute the core-sphere mask once (geometry is amplitude-independent).
+    nx, ny, nz = wf.nx, wf.ny, wf.nz
+    cx, cy, cz = nx / 2.0, ny / 2.0, nz / 2.0
+    ii, jj, kk = np.meshgrid(np.arange(nx), np.arange(ny), np.arange(nz), indexing="ij")
+    r_vox = np.sqrt((ii - cx) ** 2 + (jj - cy) ** 2 + (kk - cz) ** 2)
+    core_mask = r_vox < CORE_RADIUS_VOX
+
+    print(f"Grid: {nx}³  dx={wf.dx_am:.3f} am  dt={dt_rs:.4f} rs")
+    print(f"packet λ={LAMBDA_VOX:.0f} vox  envelope σ={SIGMA_VOX:.0f} vox  "
+          f"core R={CORE_RADIUS_VOX:.0f} vox")
+    print(f"propagate {N_PROPAGATE_STEPS} steps, sample every {SAMPLE_EVERY}; "
+          f"lifetime = step where L < ½·L₀")
+    print()
+
+    results = {}
+    for pot_label, m_freq, lam4 in [
+        ("V=0 (free-wave)", 0.0, 0.0),
+        ("KG mass ½m²|ψ|²", m_freq_kg, 0.0),
+        ("φ⁴ Mexican-hat", m_freq_kg, lambda_phi4),
+    ]:
+        print(f"[{pot_label}]")
+        print(f"    {'A/λ':>5s}  {'A (am)':>10s}  {'L₀':>8s}  {'outcome':>16s}  L(t) trace")
+        for ratio in A_OVER_LAMBDA:
+            samples, L0, lifetime, status = run_one(
+                wf, c_amrs, dt_rs, m_freq, lam4, ratio, core_mask
+            )
+            amp_am = ratio * LAMBDA_VOX * wf.dx_am
+            trace = " ".join(f"{L:.2f}" for _, L in samples[:: max(1, len(samples) // 8)])
+            if status == "diverged":
+                outcome = f"DIVERGED@{lifetime}"
+            elif status == "dispersed":
+                outcome = f"disperse@{lifetime}"
+            else:
+                outcome = f"sustained>{N_PROPAGATE_STEPS}"
+            print(f"    {ratio:>5.1f}  {amp_am:>10.1f}  {L0:>8.3f}  {outcome:>16s}  {trace}")
+            results[(pot_label, ratio)] = status
+        print()
+
+    # ================================================================
+    # Verdict
+    # ================================================================
+    print("=" * 78)
+    print("VERDICT")
+    print("=" * 78)
+    sustained = [(lbl, r) for (lbl, r), st in results.items() if st == "sustained"]
+    diverged = [(lbl, r) for (lbl, r), st in results.items() if st == "diverged"]
+    if sustained:
+        print(f"  ⚠️ SUSTAINED localization (L ≥ ½L₀ for {N_PROPAGATE_STEPS} steps, finite) at:")
+        for lbl, r in sustained:
+            print(f"       {lbl}, A/λ={r}")
+        print("  → possible substrate-agnostic resonance — investigate before M5.4.")
+    else:
+        print("  ✅ NULL (expected): no sustained localization on Vector(3) at any A/λ.")
+        print("     • Linear potentials (V=0, KG mass) disperse — and amplitude-")
+        print("       INDEPENDENTLY, as a linear PDE must (no amplitude-selected resonance).")
+        if diverged:
+            print("     • φ⁴ Mexican-hat DIVERGES: it is a director-scaled potential")
+            print("       (vacuum |ψ|=1), structurally inapplicable to a displacement-wave")
+            print("       amplitude sweep — Vector(3)'s potential toolkit can't even host")
+            print("       the test. (Diverged rows above are this, not localization.)")
+        print()
+        print("     Confirms the M5.2 closed-negative result: a metastable resonance needs")
+        print("     the matrix substrate + LdG V(M)/Skyrme + 4D clock propulsion")
+        print("     (M5.4 → M5.7), NOT the Vector(3) field. No substrate-agnostic resonance")
+        print("     — the resonance hunt belongs on the matrix substrate.")
+    print("=" * 78)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Mark M5.3 complete and M5.2 closed-negative in the roadmap; update phase badges, dates, and exit criteria to reflect the feasibility spike success and decision to proceed with in-place matrix-field migration (M5.4). Record Taichi spike findings: ti.Matrix.field(3,3) storage, commutator, and ti.sym_eig eigen-decomposition work in-kernel on Metal with ~1–2× Vector(3) cost and ~2× symmetric-memory (6 comps) — eigen is not a bottleneck. Add two sandbox scripts used by the spike: research/sandbox_v2/m5_3_matrix_feasibility.py (storage/commutator/eigen verification + benchmarks) and research/sandbox_v2/m5_3_resonance_smoke.py (Vector(3) resonance null result / φ⁴ divergence). Update question tracker timestamp/status (2026-05-26) to show M5.3 COMPLETE and M5.4 active.