### PR TITLE
Adjust GUI sub-window positions and add comment

### DIFF
--- a/openwave/i_o/render.py
+++ b/openwave/i_o/render.py
@@ -36,6 +36,7 @@ def init_UI(
     pkg_name = "OPENWAVE"
     title = pkg_name + " (v" + pkg_version + ")"
     width, height = pyautogui.size()
+    # For testing on smaller screens, uncomment the following line to use a fixed resolution:
     # width, height = 1470, 884  # uncomment to test on min supported resolution
 
     window = ti.ui.Window(title, (width, height), vsync=True)

--- a/openwave/xperiments/m4_ewt/_launcher.py
+++ b/openwave/xperiments/m4_ewt/_launcher.py
@@ -242,7 +242,7 @@ def display_xperiment_launcher(xperiment_mgr, state):
     """
     selected_xperiment = None
 
-    with render.gui.sub_window("XPERIMENT LAUNCHER", 0.00, 0.00, 0.14, 0.35) as sub:
+    with render.gui.sub_window("XPERIMENT LAUNCHER", 0.00, 0.00, 0.14, 0.37) as sub:
         sub.text("(needs window reload)", color=colormap.LIGHT_BLUE[1])
         for xp_name in xperiment_mgr.available_xperiments:
             display_name = xperiment_mgr.get_xperiment_display_name(xp_name)
@@ -259,7 +259,7 @@ def display_xperiment_launcher(xperiment_mgr, state):
 
 def display_controls(state):
     """Display the controls UI overlay."""
-    with render.gui.sub_window("CONTROLS", 0.00, 0.35, 0.16, 0.33) as sub:
+    with render.gui.sub_window("CONTROLS", 0.00, 0.37, 0.16, 0.33) as sub:
         state.SHOW_AXIS = sub.checkbox(f"Axis (ticks: {state.TICK_SPACING})", state.SHOW_AXIS)
         state.SHOW_EDGES = sub.checkbox("Sim Universe Edges", state.SHOW_EDGES)
         state.SHOW_FLUX_MESH = sub.slider_int("Flux Mesh", state.SHOW_FLUX_MESH, 0, 3)


### PR DESCRIPTION
Tweak UI layout: increase the XPERMENT LAUNCHER window height from 0.35 to 0.37 and move the CONTROLS sub-window vertical start from 0.35 to 0.37 to reduce overlap. Also add a comment in openwave/i_o/render.py explaining how to uncomment a fixed resolution for testing on smaller screens.