### PR TITLE
Update Claude Code contributor credit to Fable 5 model

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ OpenWave is a multi-contributor open-source platform. Alongside the theoretical 
 | Contributor | Role |
 | --- | --- |
 | [Rodrigo Griesi](https://github.com/xrodz) (OpenWave Labs) | Founder, lead engineer/researcher, project director — sets vision, methodology, and engineering direction |
-| [Anthropic Claude Code](https://claude.com/product/claude-code) (Opus Model) | AI agent contributor — code, numerical analysis, derivations, documentation, manuscript review |
+| [Anthropic Claude Code](https://claude.com/product/claude-code) (Fable 5 Model) | AI agent contributor: code, numerical analysis, derivations, documentation, manuscript review |
 | Community contributors | Repo open to external contributions under [Apache 2.0](LICENSE) |
 
 The platform's design treats AI agents as first-class contributors, not as a tool layered on top of the work. Numerical analyses, derivations, and code are performed by AI agents under engineering direction from OpenWave Labs; all artifacts are open-source so any researcher can reproduce, refute, or extend.


### PR DESCRIPTION
Updates the Platform Contributors table in README.md: Claude Code's model credit moves from Opus to Fable 5 (the model currently doing the work).

Scope note: current-identity credit only. Historical records of published paper bylines (the Werbos Zenodo papers print "Claude Code on Opus 4.7") are intentionally unchanged.