### PR TITLE
Update level specs title to EWT MODEL (M4)

### DIFF
--- a/openwave/xperiments/m4_ewt/_launcher.py
+++ b/openwave/xperiments/m4_ewt/_launcher.py
@@ -311,7 +311,7 @@ def display_wave_menu(state):
 def display_level_specs(state, level_bar_vertices):
     """Display OpenWave level specifications overlay."""
     render.canvas.triangles(level_bar_vertices, color=colormap.DARK_BLUE[1])
-    with render.gui.sub_window("VECTOR-WAVE MODEL (M4)", 0.84, 0.01, 0.16, 0.16) as sub:
+    with render.gui.sub_window("EWT MODEL (M4)", 0.84, 0.01, 0.16, 0.16) as sub:
         sub.text("Medium: Indexed Voxel Grid")
         sub.text("Data-Structure: Vector Field")
         sub.text("Coupling: Phase Sync")


### PR DESCRIPTION
Rename the GUI sub-window title in display_level_specs from "VECTOR-WAVE MODEL (M4)" to "EWT MODEL (M4)" to reflect the updated model naming. This updates the overlay shown in the OpenWave level specs.