### PR TITLE
Add model briefing docs for M1-M7

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -108,11 +108,13 @@ The coverage matrix scores phenomena; this companion table scores the model-leve
 
 ## Per-model results of record
 
-| Model | Deep dive |
-| --- | --- |
-| Liquid Crystal (M5) | [`99_summary_report.md`](openwave/xperiments/m5_liquid_crystal/research/99_summary_report.md): the results-of-record; [`0b_M5_roadmap.md`](openwave/xperiments/m5_liquid_crystal/research/0b_M5_roadmap.md): full program; [`0b_question_tracker.md`](openwave/xperiments/m5_liquid_crystal/research/0b_question_tracker.md): emergence catalog + open questions |
-| Ouroboros (M6) | [`0d_canonical.md`](openwave/xperiments/m6_ouroboros/research/0d_canonical.md): canonical numerical specification |
-| EWT (M4) | [`0_STATUS.md`](openwave/xperiments/m3_wolff_lafreniere/research/0_STATUS.md): targets, achieved, honest blockers |
+| Model | Briefing | Deep dive |
+| --- | --- | --- |
+| Liquid Crystal (M5) | [`__M5_model_briefing.md`](openwave/xperiments/m5_liquid_crystal/__M5_model_briefing.md) | [`99_summary_report.md`](openwave/xperiments/m5_liquid_crystal/research/99_summary_report.md): the results-of-record; [`0b_M5_roadmap.md`](openwave/xperiments/m5_liquid_crystal/research/0b_M5_roadmap.md): full program; [`0b_question_tracker.md`](openwave/xperiments/m5_liquid_crystal/research/0b_question_tracker.md): emergence catalog + open questions |
+| Ouroboros (M6) | [`__M6_model_briefing.md`](openwave/xperiments/m6_ouroboros/__M6_model_briefing.md) | [`0d_canonical.md`](openwave/xperiments/m6_ouroboros/research/0d_canonical.md): canonical numerical specification |
+| EWT (M4) | [`__M4_model_briefing.md`](openwave/xperiments/m4_ewt/__M4_model_briefing.md) | [`0_STATUS.md`](openwave/xperiments/m3_wolff_lafreniere/research/0_STATUS.md): targets, achieved, honest blockers |
+
+The one-page model briefings summarize what each model brings (identity, profile, per-particle field configurations, status, roadmap, contribution invite). Beyond the three scored columns above: [`M3 Wolff-LaFreniere`](openwave/xperiments/m3_wolff_lafreniere/__M3_model_briefing.md) (the scalar engine behind the EWT record), [`M7 HydroBoros`](openwave/xperiments/m7_hydroboros/__M7_model_briefing.md) (pre-implementation), and the wave-physics library [`M1 Granule Motion`](openwave/xperiments/m1_granule_motion/__M1_model_briefing.md) + [`M2 Free Wave`](openwave/xperiments/m2_free_wave/__M2_model_briefing.md).
 
 ## Contributing a model or a validation
 

--- a/ONBOARDING_MODELS.md
+++ b/ONBOARDING_MODELS.md
@@ -126,6 +126,7 @@ You do not need to fork or write code to *start*. The lowest-friction on-ramp is
 | Piece | What it is | Where it lives |
 | --- | --- | --- |
 | Model directory | A new home for your framework. | `openwave/xperiments/<your-model>/` with a `research/` subfolder |
+| Model briefing | A one-page front door: identity, profile, per-particle field configs, status, roadmap, invite (Section 3.1). | `openwave/xperiments/<your-model>/__<MID>_model_briefing.md` |
 | Column in the table | Your framework as a new column scored against the shared rows. | [`MODELS.md`](MODELS.md) coverage matrix |
 | Per-cell status | One of the legend icons per criterion. | each table cell |
 | Backing per claim | A runnable script **or** a short research note documenting pass/fail. | under your model directory |
@@ -143,6 +144,23 @@ Status legend (same as the table):
 A good first PR adds the column plus a model directory with one or two cells actually backed (a runnable script + a note), and the rest marked 🚧 honestly. Finite-difference / first-pass now, fuller validation later, is fine and expected.
 
 A maintainer reviews with a **light PR review** focused on two things only: (1) a runnable script that reproduces the claim, and (2) a research note documenting pass/fail honestly. It is not ideological gatekeeping.
+
+### 3.1 The model briefing (a self-test and the column's front door)
+
+Every model directory carries a one-page briefing, `__<MID>_model_briefing.md` (e.g. `__M5_model_briefing.md`), that summarizes what the model brings. Write yours early. It is the front door a reader, a maintainer, or the Models-of-Particles group hits first, and drafting it honestly is itself a **self-test**: it forces the same statements Sections 1, 4 and 5 ask for, in a form anyone can scan in a minute.
+
+Use [`m5_liquid_crystal/__M5_model_briefing.md`](openwave/xperiments/m5_liquid_crystal/__M5_model_briefing.md) as the worked template. Its six sections and the self-test each one enforces:
+
+| Section | What it states | Self-test it enforces |
+| --- | --- | --- |
+| Identity | ID, name, author, lineage, primary sources, in-repo files | provenance is explicit and citable |
+| Model Profile | short-form rows: substrate, particle, charge, Derrick escape, clock, EM, gravity, free parameters, lab anchor, next falsifier | the honest ledger (§1.2) + a falsifier (§1.4) at a glance |
+| Field Configuration of Particles | per-particle field config + "topological vortex?"; whether the clock is derived or assumed | you can actually specify each particle, not just name it |
+| Implementation Status | per-sector ✅ / ⚠️ / ❌ / 🚧 against the shared criteria + deep-dive links | honest status, negatives included (§5.1) |
+| Roadmap | what lands next, with issue numbers | the open work is named, not hidden |
+| Help Wanted | how others can contribute a validation, a falsifier, or a rival config | the column stays open |
+
+A new column's briefing may be mostly 🚧 at first, that is expected. The point is that it exists, is honest, and reads as a scannable one-pager. It does not replace the deeper docs (roadmap, question tracker, summary report); it is the index to them.
 
 ---
 
@@ -220,6 +238,7 @@ A practical pattern: run the reproducer and the independent recomputer first (do
 | Doc | For |
 | --- | --- |
 | [`MODELS.md`](MODELS.md) | The comparison table, the shared criteria, the validation legend |
+| [`m5_liquid_crystal/__M5_model_briefing.md`](openwave/xperiments/m5_liquid_crystal/__M5_model_briefing.md) | The model-briefing template (Section 3.1), a worked one-pager to copy |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Canonical setup, fork/branch/PR flow, DCO sign-off |
 | [`SYS_ARCH.md`](SYS_ARCH.md) | Repository structure and tech stack |
 | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) | Community expectations |

--- a/WELCOME.md
+++ b/WELCOME.md
@@ -159,10 +159,6 @@ To launch the Xperiments Selector Menu:
 - **GRANULE-MOTION Model** provides particle-based visualizations for intuitive understanding
 - Both are computational frameworks for testing model predictions against experimental data
 
-## OPENWAVE MODELS
-
-![models](images/models.png)
-
 ## Getting Help and Contributing
 
 - See the main [README](README.md) for contribution guidelines

