### PR TITLE
Replace mermaid mindmaps with section headings

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -38,10 +38,7 @@ Models:
 
 Every file reference is an active link to the file in this repository (under `openwave/xperiments/`). Rows are grouped by domain: particles, forces, waves + quantum emergence.
 
-```mermaid
-mindmap
-  root(PARTICLES)
-```
+## PARTICLES (full spectrum)
 
 | Criteria | Liquid Crystal (M5) | Ouroboros (M6) | EWT (M3) |
 | --- | --- | --- | --- |
@@ -61,10 +58,7 @@ mindmap
 
 ---
 
-```mermaid
-mindmap
-  root[FORCES]
-```
+## FORCES
 
 | Criteria | Liquid Crystal (M5) | Ouroboros (M6) | EWT (M3) |
 | --- | --- | --- | --- |
@@ -76,10 +70,7 @@ mindmap
 
 ---
 
-```mermaid
-mindmap
-  root((WAVES))
-```
+## WAVES + QUANTUM EMERGENCE
 
 | Criteria | Liquid Crystal (M5) | Ouroboros (M6) | EWT (M3) |
 | --- | --- | --- | --- |


### PR DESCRIPTION
Remove mermaid mindmap code blocks and add plain Markdown headings for the main domains: "PARTICLES (full spectrum)", "FORCES", and "WAVES + QUANTUM EMERGENCE". This simplifies MODELS.md for readability and editing while preserving the existing model comparison tables and links.