### PR TITLE
Bump version to 1.6.1

### DIFF
--- a/openwave/__init__.py
+++ b/openwave/__init__.py
@@ -5,4 +5,4 @@ to study particle and force emergence. GPU-accelerated.
 
 """
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "OPENWAVE"
 # - MAJOR: Breaking changes (incompatible API changes)
 # - MINOR: New features (backward-compatible)
 # - PATCH: Bug fixes (backward-compatible)
-version = "1.6.0"
+version = "1.6.1"
 
 requires-python = ">=3.12"
 


### PR DESCRIPTION
Updates the package version from 1.6.0 to 1.6.1 in both `pyproject.toml` and `openwave/__init__.py` to keep release metadata aligned.