--- a/openwave/xperiments/m1_granule_motion/__M1_model_briefing.md
+++ b/openwave/xperiments/m1_granule_motion/__M1_model_briefing.md
@@ -1,0 +1,80 @@
+# M1 Granule Motion: Model Briefing
+
+> **What M1 brings.** A granule-medium wave-propagation sandbox: it shows how spherical
+> longitudinal waves from harmonic sources superpose into interference and standing-wave
+> patterns on a discrete BCC spacetime lattice. M1 is a **wave-physics library to mine,
+> not a particle-emergence model**, and it is not scored in the
+> [`MODELS.md`](../../../MODELS.md) coverage matrix.
+
+## Identity
+
+| Field | Value |
+| --- | --- |
+| Model ID | M1 |
+| Name | Granule Motion |
+| Author | OpenWave educational library (no single originating theorist named) |
+| Physics anchor | Energy Wave Theory wave constants (Jeff Yee); Wolff-style in / out standing waves |
+| Role | reusable wave primitives for the particle models (M3-M7), not a coverage column |
+| Primary sources | EWT papers (Jeff Yee); Milo Wolff wave-structure-of-matter (in / out waves) |
+| In-repo | `medium.py` (BCC lattice) + `wave_engine.py` + `_launcher.py`; `research/README.md`, `research/spherical_wave.md`, `research/phase_shift.md` |
+
+## Model Profile (what it brings, short form)
+
+| Attribute | M1 |
+| --- | --- |
+| Substrate | BCC granule lattice (fluid-like medium, sub-attometer granules; 2 per unit cell) |
+| Granule | point-mass unit vibrating harmonically about its equilibrium |
+| Wave | displacement field `x(t) = x_eq + A(r)·cos(ωt + φ)·dir`, phase `φ = -kr` |
+| Wave types | standing · traveling · spherical · energy (base / in / out toggles) |
+| Charge / particle | none (per-source phase offset is the only particle-like handle) |
+| Free parameters | fixed EWT constants (c, λ, f, A, ρ); per-demo: source count / positions / phase, base-in-out toggles |
+| Anchor | analytic PSHO (phase-synchronized harmonic oscillation), `v = fλ = c` by construction; theory only, no lab data |
+
+## Wave Primitives Provided
+
+M1 does not model particles, so in place of a per-particle field-configuration table it
+supplies the wave mechanics the higher models reuse:
+
+| Primitive | What it is |
+| --- | --- |
+| base_wave | background wave summed from the 8 universe-box vertices (constant amplitude) |
+| in_wave | inward wave toward a wave-center (full amplitude) |
+| out_wave | outward spherical wave with 1/r amplitude falloff |
+| superposition engine | per-granule sum of all sources → constructive / destructive interference |
+| energy-conservation primitives | 1/r falloff, singularity clamp `r_min = 1λ`, physical cap `A ≤ r` |
+
+Wave-center → particle formation (constructive / destructive interference assembling a
+particle) is aspirational here, not implemented; that work lives in the particle models.
+
+## Implementation Status
+
+Not a MODELS.md coverage column. M1 is a runnable Taichi GGUI application
+(`python _launcher.py`) with 9 preset demos (granule motion, 3D spherical wave, standing
+wave, wave interference, spacetime vibration, medium disturbance, golden-ratio spiral, and
+two multi-source force demos). Parameters are correct *by construction* (the analytic PSHO
+solution), not claim-backed validations. The M7 implementation plan classifies M1 as part
+of the wave-physics library to mine for insights, explicitly "not a parent" model.
+
+## Roadmap
+
+| Next | What lands |
+| --- | --- |
+| Phase manipulation | richer multi-source interference phase + a particle-interaction phase (hooks only today) |
+| Wave-center → particle | assembling particles from interference (aspirational; belongs to M3-M7) |
+| Doc cleanup | `research/README.md` drift (legacy names, removed presets) |
+
+## Help Wanted
+
+M1 is a shared wave library, not a scored model, so there are no coverage cells to fill.
+The value is clean, reusable wave mechanics. Useful contributions:
+
+| You can contribute | How |
+| --- | --- |
+| A new wave primitive or demo | e.g. polarization, dispersion, a new source geometry, as an `xparameters/` preset |
+| Reuse into the particle models | wire these seeders into M3-M7 (the M7 plan calls M1-M4 the library to mine) |
+| A doc / layout cleanup | reconcile `research/README.md` with the current file tree |
+
+Flow: open an issue or discussion → fork → branch → PR with a DCO sign-off
+(`git commit -s`), under Apache 2.0. See [`../../../CONTRIBUTING.md`](../../../CONTRIBUTING.md)
+and [`../../../MODELS.md`](../../../MODELS.md). Model discussion runs in the
+Models-of-Particles group.

