### PR TITLE
Rename level bar to model bar

### DIFF
--- a/openwave/common/colormap.py
+++ b/openwave/common/colormap.py
@@ -648,12 +648,12 @@ def get_palette_scale(color_palette, x, y, width, height):
 
 
 # ================================================================
-# Level Bar Geometry - visual indicator for xperiment Level
+# Model Bar Geometry - visual indicator for xperiment Model
 # ================================================================
 
 
-def get_level_bar_geometry(x, y, width, height):
-    """Generate level bar geometry as two triangles forming a rectangle.
+def get_model_bar_geometry(x, y, width, height):
+    """Generate model bar geometry as two triangles forming a rectangle.
 
     Creates a horizontal bar at specified screen coordinates.
     Canvas coordinates: (0,0) at bottom-left, X increases to the right.
@@ -662,7 +662,7 @@ def get_level_bar_geometry(x, y, width, height):
         ti.Vector.field: vertices_field for rendering with canvas.triangles()
     """
     # Create Taichi field for triangle vertices
-    level_bar_vertices = ti.Vector.field(2, dtype=ti.f32, shape=6)
+    model_bar_vertices = ti.Vector.field(2, dtype=ti.f32, shape=6)
 
     # Position parameters (screen coordinates)
     x_left = x
@@ -671,16 +671,16 @@ def get_level_bar_geometry(x, y, width, height):
     y_bottom = 1 - (y + height)
 
     # First triangle (bottom-left, bottom-right, top-left)
-    level_bar_vertices[0] = ti.Vector([x_left, y_bottom])
-    level_bar_vertices[1] = ti.Vector([x_right, y_bottom])
-    level_bar_vertices[2] = ti.Vector([x_left, y_top])
+    model_bar_vertices[0] = ti.Vector([x_left, y_bottom])
+    model_bar_vertices[1] = ti.Vector([x_right, y_bottom])
+    model_bar_vertices[2] = ti.Vector([x_left, y_top])
 
     # Second triangle (top-left, bottom-right, top-right)
-    level_bar_vertices[3] = ti.Vector([x_left, y_top])
-    level_bar_vertices[4] = ti.Vector([x_right, y_bottom])
-    level_bar_vertices[5] = ti.Vector([x_right, y_top])
+    model_bar_vertices[3] = ti.Vector([x_left, y_top])
+    model_bar_vertices[4] = ti.Vector([x_right, y_bottom])
+    model_bar_vertices[5] = ti.Vector([x_right, y_top])
 
-    return level_bar_vertices
+    return model_bar_vertices
 
 
 # ================================================================

--- a/openwave/xperiments/m1_granule_motion/_launcher.py
+++ b/openwave/xperiments/m1_granule_motion/_launcher.py
@@ -276,9 +276,9 @@ def display_wave_menu(state):
                 sub.text(f"0       {state.peak_amplitude:.0e}m")
 
 
-def display_level_specs(state, level_bar_vertices):
-    """Display OpenWave level specifications overlay."""
-    render.canvas.triangles(level_bar_vertices, color=colormap.WHITE[1])
+def display_model_specs(state, model_bar_vertices):
+    """Display OpenWave model specifications overlay."""
+    render.canvas.triangles(model_bar_vertices, color=colormap.WHITE[1])
     with render.gui.sub_window("GRANULE-MOTION MODEL (M1)", 0.84, 0.01, 0.16, 0.16) as sub:
         sub.text("Medium: Granule-Based Lattice")
         sub.text("Data-Structure: Vector Field")
@@ -347,7 +347,7 @@ def initialize_xperiment(state):
     """
     global og_palette_vertices, og_palette_colors
     global ib_palette_vertices, ib_palette_colors
