### PR TITLE
Refine M5 vacuum note and M7 references

### DIFF
--- a/openwave/xperiments/m5_liquid_crystal/__M5_model_briefing.md
+++ b/openwave/xperiments/m5_liquid_crystal/__M5_model_briefing.md
@@ -23,7 +23,7 @@
 | Attribute | M5 |
 | --- | --- |
 | Substrate | `M`, a 4×4 real symmetric tensor field (`M = O·D·Oᵀ`); the eigenspectrum `D` is fixed only in vacuum (the potential minimum) |
-| Vacuum | the preferred shape `D = diag(g, 1, δ, 0)`, the minimum of the potential |
+| Vacuum | the preferred shape `D = diag(g, 1, δ, 0)`, the minimum of the potential, its dynamics unifies EM+QM+GEM |
 | Particle | defect of `M`: a point-like topological charge (elementary electric charge), a topological vortex line (quark string) |
 | Charge | integer winding of the director (Gauss-Bonnet), `\|Q\| = ±1`, additive |
 | Derrick escape | time-periodic resonance (no static soliton; the stable object is 4D) |

--- a/openwave/xperiments/m7_hydroboros/research/m7_background.md
+++ b/openwave/xperiments/m7_hydroboros/research/m7_background.md
@@ -223,3 +223,5 @@ Solve it two ways, exactly as M5.11 does:
 - Production-engine template: [`../../m5_liquid_crystal/`](../../m5_liquid_crystal/) (`medium.py`, `engine1_seeds.py` … `_launcher.py`)
 - Comparison table (the M7 column goal): [`MODELS.md`](../../../../MODELS.md) · new-model flow [`ONBOARDING_MODELS.md`](../../../../ONBOARDING_MODELS.md), [`CONTRIBUTING.md`](../../../../CONTRIBUTING.md)
 - Model briefing stub: [`../__M7_model_briefing.md`](../__M7_model_briefing.md)
+- Question Tracker: [m7_question_tracker.md](m7_question_tracker.md)
+- Roadmap: [m7_roadmap.md](m7_roadmap.md)


### PR DESCRIPTION
Updates the M5 model briefing to clarify that vacuum dynamics are framed as unifying EM, QM, and GEM. Also extends the M7 background references with direct links to the question tracker and roadmap documents for easier navigation of ongoing work.