--- a/openwave/xperiments/m2_free_wave/__M2_model_briefing.md
+++ b/openwave/xperiments/m2_free_wave/__M2_model_briefing.md
@@ -1,0 +1,80 @@
+# M2 Free Wave: Model Briefing
+
+> **What M2 brings.** A stable GPU voxel-grid PDE wave substrate: an energy-wave freely
+> propagates, reflects, and superposes on a 3D lattice (longitudinal + transverse), with no
+> particles present. Like M1, M2 is a **wave-physics library to mine, not a
+> particle-emergence model**, and it is not scored in the
+> [`MODELS.md`](../../../MODELS.md) coverage matrix.
+
+## Identity
+
+| Field | Value |
+| --- | --- |
+| Model ID | M2 |
+| Name | Free Wave |
+| Author | OpenWave wave-dynamics engine (no single originating theorist named) |
+| Physics anchor | Energy Wave Theory constants (Jeff Yee lineage); Wolff standing-wave design |
+| Role | PDE wave substrate + primitives for the particle models, not a coverage column |
+| Primary sources | `research/00_LEVEL1_PLAN.md`, `research/10_STABILITY_ANALYSIS.md`, `research/stable_waves.md` |
+| In-repo | `medium.py` (voxel grid, `psiL`/`psiT`) + `wave_engine.py` + `_launcher.py` |
+
+## Model Profile (what it brings, short form)
+
+| Attribute | M2 |
+| --- | --- |
+| Substrate | cell-centered cubic voxel grid (~1e9 target voxels, f32); scalar displacement split into longitudinal `psiL` + transverse `psiT` |
+| Free wave | an energy-wave propagating / reflecting / superposing with no wave-centers present |
+| Dynamics | 3D wave eqn `∂²ψ/∂t² = c²∇²ψ`, leap-frog / Verlet, 6-pt (opt. 18-pt) Laplacian, Dirichlet reflective walls |
+| Stability | escapes the LEVEL-0 numerical explosion via slow-motion on wave *speed* (not timestep); CFL `dt ≤ dx/(c√3)`, single step per frame |
+| Charge / particle | "charge" = energy-charging the field (pulse injection), NOT electric charge; no particles |
+| Free parameters | universe size / edge, target voxels (resolution), static boost (charge amplitude), sim speed; physics constants fixed |
+| Anchor | EWT energy-wave constants (λ ≈ 28.5 am, f ≈ 1.05e25 Hz, ρ ≈ 3.86e22 kg/m³); analytic, no lab data |
+
+## Wave Primitives Provided
+
+M2 does not model particles, so in place of a per-particle field-configuration table it
+supplies the PDE wave mechanics the higher models reuse:
+
+| Primitive | What it is |
+| --- | --- |
+| charging (energy injection) | `charge_full` (radial outgoing), `charge_gaussian` (packet), `charge_oscillator_*` (continuous drivers) |
+| propagation | `propagate_wave` (leap-frog PDE, L + T), `compute_laplacian` (6 / 18-pt) |
+| damping / envelopes | `damp_full`, charge-envelope + damping-factor helpers |
+| wave-center interactions | `interact_wc_*` (standing, spin up / down, lens, drain), experimental, NOT wired into the live loop |
+
+Wave-centers and particle formation are Phases C-D of the plan (designed + experimental
+code), not validated; the live loop today is charge + free propagation only.
+
+## Implementation Status
+
+Not a MODELS.md coverage column. M2 is self-described as NOT YET VALIDATED (architecture
+complete, implementation in progress). What runs live (`python _launcher.py`): grid build +
+energy charging + free-wave PDE propagation with reflective boundaries and flux-mesh
+visualization; a 20,000-step stable-charging verification is on record. Wave-center /
+particle dynamics are not running. The M7 plan lists M2 among the wave library (M1-M4) to
+mine, "not a parent" model.
+
+## Roadmap
+
+| Next | What lands |
+| --- | --- |
+| Phase A / B (core + charging) | solver + energy-conservation + boundary tests; measure wave speed and λ |
+| Phase C / D (wave centers + particles) | reflective voxels → standing waves → mass from trapped energy → force + Newtonian motion |
+| Phase E / F (viz + analysis) | data export, plots, video |
+| Validation targets (open) | wave speed ≈ c (±5-10%), energy drift < 1% over 1M steps, standing waves at `r = nλ/2` |
+
+## Help Wanted
+
+M2 is a shared wave library, not a scored model, so there are no coverage cells to fill.
+Useful contributions:
+
+| You can contribute | How |
+| --- | --- |
+| A new wave primitive or demo | a new source / boundary / driver, as an `xparameters/` preset |
+| Wire the wave-center engine into the live loop | move the experimental `interact_wc_*` kernels from designed to running |
+| Reuse into the particle models | use the PDE substrate as a seeder for M7 (the M7 plan calls M1-M4 the library to mine) |
+
+Flow: open an issue or discussion → fork → branch → PR with a DCO sign-off
+(`git commit -s`), under Apache 2.0. See [`../../../CONTRIBUTING.md`](../../../CONTRIBUTING.md)
+and [`../../../MODELS.md`](../../../MODELS.md). Model discussion runs in the
+Models-of-Particles group.