-    global level_bar_vertices
+    global model_bar_vertices
 
     # Initialize color palettes for gradient rendering and level indicator
     og_palette_vertices, og_palette_colors = colormap.get_palette_scale(
@@ -356,7 +356,7 @@ def initialize_xperiment(state):
     ib_palette_vertices, ib_palette_colors = colormap.get_palette_scale(
         colormap.ironbow, 0.00, 0.73, 0.079, 0.01
     )
-    level_bar_vertices = colormap.get_level_bar_geometry(0.84, 0.00, 0.159, 0.01)
+    model_bar_vertices = colormap.get_model_bar_geometry(0.84, 0.00, 0.159, 0.01)
 
     # Initialize wave sources
     ewave.build_source_vectors(
@@ -514,7 +514,7 @@ def main():
         # Display additional UI elements and scene
         display_wave_menu(state)
         display_data_dashboard(state)
-        display_level_specs(state, level_bar_vertices)
+        display_model_specs(state, model_bar_vertices)
         render.show_scene()
 
         # Capture frame for video export (stops after VIDEO_FRAMES)

--- a/openwave/xperiments/m2_free_wave/_launcher.py
+++ b/openwave/xperiments/m2_free_wave/_launcher.py
@@ -321,9 +321,9 @@ def display_wave_menu(state):
                 sub.text(f"0       {state.freq_global_avg*2*state.wave_field.scale_factor:.0e}Hz")
 
 
-def display_level_specs(state, level_bar_vertices):
-    """Display OpenWave level specifications overlay."""
-    render.canvas.triangles(level_bar_vertices, color=colormap.LIGHT_BLUE[1])
+def display_model_specs(state, model_bar_vertices):
+    """Display OpenWave model specifications overlay."""
+    render.canvas.triangles(model_bar_vertices, color=colormap.LIGHT_BLUE[1])
     with render.gui.sub_window("FREE-WAVE MODEL (M2)", 0.84, 0.01, 0.16, 0.16) as sub:
         sub.text("Medium: Indexed Voxel Grid")
         sub.text("Data-Structure: Scalar Field")
@@ -419,7 +419,7 @@ def initialize_xperiment(state):
     global vr_palette_vertices, vr_palette_colors
     global ib_palette_vertices, ib_palette_colors
     global bp_palette_vertices, bp_palette_colors
-    global level_bar_vertices
+    global model_bar_vertices
 
     # Initialize color palette scales for gradient rendering and level indicator
     gy_palette_vertices, gy_palette_colors = colormap.get_palette_scale(
@@ -437,7 +437,7 @@ def initialize_xperiment(state):
     bp_palette_vertices, bp_palette_colors = colormap.get_palette_scale(
         colormap.blueprint, 0.00, 0.73, 0.079, 0.01
     )
-    level_bar_vertices = colormap.get_level_bar_geometry(0.84, 0.00, 0.159, 0.01)
+    model_bar_vertices = colormap.get_model_bar_geometry(0.84, 0.00, 0.159, 0.01)
 
     # STATIC CHARGING methods (single radial pulse pattern, fast charge) ==================================
     # Provides initial energy source, dynamic chargers do maintenance around 100%
@@ -625,7 +625,7 @@ def main():
         # Display additional UI elements and scene
         display_wave_menu(state)
         display_data_dashboard(state)
-        display_level_specs(state, level_bar_vertices)
+        display_model_specs(state, model_bar_vertices)
         render.show_scene()
 
         # Capture frame for video export (stops after VIDEO_FRAMES)

--- a/openwave/xperiments/m3_wolff_lafreniere/_launcher.py
+++ b/openwave/xperiments/m3_wolff_lafreniere/_launcher.py
@@ -315,9 +315,9 @@ def display_wave_menu(state):
                 sub.text(f"0       {state.energy_global_avg*2:.0e}J")
 
 
-def display_level_specs(state, level_bar_vertices):
-    """Display OpenWave level specifications overlay."""
-    render.canvas.triangles(level_bar_vertices, color=colormap.GREEN[1])
+def display_model_specs(state, model_bar_vertices):
+    """Display OpenWave model specifications overlay."""
+    render.canvas.triangles(model_bar_vertices, color=colormap.GREEN[1])
     with render.gui.sub_window("WOLFF-LAFRENIERE MODEL (M3)", 0.84, 0.01, 0.16, 0.16) as sub:
         sub.text("Medium: Indexed Voxel Grid")
         sub.text("Data-Structure: Scalar Field")
@@ -384,7 +384,7 @@ def initialize_xperiment(state):
     global gy_palette_vertices, gy_palette_colors
     global vr_palette_vertices, vr_palette_colors
     global ib_palette_vertices, ib_palette_colors
-    global level_bar_vertices
+    global model_bar_vertices
 
     # Initialize color palette scales for gradient rendering and level indicator
     gy_palette_vertices, gy_palette_colors = colormap.get_palette_scale(
@@ -396,7 +396,7 @@ def initialize_xperiment(state):
     ib_palette_vertices, ib_palette_colors = colormap.get_palette_scale(
         colormap.ironbow, 0.00, 0.73, 0.079, 0.01
     )
-    level_bar_vertices = colormap.get_level_bar_geometry(0.84, 0.00, 0.159, 0.01)
+    model_bar_vertices = colormap.get_model_bar_geometry(0.84, 0.00, 0.159, 0.01)
 
     if state.INSTRUMENTATION:
         print("\n" + "=" * 64)
@@ -596,7 +596,7 @@ def main():
         # Display additional UI elements and scene
         display_wave_menu(state)
         display_data_dashboard(state)
-        display_level_specs(state, level_bar_vertices)
+        display_model_specs(state, model_bar_vertices)
         render.show_scene()
 
         # Capture frame for video export (stops after VIDEO_FRAMES)

--- a/openwave/xperiments/m4_ewt/_launcher.py
+++ b/openwave/xperiments/m4_ewt/_launcher.py
@@ -308,9 +308,9 @@ def display_wave_menu(state):
                 sub.text(f"0       {state.energy_global_avg*2:.0e}J")
 
 
-def display_level_specs(state, level_bar_vertices):
-    """Display OpenWave level specifications overlay."""
-    render.canvas.triangles(level_bar_vertices, color=colormap.DARK_BLUE[1])
+def display_model_specs(state, model_bar_vertices):
+    """Display OpenWave model specifications overlay."""
+    render.canvas.triangles(model_bar_vertices, color=colormap.DARK_BLUE[1])
     with render.gui.sub_window("EWT MODEL (M4)", 0.84, 0.01, 0.16, 0.16) as sub:
         sub.text("Medium: Indexed Voxel Grid")
         sub.text("Data-Structure: Vector Field")
@@ -377,7 +377,7 @@ def initialize_xperiment(state):
     global og_palette_vertices, og_palette_colors
     global ib_palette_vertices, ib_palette_colors
     global bp_palette_vertices, bp_palette_colors
-    global level_bar_vertices
+    global model_bar_vertices
 
     # Initialize color palette scales for gradient rendering and level indicator
     og_palette_vertices, og_palette_colors = colormap.get_palette_scale(
@@ -389,7 +389,7 @@ def initialize_xperiment(state):
     bp_palette_vertices, bp_palette_colors = colormap.get_palette_scale(
         colormap.blueprint, 0.00, 0.73, 0.079, 0.01
     )
-    level_bar_vertices = colormap.get_level_bar_geometry(0.84, 0.00, 0.159, 0.01)
+    model_bar_vertices = colormap.get_model_bar_geometry(0.84, 0.00, 0.159, 0.01)
 
     if state.INSTRUMENTATION:
         print("\n" + "=" * 64)
@@ -616,7 +616,7 @@ def main():
         # Display additional UI elements and scene
         display_wave_menu(state)
         display_data_dashboard(state)
-        display_level_specs(state, level_bar_vertices)
+        display_model_specs(state, model_bar_vertices)
         render.show_scene()
 
         # Capture frame for video export (stops after VIDEO_FRAMES)

--- a/openwave/xperiments/m5_liquid_crystal/_launcher.py
+++ b/openwave/xperiments/m5_liquid_crystal/_launcher.py
@@ -525,9 +525,9 @@ def display_wave_menu(state):
                     sub.text("0           max")
 
 
-def display_level_specs(state, level_bar_vertices):
-    """Display OpenWave level specifications overlay."""
-    render.canvas.triangles(level_bar_vertices, color=colormap.ORANGE[1])
+def display_model_specs(state, model_bar_vertices):
+    """Display OpenWave model specifications overlay."""
+    render.canvas.triangles(model_bar_vertices, color=colormap.ORANGE[1])
     with render.gui.sub_window("LIQUID-CRYSTAL MODEL (M5)", 0.84, 0.01, 0.16, 0.16) as sub:
         sub.text("Medium: Indexed Voxel Grid")
         sub.text("Data-Structure: Tensor Field")
@@ -612,7 +612,7 @@ def initialize_xperiment(state):
     global bp_palette_vertices, bp_palette_colors
     global gy_palette_vertices, gy_palette_colors
     global br_palette_vertices, br_palette_colors
-    global level_bar_vertices
+    global model_bar_vertices
 
     # Initialize color palette scales for gradient rendering and level indicator
     og_palette_vertices, og_palette_colors = colormap.get_palette_scale(
@@ -630,7 +630,7 @@ def initialize_xperiment(state):
     br_palette_vertices, br_palette_colors = colormap.get_palette_scale(
         colormap.bluered, 0.00, 0.68, 0.079, 0.01
     )
-    level_bar_vertices = colormap.get_level_bar_geometry(0.84, 0.00, 0.159, 0.01)
+    model_bar_vertices = colormap.get_model_bar_geometry(0.84, 0.00, 0.159, 0.01)
 
     # (M5.8 ψ-retire: the legacy TEST_SEED Gaussian/plane-wave seeding path was
     # removed with the Vector(3) ψ engine — all live xperiments use TOPOLOGY_SEED.)
@@ -1254,7 +1254,7 @@ def main():
         # Display additional UI elements and scene
         display_wave_menu(state)
         display_data_dashboard(state)
-        display_level_specs(state, level_bar_vertices)
+        display_model_specs(state, model_bar_vertices)
         render.show_scene()
 
         # Capture frame for video export (stops after VIDEO_FRAMES)


### PR DESCRIPTION
Rename level-bar API and variables to model-bar across the codebase for clearer semantics. Updated colormap.get_level_bar_geometry -> colormap.get_model_bar_geometry (and its internal variable names/return value) and the header comment in openwave/common/colormap.py. Updated callers in experiment launchers (m1..m5) to use display_model_specs, model_bar_vertices, and colormap.get_model_bar_geometry. Functionality and visual output are unchanged; this is a refactor to standardize naming.