--- a/openwave/xperiments/m3_wolff_lafreniere/__M3_model_briefing.md
+++ b/openwave/xperiments/m3_wolff_lafreniere/__M3_model_briefing.md
@@ -1,0 +1,92 @@
+# M3 Wolff-LaFreniere (WSM): Model Briefing
+
+> **What M3 brings.** The Wave Structure of Matter made runnable: particles as standing-wave
+> centers in an elastic wave medium, where force is an energy gradient (`F = −∇E`). It is the
+> scalar engine that holds OpenWave's EWT validation record, demonstrating the standing-wave
+> lock-in *mechanism* while honestly documenting where selectivity fails. It shares the
+> "EWT (M4)" [`MODELS.md`](../../../MODELS.md) column with M4.
+
+## Identity
+
+| Field | Value |
+| --- | --- |
+| Model ID | M3 |
+| Name | Wolff-LaFreniere (Wave Structure of Matter / WSM) |
+| Author | Milo Wolff (Space Resonance Theory) + Gabriel LaFreniere (wave mechanics); formalized as Energy Wave Theory by Jeff Yee (with Dieter Hauger) |
+| Extension | Łukasz Smoliński (BCC-lattice, zero-parameter EWT) |
+| Relationship | the scalar WSM engine; the vector-PDE successor is M4 (see [`../m4_ewt/__M4_model_briefing.md`](../m4_ewt/__M4_model_briefing.md)) |
+| Primary sources | Wolff, *Exploring the Physics of the Unknown Universe* (Ch. 12); LaFreniere wave-mechanics pages; Jeff Yee EWT papers |
+| In-repo | `medium.py` + `particle.py` + `wave_engine.py` + `force_motion.py` + `_launcher.py`; `research/0_OVERVIEW.md`, `0_STATUS.md`, `0_ROADMAP.md`, `0a_equations.md` |
+
+## Model Profile (what it brings, short form)
+
+| Attribute | M3 |
+| --- | --- |
+| Substrate | elastic fluid-like spacetime medium; scalar longitudinal displacement field ψ |
+| Particle | a wave-center (WC): a point that elastically disturbs the base wave; the standing-wave structure IS the particle |
+| Charge | intended emergent (tetrahedral geometry + spin, L→T); currently imposed via `cos(source_offset)` (0 = electron, π = positron) |
+| Stability | standing-wave lock-in: same-phase WCs settle into sinc energy wells at λ spacing |
+| Governing eqn | Combined Wolff-LaFreniere `ψ(r,t) = A·[sin(ωt−kr) − sin(ωt)]/r`, 1/r energy-conserving falloff |
+| Force | `F = −∇E` (energy gradient) |
+| Free parameters | EWT wave constants (amplitude A, wavelength λ, density ρ) + per-script envelope / threshold choices |
+| Anchor | ρ = 3.86e22 kg/m³, c, A₀ = 9.22e-19 m, f₀ = 1.05e25 Hz, λ₀ = 2.85e-17 m |
+
+## Field Configuration of Particles
+
+Duda's standing demand: *state the field configuration of each particle, and say whether it
+uses topological vortices.* M3's answers (all "no topology": it is a scalar field, so there
+is no winding number, no vortex, unlike M5's defects or M7's toroidal knots):
+
+| Particle | Field configuration in M3 | Topological vortex? |
+| --- | --- | --- |
+| Electron neutrino | 1 wave-center (K = 1), symmetric, neutral | ❌ standing wave |
+| Electron / positron | K = 10 "1-3-6 tetrahedron" of in-phase WCs (charged); positron = opposite nodes (λ/2 offset) | ❌ standing wave |
+| Annihilation pair | two opposite-phase WCs (0 vs π), head-on → positronium wells | ❌ |
+| Heavier families | neutral K = 1, 8, 20 (ν); charged K = 10, 28, 50 (e, μ, τ); magic numbers 2, 8, 10, 20, 28, 50 | ❌ |
+
+## Implementation Status
+
+The EWT family shares one MODELS.md column, "EWT (M4)": **0 ✅, 8 ⚠️, 3 ❌, 10 🚧** (of 21).
+These are the results recorded on this scalar engine; the vector-PDE successor is M4.
+
+| Sector | Status |
+| --- | --- |
+| Standing-wave lock-in | ⚠️ same-phase wells at λ spacing (mechanism shown) |
+| Annihilation | ⚠️ opposite-phase pair annihilates with documented assists (0.5λ threshold, damping, velocity clamp) |
+| Electron mass | ⚠️ lock-in shown; mass values from analytic EWT, not in-sim dynamics |
+| Charge quantization | ❌ charge sign imposed via `cos(source_offset)`, not emergent (#203) |
+| Lepton spectrum (K-selectivity) | ❌ all K = 2..10 equally stable at perfect placement; K = 10 breaks worst under perturbation (#201) |
+| Electric / Coulomb force | ❌ sinc-envelope barriers block far-field attraction / repulsion (#202) |
+| de Broglie clock · spin · quarks · gravity | 🚧 not yet |
+
+Honest conclusion (`0_STATUS.md`): the scalar monochromatic model shows the *mechanism*
+(lock-in) but not the *selectivity* (why K = 10, not K = 3). It needs missing physics
+(variable λ, spin, non-linear terms). Deep dives:
+[`research/0_OVERVIEW.md`](research/0_OVERVIEW.md),
+[`research/0_STATUS.md`](research/0_STATUS.md) (honest blockers),
+[`research/0_ROADMAP.md`](research/0_ROADMAP.md).
+
+## Roadmap
+
+| Next | What lands |
+| --- | --- |
+| Magic-number stability | stabilize K = 2, 8, 10 (the electron tetrahedron) under perturbation |
+| Variable λ(r) | Yee-Hauger wavelength shells to fix the non-node pair distances in K = 10 |
+| Non-linear ψ³ | Smoliński soliton / Lagrangian stabilizer |
+| Flux-based Coulomb | `S = −c²·ψ·∇ψ` as the far-field force candidate; 3D flux integration |
+| Vector successor | the L→T spin + far-field EM route moves to M4 (the vector engine) |
+
+## Help Wanted
+
+| You can contribute | How |
+| --- | --- |
+| A K-selectivity mechanism | make K = 10 uniquely stable under perturbation (variable λ, ψ³, volume-integrated ∇E) |
+| A far-field Coulomb test | a flux-based force that survives the sinc envelope |
+| An independent reproduction | re-run the lock-in / annihilation configs and confirm pass / fail |
+| A documented negative | a runnable "this does not work, here is why" is as valuable as a positive |
+
+Flow: open an issue or discussion → fork → branch → PR with a DCO sign-off
+(`git commit -s`), under Apache 2.0. See [`../../../MODELS.md`](../../../MODELS.md)
+§ Contributing, [`../../../ONBOARDING_MODELS.md`](../../../ONBOARDING_MODELS.md),
+[`../../../CONTRIBUTING.md`](../../../CONTRIBUTING.md). Model discussion runs in the
+Models-of-Particles group.

--- a/openwave/xperiments/m4_ewt/__M4_model_briefing.md
+++ b/openwave/xperiments/m4_ewt/__M4_model_briefing.md
@@ -1,0 +1,89 @@
+# M4 EWT (Energy Wave Theory): Model Briefing
+
+> **What M4 brings.** Jeff Yee's Energy Wave Theory as a live vector-field non-linear PDE
+> engine: the successor to M3's scalar core, carrying EWT's analytic wave constants +
+> equations into a time-integrated solver. The substrate upgrade is complete; the
+> electron-soliton search is the live open work. It shares the "EWT (M4)"
+> [`MODELS.md`](../../../MODELS.md) column with M3.
+
+## Identity
+
+| Field | Value |
+| --- | --- |
+| Model ID | M4 |
+| Name | EWT (Energy Wave Theory) |
+| Author | Jeff Yee, built on Milo Wolff + Gabriel LaFreniere pioneer work |
+| Extension | Łukasz Smoliński (ψ³ soliton stabilizer, the 1-3-6 arrangement) |
+| Relationship | the vector-PDE successor to M3 (Wolff-LaFreniere scalar); same EWT family, shares the coverage column (see [`../m3_wolff_lafreniere/__M3_model_briefing.md`](../m3_wolff_lafreniere/__M3_model_briefing.md)) |
+| Primary sources | Yee energywavetheory.com papers (01-10 + supplements); Smoliński soliton paper (`theory/`) |
+| In-repo | `medium.py` + `particle.py` + `wave_engine.py` + `force_motion.py` + `_launcher.py`; `research/M4_engine_upgrade.md`; validation record under `../m3_wolff_lafreniere/research/` |
+
+## Model Profile (what it brings, short form)
+
+| Attribute | M4 |
+| --- | --- |
+| Substrate | indexed cubic voxel grid (attometer f32); 3-component displacement field ψ (triple-buffer leapfrog) |
+| Particle | a WaveCenter: a localized wave-deflector that emits spherical waves and responds to energy gradients; neutrino = K = 1 seed |
+| Approach | EWT wave constants + equations: non-linear vector wave PDE `∂²ψ/∂t² = c²∇²ψ − dV(ψ)`; energy `E = ρV(fA)²`; force `F = −∇E` |
+| Charge | phase offset (0 = electron, π = positron), imposed not emergent |
+| V(ψ) modes | linear / cubic / saturating / double-well (swappable) |
+| Free parameters | EWT analytic wave constants (A, λ, f, ρ, c) + electron K = 10, outer-shell Oe, orbital gλ |
+| Anchor | electron (K = 10 tetrahedron), neutrino (K = 1 seed); constants calibrated to measured electron radius / energy / mass |
+
+## Field Configuration of Particles
+
+Same particle picture as M3 (the EWT family), now on a vector substrate. All configurations
+use **standing-wave interference, not topology** (no winding number, no vortex):
+
+| Particle | Field configuration in M4 | Topological vortex? |
+| --- | --- | --- |
+| Electron / positron | K = 10 "1-3-6 tetrahedron" of in-phase wave-centers; positron = phase π | ❌ standing wave |
+| Electron neutrino | K = 1 fundamental wave-center seed | ❌ standing wave |
+| Annihilation pair | two opposite-phase WCs, head-on | ❌ |
+
+The vector engine adds the machinery (L / T split, swappable `V(ψ)`) intended to make
+selectivity and far-field EM *emerge*, but the electron-soliton core is not yet obtained.
+
+## Implementation Status
+
+The EWT family shares one MODELS.md column, "EWT (M4)": **0 ✅, 8 ⚠️, 3 ❌, 10 🚧** (of 21).
+The validation record is authored on the M3 scalar engine; M4 is the vector-PDE successor
+whose in-sim validation is in progress. The engine substrate upgrade (P0-P4) is complete;
+zero cells are yet fully validated in-platform.
+
+| Sector | Status |
+| --- | --- |
+| Vector-PDE substrate | ✅ built + runs (medium, leapfrog PDE, swappable `V(ψ)`, WC modes, `F = −∇E`, annihilation detection) |
+| Electron mass | ⚠️ analytic EWT values, not in-sim dynamics |
+| Charge quantization | ❌ imposed via `cos(offset)` (#203) |
+| Lepton K-selectivity | ❌ all K = 2..10 equally stable at perfect placement (#201) |
+| Coulomb far-field | ❌ needs the L / T divergence-curl split (#202) |
+| Soliton core / oscillon | 🚧 not yet obtained (pure cubic collapses; saturating quintic does not arrest at CFL dt) |
+
+Deep dives: [`research/M4_engine_upgrade.md`](research/M4_engine_upgrade.md); the shared EWT
+record under
+[`../m3_wolff_lafreniere/research/0_STATUS.md`](../m3_wolff_lafreniere/research/0_STATUS.md).
+
+## Roadmap
+
+| Next | What lands |
+| --- | --- |
+| Electron soliton (#201) | the oscillon route: localized seed + sub-CFL dt + mass term |
+| Smoliński ψ³ stabilizer | coupling γ ≈ 2.41e4 from BCC geometry (γ = 8π⁷); verify the 1-3-6 stability postulate numerically |
+| Emergent Coulomb (#202) | add the L / T divergence-curl split for far-field EM |
+| Absorbing boundary | replace the Dirichlet reflections that pollute the soliton search |
+
+## Help Wanted
+
+| You can contribute | How |
+| --- | --- |
+| Land the electron oscillon | find a localized, stable soliton core in the vector PDE (the headline open problem) |
+| Implement the L / T split | unlock emergent Coulomb (#202) |
+| Verify the Smoliński stabilizer | test whether ψ³ with γ = 8π⁷ holds the 1-3-6 arrangement |
+| A documented negative | a runnable "this does not work, here is why" counts as much as a positive |
+
+Flow: open an issue or discussion → fork → branch → PR with a DCO sign-off
+(`git commit -s`), under Apache 2.0. See [`../../../MODELS.md`](../../../MODELS.md)
+§ Contributing, [`../../../ONBOARDING_MODELS.md`](../../../ONBOARDING_MODELS.md),
+[`../../../CONTRIBUTING.md`](../../../CONTRIBUTING.md). Model discussion runs in the
+Models-of-Particles group.

--- a/openwave/xperiments/m5_liquid_crystal/__M5_model_briefing.md
+++ b/openwave/xperiments/m5_liquid_crystal/__M5_model_briefing.md
@@ -1,0 +1,109 @@
+# M5 Liquid Crystal (LC): Model Briefing
+
+> **What M5 brings.** Particles as topological defects of a Landau-de Gennes matrix
+> field: the electron is a biaxial hedgehog whose de Broglie clock is the
+> energy-minimizing state, charge is the defect's topological winding, and the four
+> forces plus gravity emerge from the geometry of the same field. It is OpenWave's
+> most-validated model (16 of 21 [`MODELS.md`](../../../MODELS.md) cells).
+
+## Identity
+
+| Field | Value |
+| --- | --- |
+| Model ID | M5 |
+| Name | Liquid Crystal (LC) |
+| Author | Jarek Duda (Jagiellonian University, Kraków) |
+| Key inputs | Manfried Faber (TU Wien) core regularization; framework exchange with Robert Close (Clark College) + Jeff Yee |
+| Lineage | Landau-de Gennes nematics + Skyrme term + Einstein teleparallel gravity |
+| Primary sources | Duda arXiv:2501.04036 (time crystal), arXiv:2108.07896 (superfluid / KG-around-hedgehog); Faber arXiv:2201.13262, Faber & Golubich arXiv:2604.12021 |
+| In-repo | `medium.py` + `engine1-4` + `_launcher.py` (production); `research/sandbox_v1..v11` (headless); [`__M5_course.md`](__M5_course.md) (intuition) |
+
+## Model Profile (what it brings, short form)
+
+| Attribute | M5 |
+| --- | --- |
+| Substrate | symmetric matrix field `M = O·D·Oᵀ` (LdG order parameter, 6 DOF) on a 3D/4D lattice |
+| Vacuum | preferred shape `D = diag(g, 1, δ, 0)` |
+| Particle | topological defect of `M` (biaxial hedgehog / disclination) |
+| Charge | integer winding of the director (Gauss-Bonnet), `\|Q\| = 1`, additive |
+| Derrick escape | time-periodic resonance (no static soliton; the stable object is 4D) |
+| de Broglie clock | bounded, self-starting, frequency-rigid time crystal = the energy-minimizing state |
+| EM | Maxwell from tilts of the 1-axis (two independent routes, at c) |
+| Quantum | Klein-Gordon from biaxial twist, mass geometric (no added mass term) |
+| Gravity | boost of the 4×4 time axis → gravitoelectromagnetism (GEM) |
+| Free parameters | δ (quantum phase), g (time/gravity axis), 1-2 LdG coeffs, boost b; calibration knobs: Faber r₀ (mass), Coulomb units |
+| Lab anchor | hopfions/skyrmions in real media (Liu et al. 2026, Nature Physics); pilot-wave droplets (Bush-Couder) |
+| Formal artifacts | every MODELS.md cell backed by a runnable script + note; negatives preserved (M5.2, M5.7) |
+| Next falsifier | g-factor ≈ 2 (order confirmed), the absolute-ω calibration chain, neutrino δ_CP = 180° (JUNO/DUNE) |
+
+## Field Configuration of Particles
+
+Standing demand of any particle model: *state the field configuration of each
+particle, and say whether it uses topological vortices.* M5's answers:
+
+| Particle | Field configuration in M5 | Topological vortex? |
+| --- | --- | --- |
+| Electron | biaxial hedgehog defect of `M`, winding `Q = -1`, with internal de Broglie clock | ✅ disclination hedgehog |
+| Positron | the `Q → -Q` reflected defect | ✅ |
+| Photon / EM wave | propagating tilt mode of the 1-axis (at c) | ❌ (radiation, not a defect) |
+| Neutrinos | light, charge-0 loop of quark string; flavour = SO(3) spatial rotation | ✅ loop |
+| Quarks | fractional-charge segment of a 1D quark string (fraction-of-π rotation) | ✅ string |
+| Baryons / mesons | knots of quark strings (baryon = simplest knot; pion = twist / reconnection) | ✅ knot |
+
+The de Broglie clock is *derived*, not assumed: the Zitterbewegung frequency is the one
+that minimizes the field energy (M5.8), exactly the "preferred time derivative". Neutrino mixing (PMNS, δ_CP) falls out of the SO(3) flavour rotation, a
+testable parameter reachable in the model that mainstream physics reaches only through
+large neutrino experiments.
+
+## Implementation Status
+
+16 of 21 MODELS.md criteria carried (8 ✅ validated in-platform, 8 ⚠️ partial), 0 ❌,
+5 🚧 planned. It is the most-validated column in the coverage matrix. Phases M5.0 → M5.11
+complete.
+
+| Sector | Status |
+| --- | --- |
+| Electron (4 observables) | ✅ mass (Faber r₀ → 0.511 MeV), charge (winding), μ + spin, spin-½ (apolar 720°) |
+| Coulomb 1/r | ✅ R² = 0.978 between two hedgehogs (pure topology) |
+| Maxwell EM | ✅ recovered two routes (hydrodynamic + Faber curvature) |
+| Klein-Gordon (QM) | ✅ geometric mass from biaxial twist (Fig 9) |
+| de Broglie clock | ✅ bounded self-starting time crystal; ZBW scale recovered to ~13% (geo-mean of energy + length anchors) |
+| Neutrino mixing | ⚠️ PMNS from SO(3): tri-bimaximal + δ_CP ≈ 180° parameter-free; θ₁₃ ≈ 8.5° = the SO(3)-breaking |
+| Lepton mass spectrum | ⚠️ mass law `E ∝ Λ³` fixed; the 1 : 5.9 : 15.1 hierarchy origin open |
+| Gravity | ⚠️ GEM ∝ (b·g)² measured (boost-tilt route); dynamical metric not implemented |
+| Strong / weak | ⚠️ short-range running-coupling onset ✅; Cornell confinement + SU(2) chiral open |
+| Quarks · baryons · mesons · orbital quantization | 🚧 planned (15a composite-particles stage) |
+
+Deep dives: [`research/99_summary_report.md`](research/99_summary_report.md) (results of
+record), [`research/0b_M5_roadmap.md`](research/0b_M5_roadmap.md) (full program),
+[`research/0b_question_tracker.md`](research/0b_question_tracker.md) (open questions).
+
+## Roadmap
+
+| Next | What lands |
+| --- | --- |
+| Lepton hierarchy origin (#200) | why the eigenvalue ratios give 1 : 5.9 : 15.1 (the mass law `E ∝ Λ³` is already fixed) |
+| Absolute-ω calibration (#220) | close the ZBW scale from a mass-family test + the Coulomb-unit map |
+| Neutrino field follow-up (#200) | the charged-lepton second-rotation matrix behind θ₁₃ |
+| Quarks / hadrons (15a) | Cornell confinement via 1D vortex string; baryons / mesons as knots |
+| Weak force | a clean SU(2) chiral reconnection mechanism (currently sketched) |
+| Orbital quantization | pilot-wave standing-wave resonance around the electron clock |
+
+## Help Wanted
+
+M5 is an open column in an open arena. Anyone can extend it, and a documented *negative*
+(a runnable script showing "this doesn't work, here's why") counts as much as a positive.
+
+| You can contribute | How |
+| --- | --- |
+| A new validation of an M5 cell | runnable script + short note, pass/fail against the shared criteria |
+| A harder falsifier | pick an open ⚠️ / 🚧 cell (hierarchy origin, weak force, quarks) |
+| A rival field configuration | propose an alternative ansatz for a particle, test it head-to-head |
+| A whole new model | a new `openwave/xperiments/<model>/` column, same shared criteria |
+
+Flow: open an issue or discussion → fork → branch → PR with a DCO sign-off
+(`git commit -s`), under Apache 2.0. Light review checks only reproducibility + honest
+documentation, not orthodoxy. Start here: [`../../../MODELS.md`](../../../MODELS.md)
+§ Contributing, [`../../../ONBOARDING_MODELS.md`](../../../ONBOARDING_MODELS.md),
+[`../../../CONTRIBUTING.md`](../../../CONTRIBUTING.md). Model discussion runs in the
+Models-of-Particles group.

--- a/openwave/xperiments/m6_ouroboros/__M6_model_briefing.md
+++ b/openwave/xperiments/m6_ouroboros/__M6_model_briefing.md
@@ -1,0 +1,106 @@
+# M6 Ouroboros: Model Briefing
+
+> **What M6 brings.** A classical two-vector-field theory where every particle is a knotted,
+> time-periodic soliton (a "chaoiton") whose integer Chern-Simons / Hopf linking number *is*
+> electric charge, reproducing the electron, the lepton spectrum, and a sub-MeV dark-matter
+> candidate from one Lagrangian. It is a published, externally-cited credibility anchor,
+> currently on permanent hold at the sandbox level.
+
+## Identity
+
+| Field | Value |
+| --- | --- |
+| Model ID | M6 |
+| Name | Ouroboros (Chaoiton framework) |
+| Author | Paul J. Werbos (NSF, retired) |
+| Collaboration | AI co-authorship disclosed on the papers: DeepSeek + Claude (Sonnet 4.6, Code Opus 4.7); OpenWave contributed the neutral-chaoiton BVP profile + scaling symmetry |
+| Lineage | Schwinger 1969 dyons + Maxwell extension (toroidal-poloidal mutual confinement); shares the Schwinger ancestor with M5 |
+| Primary sources | [`research/0d_canonical.md`](research/0d_canonical.md); Werbos Zenodo 20030162 (chaoitons), 20296060 (Lean Hopf proof), 20350105 (DM paper v2) |
+| In-repo | `research/` + `theory/` + `research/sandbox_v8..v11` scripts (sandbox-only; no Taichi production port) |
+
+## Model Profile (what it brings, short form)
+
+| Attribute | M6 |
+| --- | --- |
+| Substrate | two coupled Lorenz-constrained vector fields `A_μ, J_μ` on Minkowski (−,+,+,+) |
+| Lagrangian | `L = −¼F·F − ¼G·G + m_J² A·J − f(J·J)`, `f(s) = (g/4)s²` (F = dA, G = dJ) |
+| Particle | chaoiton = localized time-periodic soliton; charge = mutual Chern-Simons linking `Q_CS` (= Hopf invariant) |
+| Derrick escape | time-periodicity / oscillation (the "third escape") |
+| EM | `A_μ` IS the EM 4-potential; Maxwell exact in the J→0 linear limit |
+| Electron benchmark | `H/Q = 1.6969` (0.090% at g = 1, ω = 1) |
+| Free parameters | 3 claimed (g, λ, ω); the neutral-sector exact scaling closes the (g, λ) plane → `m_J` parameter-free |
+| Formal artifacts | Lean 4 proofs (linking-number quantization Zenodo 20296060, mountain-pass existence, power counting) |
+| Solve method | 1D radial ODE / BVP (scipy), sandbox-only |
+| Next falsifier | sub-MeV direct-detection; six-peak Gaia-stream annual modulation of the J-field flux; NEGF vertex check |
+
+## Field Configuration of Particles
+
+Duda's standing demand of any particle model: *state the field configuration of each
+particle, and say whether it uses topological vortices.* M6's answers:
+
+| Particle | Field configuration in M6 | Topological vortex? |
+| --- | --- | --- |
+| Electron | charged chaoiton, `Q_CS = +1`, ω = 1 → `H/Q = 1.6969` | ✅ knot (linking) |
+| Positron | `Q_CS = -1` (opposite linking sign) | ✅ |
+| Muon / tau | ω-harmonics (12.82 → 0.80%, 50.0 → 6.47%) | ✅ |
+| Pion+ (candidate) | charged chaoiton at ω = 15.0 → 3.25% | ✅ |
+| Neutral chaoiton (DM) | `Q_CS = 0`, l = 1 p-wave → m_χ = 0.460 MeV, m_J = 0.6184 MeV, C = 770 MeV·fm | ✅ neutral knot |
+
+Honest caveat on Duda's test: the clock is *built into* the `e^{iωt}` ansatz (assumed, not
+yet derived as the energy-minimizer), and no discrete-spectrum mechanism selects the lepton
+ω values (every ω in 1-60 localizes equally). Charge quantization is Lean-proved plus
+author-claimed, not yet re-derived in-platform.
+
+## Implementation Status
+
+9 of 21 MODELS.md criteria carried (4 ✅ validated in-platform, 5 ⚠️ partial), 0 ❌,
+12 🚧 planned. All results are sandbox / 1D radial BVP; there is no Taichi production port
+(Stage-2 NO-GO → permanent hold). The dark-matter paper (ApJ-targeted, Zenodo 20350105 v2)
+uses OpenWave's numbers verbatim and is M6's credibility anchor.
+
+| Sector | Status |
+| --- | --- |
+| Electron rest mass | ✅ `H/Q = 1.6969` (0.090%) |
+| Particle stability | ✅ neutral BVP ground state (K₁ tail, zero sign changes) |
+| Dark-matter candidate | ✅ neutral chaoiton m_χ = 0.460 MeV, parameter-free m_J |
+| Maxwell EM | ✅ `A_μ` is the 4-potential by construction |
+| Charge quantization | ⚠️ Lean-proved + author claim, not re-derived in-platform |
+| de Broglie clock | ⚠️ built into the ansatz, not emergent |
+| Lepton spectrum | ⚠️ μ / τ fit at chosen harmonics; no ω-selection mechanism |
+| Magnetic moment · spin · quarks · gravity · weak | 🚧 not addressed / paper-level |
+
+Deep dives: [`research/0d_canonical.md`](research/0d_canonical.md) (canonical numerical
+spec), [`research/0b_M6_roadmap.md`](research/0b_M6_roadmap.md),
+[`research/0b_question_tracker.md`](research/0b_question_tracker.md),
+[`research/0e_dm_paper_review.md`](research/0e_dm_paper_review.md).
+
+## Roadmap
+
+Status: **permanent hold**. Stage-1 is a strong pass at the sandbox level; Stage-2 (the
+Taichi production port) is a NO-GO unless a trigger lands. The full-3D route M6 never took is
+picked up by **M7 HydroBoros**, which carries M6's Lagrangian, `m_J`, `g`, and the `H/Q`
+benchmark onto a 3D lattice (see [`../m7_hydroboros/__M7_model_briefing.md`](../m7_hydroboros/__M7_model_briefing.md)).
+
+| Next | What lands |
+| --- | --- |
+| Author's near-term tests | NEGF vertex check; sub-MeV searches; six-peak Gaia-stream annual modulation |
+| Discrete-ω mechanism | find what selects the lepton ω values (the key open question) |
+| QCD reconciliation | the 3-chaoiton proton (Schwinger H-particle); active neutrinos |
+| Full-3D continuation | M7 HydroBoros (above) |
+
+## Help Wanted
+
+M6 is on hold but fully reproducible from the canonical spec. Contributions welcome.
+
+| You can contribute | How |
+| --- | --- |
+| A full-3D validation | the biggest open gap: run the chaoiton on a lattice (M7's program) |
+| A discrete-ω mechanism | find what selects the lepton ω values |
+| An independent re-derivation | reproduce `H/Q` or the DM inputs from [`research/0d_canonical.md`](research/0d_canonical.md) |
+| A falsifier test | the Gaia-stream modulation or a sub-MeV direct-detection comparison |
+
+Flow: open an issue or discussion → fork → branch → PR with a DCO sign-off
+(`git commit -s`), under Apache 2.0. See [`../../../MODELS.md`](../../../MODELS.md)
+§ Contributing, [`../../../ONBOARDING_MODELS.md`](../../../ONBOARDING_MODELS.md),
+[`../../../CONTRIBUTING.md`](../../../CONTRIBUTING.md). Model discussion runs in the
+Models-of-Particles group.

--- a/openwave/xperiments/m7_hydroboros/__M7_model_briefing.md
+++ b/openwave/xperiments/m7_hydroboros/__M7_model_briefing.md
@@ -1,0 +1,89 @@
+# M7 HydroBoros: Model Briefing
+
+> **What M7 brings.** The rigorous full-3D-PDE toroidal Beltrami electron that neither parent
+> built: it fuses Fleury's toroidal-EM electron (analytic) with Werbos's Ouroboros
+> self-confinement (1D radial) on OpenWave's M5-proven Taichi lattice, so the electron's
+> field configuration is both *specified* and *earned* as the energy-minimizer. It is
+> pre-implementation (planning stage); its [`MODELS.md`](../../../MODELS.md) column is the
+> M7.7 milestone.
+
+## Identity
+
+| Field | Value |
+| --- | --- |
+| Model ID | M7 |
+| Name | HydroBoros (Hydrodynamics + Ouroboros; evokes the Hydra water-snake) |
+| Author | Marc Fleury (toroidal-EM electron) + Paul Werbos (Ouroboros / M6): the two physics parents |
+| Blend | Fleury's toroidal EM electron (arXiv:2510.22384) fused with Werbos's Ouroboros self-confinement (M6) |
+| Lineage | force-free / Beltrami (Trkalian → variable-λ) + knotted-EM / Clebsch + Faber geometric soliton |
+| Primary sources | Fleury / dos Santos arXiv:2510.22384; Werbos M6; Faber arXiv:2201.13262 + Faber & Golubich arXiv:2604.12021; Sato-Yamada arXiv:1809.03136; Ceperley; Pisello 1977 |
+| In-repo | [`research/0a_implementation_plan.md`](research/0a_implementation_plan.md) (master plan); `theory/` (52-PDF electron-Beltrami corpus + notes); `images/` icon |
+
+## Model Profile (what it brings, short form)
+
+| Attribute | M7 |
+| --- | --- |
+| Substrate | A-primary ontology; leading candidate = the Ouroboros doublet `(A_μ, J_μ)` read via Riemann-Silberstein (diagnostic); target manifold S² / S³ open (Q1) |
+| Particle | electron = self-linked toroidal Beltrami vortex |
+| Charge | variable-λ Beltrami divergence `∇·F`, unified with Chern-Simons linking / helicity `∫A·B` |
+| Derrick escape | Faddeev-Niemi 4th-order stabilizer (outward pressure balancing collapse) |
+| Energy functional | Maxwell / fluid kinetic (Fleury) + 4th-order (Faddeev-Niemi) + Ouroboros confinement `m_J²A·J − f(J·J)` (Werbos) |
+| Solve method | Taichi reverse-mode AD gradient (vs numpy FD to ~1e-13) + FIRE / L-BFGS relaxation + constrained Minkowski leapfrog; inherits the M5.11 method |
+| Free parameters | `m_J`, `g` (from M6, canonical g = 1); `κ` (4th-order, Q2); `λ(x)` profile (Q7) |
+| Reproduction targets | Fleury `U ≈ 0.795 m_e c²`, `ω = 2c/R₀`; M6 `H/Q = 1.6969` (in full 3D); Faber & Golubich α⁻¹ ≈ 137 |
+
+## Field Configuration of Particles
+
+The electron's field configuration *is* the self-linked toroidal Beltrami vortex (a
+topological vortex).
+
+| Test | M7's answer | Phase |
+| --- | --- | --- |
+| Coulomb | two charge configs → read the `1/r` interaction energy `E(d)` | M7.4 (single-charge `1/r`) + M7.6 (two-charge `E(d) ~ 1/d`) |
+| Clock | the de Broglie frequency = the energy-minimizing one | M7.5 (= the M5.8 mechanism) |
+
+Other particles ride the same substrate later: the neutral knot = dark matter (M7.13), the
+lepton / neutrino family (M7.12), quarks / baryons / mesons (M7.14).
+
+## Implementation Status
+
+**Pre-implementation / planning stage.** No sandbox runs yet (`research/sandbox_v1` is an
+empty stub), and there is no MODELS.md column yet (adding it is the M7.7 milestone). The
+master plan is complete and the 52-PDF Beltrami theory corpus is assembled. The decisive
+credibility gates are M7.1-M7.3: reproduce *both* parents (Fleury's torus and M6's `H/Q`)
+from one lattice code, then earn the new physics (the charged variable-λ soliton) at M7.4.
+
+## Roadmap
+
+Three arcs, phases M7.1 → M7.14 (full detail in
+[`research/0a_implementation_plan.md`](research/0a_implementation_plan.md) § 6):
+
+| Arc | Phases | What lands |
+| --- | --- | --- |
+| A , electron + the column | M7.1-M7.7 | infra → reproduce Fleury → reproduce M6 in 3D → charged soliton (constant-λ → variable-λ, the new physics) + Coulomb → clock + stability → observables → consolidate the M7 column (milestone) |
+| B , forces + sectors | M7.8-M7.13 | magnetic, gravity (hard), nuclear (strong / weak), antimatter / annihilation, lepton + neutrino family, dark matter |
+| C , composites | M7.14 | quarks, baryons, mesons, orbital quantization |
+
+Open questions Q1-Q7: substrate + target manifold (Q1), the 4th-order form + κ (Q2), whether
+divergence-charge and linking-charge are forced equal (Q3), whether variable-λ fields still
+hold clean knots (Q5), and the `λ(x)` charge-carrying ansatz (Q7, the core of M7.4).
+
+## Help Wanted
+
+M7 is the newest and most open program, actively recruiting. It is the natural home for the
+hydrodynamics / Beltrami and toroidal-electron communities.
+
+| You can contribute | How |
+| --- | --- |
+| Build a phase | pick a sandbox phase (M7.1 infra, M7.2 Fleury reproduction, ...) and land its gate |
+| Bring Beltrami expertise | the variable-λ (charge-carrying) construction is the research core (the Spanish Beltrami school is being invited) |
+| Contribute a source or seeder | knotted-EM / Bateman / Trkalian seed generators |
+| Answer an open question | Q1-Q7, especially the substrate manifold (S² vs S³) and the `λ(x)` profile |
+
+Flow: open an issue or discussion → fork → branch → PR with a DCO sign-off
+(`git commit -s`), under Apache 2.0. New-model governance: open an issue first so a
+maintainer adds the column at the M7.7 milestone. See
+[`../../../MODELS.md`](../../../MODELS.md) § Contributing,
+[`../../../ONBOARDING_MODELS.md`](../../../ONBOARDING_MODELS.md),
+[`../../../CONTRIBUTING.md`](../../../CONTRIBUTING.md). Model discussion runs in the
+Models-of-Particles group.

--- a/openwave/xperiments/m7_hydroboros/research/0a_implementation_plan.md
+++ b/openwave/xperiments/m7_hydroboros/research/0a_implementation_plan.md
@@ -28,13 +28,14 @@
 | --- | --- | --- | --- | --- |
 | **Fleury** (hydrodynamics school), [arXiv:2510.22384](https://arxiv.org/abs/2510.22384) | EM field `E, B` confined to a torus | closed-form **analytic** ansatz + Heaviside mask | `ρ = ∇·E` (geometric / divergence charge) | physics parent; limit: mask unphysical at boundary, energy `0.795 m_e c²`, **no dynamics/PDE** |
 | **Werbos Ouroboros** (M6), [`0d_canonical.md`](../../m6_ouroboros/research/0d_canonical.md) | **double vector field** `(A_μ, J_μ)` | **reduced 1D ODE / BVP** (cylindrical `(α,β)`; spherical `l=1`) | `Q_CS` = Chern-Simons **linking** number | physics parent; limit: never a full **3D** field, electron only a radial profile (`H/Q = 1.6969`) |
-| **M5** (Liquid Crystal, Duda) , the **method + rigor** source | 3×3 / 4×4 tensor field `M = ODO^T` | **full 3D Taichi-AD lattice + FIRE / L-BFGS minimizer** (M5.11) | topological winding (Gauss-Bonnet integer) | M7 borrows the **method + engine + workflow + physics primitives**, not the substrate |
 
 The honest gap the two physics parents share: **neither has ever been evolved as a full 3D nonlinear
 PDE on a lattice.** Fleury is analytic; M6 is a 1D radial reduction. That is exactly the gap M5.11
 closed for the tensor model (Taichi-AD lattice + FIRE / L-BFGS minimizer, reproduce Faber's electron
 from the relaxed 3D field). **M7's contribution is to build the rigorous 3D PDE simulation neither
 parent did**, with the toroidal vortex as the soliton sector.
+
+**M5 as a reference** (Liquid Crystal, Duda) , the **method + rigor** source | 3×3 / 4×4 tensor field `M = ODO^T` | **full 3D Taichi-AD lattice + FIRE / L-BFGS minimizer** (M5.11) | topological winding (Gauss-Bonnet integer) | M7 borrows the **method + engine + workflow + physics primitives**, not the substrate
 
 **M5 is the third source , for its proven method, not its substrate.** M7 is built on OpenWave's
 M5-validated lattice + energy-minimizer and inherits M5's physics primitives (the **4th-order term
@@ -321,13 +322,12 @@ column exists in MODELS.md.** Note: **Coulomb rides with the electron**, not as 
 once the divergence charge `∇·F` exists (M7.4), its `1/r` field is immediate (Gauss's law), and the
 two-body `E(d) ~ 1/d` is confirmed at M7.6, exactly as M5 got Coulomb in its first `m5_1` milestone.
 
-**Duda's prescription (Jarek Duda, 2026-06-29 models-of-particles thread; Ouroboros #247).** Duda's
-standing demand of any particle-model framework: *specify the field configuration of each particle*
+**Prescription (Jarek Duda, 2026-06-29 models-of-particles thread; Ouroboros #247).** Standing demand of any particle-model framework: *specify the field configuration of each particle*
 (electron, neutrino, photon, mesons, baryons), and *does it use topological vortices?* HydroBoros
 answers head-on , the electron's field configuration **is** the self-linked toroidal Beltrami vortex
 (§ 0), a topological vortex. His two concrete tests map onto the plan exactly:
 
-| Duda's test | What it prescribes | M7 phase |
+| Test | What it prescribes | M7 phase |
 | --- | --- | --- |
 | **Coulomb** | assume **two** charge field-configurations, read the `1/r` interaction energy `E(d)` | M7.4 (single-charge `1/r`) + M7.6 (two-charge `E(d)~1/d`), the M5 `m5_1` way |
 | **the clock** | the de Broglie frequency is the one that **minimizes the energy** | M7.5 (clock + stability), = the M5.8 energy-minimizing-clock mechanism |


### PR DESCRIPTION
Introduce one-page briefing documents for every model and wave library, covering identity, field configuration, current status, roadmap, and contribution entry points. Update MODELS.md and ONBOARDING_MODELS.md to surface these briefings as the new front door for model evaluation, remove the outdated models image from WELCOME.md, and align the M7 implementation plan language with the new briefing structure.