### PR TITLE
Clarify M5.27 pilot scope and phasing

### DIFF
--- a/openwave/xperiments/m5_liquid_crystal/__M5_course.md
+++ b/openwave/xperiments/m5_liquid_crystal/__M5_course.md
@@ -1787,6 +1787,17 @@ So the "where do waves live" tension is **unique to the topological models**. M1
 The question isn't "are waves still here" — it's **which layer** they live on now that they're no
 longer the substrate.
 
+### Scope addendum (2026-07-23): the layer below the substrate
+
+The ledger below says "the substrate does not wave; the wave is downstream." That statement is
+scoped to **M5's own substrate**: the field `M` does not wave. The 2026-07-23 planning voicenotes
+(the M5.27 pilot) propose a layer BELOW that substrate: Planck-scale granule oscillations composing
+fundamental waves, with `M` as their coarse-grained order parameter. So within M5 the ledger stands
+unchanged, and the deeper-layer claim lives one level down as an **open hypothesis** (the same
+honesty grade as L1 Q9's granule-covariance reading). The M5.27 background scalar χ is the first
+in-model representative of that layer; the full frame is documented at
+[`m5_27_task_details.md § 2b`](research/tasks/m5_27_task_details.md).
+
 ### THE EMERGENCE LEDGER — what comes from where (none of it a base wave)
 
 The reconciliation: the M5 universe is an **emergence ledger**. A static substrate is *given*;

--- a/openwave/xperiments/m5_liquid_crystal/research/tasks/m5_27_task_details.md
+++ b/openwave/xperiments/m5_liquid_crystal/research/tasks/m5_27_task_details.md
@@ -25,9 +25,39 @@ The Lagrangian has been frozen since the verified-L era by design; M5.17 → M5.
 | Vacuum | χ = A·cos(ω̄t), spatially uniform: a vacuum rest-frame background oscillation |
 | Coupling | Promote the g-eigenvalue of the author's own spectrum `D = diag(g, 1, δ, 0)` to `g + κχ(x,t)`: the 4×4's time-time entry made dynamical FIRST, the (0,i) mixed block deferred. A STAGED 4×4, not an alternative to the author's 4×4 selection |
 | Economy | +1 field component vs +4 (M₀₀ + three M₀ᵢ); a standard sign-definite kinetic term, while the all-negative time-mixing curvatures ([M5.21.3](m5_21_3_task_details.md)) and the divergent regions of the author's analytical notebook live in the deferred mixed block (hypothesis, checkable against [M5.21.8](m5_21_8_task_details.md)) |
-| First observables | Lock-or-not (Arnold tongue in κ, ω̄); J and μ re-read under lock (the [M5.21.5](m5_21_5_task_details.md) protocol re-run); two-defect force under a shared background (the in-phase attraction channel); the drive-power ledger |
+| First observables | Lock-or-not (Arnold tongue in κ, ω̄); J and μ re-read under lock (the [M5.21.5](m5_21_5_task_details.md) protocol re-run); the drive-power ledger; the eigenvalue-excursion read (§ 6b U3). The two-defect force under a shared background (the in-phase attraction channel) moves to phase B (§ 2c): it needs a dynamical χ the defects can source |
+| Phasing | Phase A = prescribed uniform drive (this pilot); phase B = dynamical χ (an M5.27.x follow-on); the decision record is § 2c |
 
 The economy argument in one line: promoting M to a 4×4 spacetime tensor adds ~4 awkwardly-signed components; a scalar background adds 1. The 4×4 route's persistent trouble may simply mean the time sector wants to be a SEPARATE FIELD, not extra indices on the order parameter.
+
+## 2b. THE ONTOLOGY FRAME (open hypothesis, captured 2026-07-23 planning session)
+
+Where χ comes from, stated as a layered claim (the 2026-07-23 planning voicenotes, organized):
+
+| Layer | What it is | Owns |
+| --- | --- | --- |
+| Fundamental (intractable) | Planck-scale granules, oscillating; "the wave is a composition of that oscillation" | time itself (the oscillation IS the clock) |
+| Wave layer | the fundamental waves those oscillations compose | time / the clock; gravity = spatial gradient of clock rates; drives magnetism (director circulation) |
+| Order parameter (tractable) | the LC ellipsoid field `M`, a coarse-grained average of the layer below | electrostatics + the whole static-topological sector; "liquid crystal is a RESULT, not the substrate" |
+
+One sharpening against the record: "liquid crystal is only for electrostatics" is too narrow. The verified 3×3 stack owns the whole static-topological sector (charge quantization, spin-½, annihilation, the lepton census), not just Coulomb. The clean statement: **`M` owns everything static-topological; the wave layer owns everything the time sector failed to close.** That maps exactly onto the § 1 diagnosis (statics ✅, time sector ❌), which is why the frame fits: it says the time sector failed on `M` because time never lived in `M`. It also upgrades the § 2 economy argument from parameter-counting to structure: χ is the tractable in-model representative of the wave layer, and `M` is the order parameter of the same layer's spatial structure. Two fields because two layers.
+
+| Consistency point | Resolution on record |
+| --- | --- |
+| The course L11 emergence ledger says "the substrate does not wave; the wave is downstream", while this frame says waves are more fundamental than the LC | Not a contradiction, a scope statement: L11 is correct WITHIN M5 (the `M` field does not wave as a substrate). This frame proposes a layer BELOW M5's substrate; χ is the first in-model representative of that layer. L11 carries a dated scope addendum saying so ([`__M5_course.md § L11`](../../__M5_course.md)) |
+| This task is author-facing as a "staged 4×4" (g → g+κχ), while the frame reads it as "time from waves, not from the 4×4 matrix" | Keep the staged-4×4 frame in anything author-facing (it is the diplomatic and technically true description); the wave-layer reading is the interpretive frame, documented as an open hypothesis, the same honesty grade the course gives the granule-covariance reading (L1 Q9) |
+| The § 6 preferred-frame hazard | Reframed, not removed: if a wave layer is fundamental, a rest frame at that layer is EXPECTED, and Lorentz covariance must emerge from Doppler-consistent kinematics (the de Broglie 1924 construction, § 7). The boost test stays pre-registered |
+
+Status: open ontological hypothesis, not something the pilot asserts or tests (§ 6b U1-U2); the pilot measures what the coupled system does.
+
+## 2c. PHASING (design decision, 2026-07-23)
+
+| Phase | χ status | Scope |
+| --- | --- | --- |
+| A (this pilot) | PRESCRIBED uniform drive: χ = A·cos(ω̄t) imposed, not evolved | The lock scan (Arnold tongue), the J/μ re-read under lock, the drive-power ledger, the boost test, the eigenvalue-excursion read (§ 6b U3) |
+| B (an M5.27.x follow-on, out of pilot scope) | DYNAMICAL χ: own kinetic + potential term, defects can source it | Gravity (near-field frequency depression), the two-defect in-phase force (Bjerknes), background propagation (§ 6b U5) |
+
+The reasoning (the § 6b T1 tripwire is the decision that shapes the whole run plan): phase A prescribed-drive first keeps the pilot falsifiable with three knobs and a clean ledger, and answers the fork question (entrain vs replace vs null) before paying for a dynamical χ sector. With a dynamical χ, ω̄ stops being a free knob (it becomes the χ potential's mass parameter), the defect gains a NEW radiation channel into χ, and the energy ledger gains a sector: phase B costs are real and only worth paying on a phase-A lock. The § 5 gravity and two-defect rows therefore read as PHASE B chances; a prescribed uniform drive cannot produce them (the background is unaffected by the defects by construction).
 
 ## 3. DESIGN DECISION: ENTRAIN, not REPLACE
 
@@ -55,7 +85,7 @@ Discipline: all quantities in M5 program units; no physical constants enter the 
 
 ## 5. CHANCES BY SECTOR (pre-run assessment)
 
-The structural reason the import is attractive: each side's validated strength covers the other's recorded negative. M5's open sectors (free-clock existence, hierarchy origin, the 4×4 route, gravity) are exactly where a background wave has known mechanisms.
+The structural reason the import is attractive: each side's validated strength covers the other's recorded negative. M5's open sectors (free-clock existence, hierarchy origin, the 4×4 route, gravity) are exactly where a background wave has known mechanisms. Phase split (§ 2c): the clock, stability, and boost/de Broglie rows are phase A physics; gravity, the two-defect channel, and any near-field-modification mechanism need phase B's dynamical χ (a prescribed uniform background cannot be sourced or depressed by defects by construction).
 
 | Sector | What the background brings | Known-physics anchor | Chance |
 | --- | --- | --- | --- |
@@ -77,6 +107,29 @@ The structural reason the import is attractive: each side's validated strength c
 | Replace vs entrain | Decided upfront (§ 3): ENTRAIN. An undecided hybrid would double-count the clock energy |
 | Parameter growth | κ, A, ω̄ are new knobs; platform standards apply (derive or pre-register with search spaces, nothing tuned per observable) |
 
+## 6b. UNKNOWNS MAP + TRIPWIRES (2026-07-23 planning session)
+
+The planning-session question set, routed (machine-checkable in the pilot / author-gated / nature-gated):
+
+| # | Question | Route | What the pilot can do |
+| --- | --- | --- | --- |
+| U1 | What IS the oscillation? (what medium does χ coarse-grain?) | Nature-gated | Documented as the § 2b frame; the pilot measures what the coupled system DOES, not what χ is |
+| U2 | Are the granules tracing the ellipsoid? | Nature-gated | The course L1 Q9 covariance hypothesis, carried unchanged; untestable at pilot scope |
+| U3 | "Amplitude gives the ellipsoid its eigenvalues" | Machine-checkable ✅ | NEW OBSERVABLE: track the local eigen-spectrum excursion of `M` under drive; does drive amplitude A map monotonically onto eigenvalue excursion? Cheap to instrument; directly tests the amplitude→shape reading |
+| U4 | "The frequency is too high, so the ellipsoids gain structure" (time-averaging / scale separation) | Machine-checkable, and a design constraint | Exposes that § 5 mixes two regimes: entrainment lock needs ω̄ NEAR the intrinsic clock (Arnold tongue); Kapitza stabilization needs ω̄ FAR ABOVE it. One ω̄ scan cannot do both: the two windows are pre-registered as SEPARATE experiments (DoD 1) |
+| U5 | The relationship between ellipsoids and the propagation of their oscillations | Machine-checkable at phase B only | A prescribed uniform χ has no propagation by construction; the question is the heart of the phase B dynamical-χ scope (§ 2c) |
+| U6 | "The ellipsoid exists when multiple waves are colliding" (multi-particle dependence) | Partially machine-checkable | The two-defect shared-background test is the in-model handle (phase B); the full multi-wave-collision reading stays nature-gated |
+
+Tripwires (named before numerics; each carries its guard):
+
+| # | Tripwire | Guard |
+| --- | --- | --- |
+| T1 | Prescribed drive vs dynamical χ left undeclared: the two designs answer different questions and book energy differently | RESOLVED by § 2c: phase A prescribed, phase B dynamical, declared upfront |
+| T2 | Lock vs parametric-instability confusion: parametric driving both stabilizes AND destabilizes (the Mathieu chart has tongues of INSTABILITY). Blow-up at some (κ, ω̄) is a Mathieu instability, not a failed lock; survival is not automatically entrainment | Pre-registered discriminator: lock = phase-locked clock at zero average drive power; instability = unbounded energy growth on the ledger; neither = null |
+| T3 | Statics contamination at κ ≠ 0: the inherited ✅ sector was verified at κ = 0; a drive can shift static energies even where topology protects the invariants | Gate: re-measure the key static observables at κ ≠ 0 with the drive ON, beyond the κ = 0 regression |
+| T4 | Box-mode interference: a standing background in a finite box interacts with the box's own eigenfrequencies; an ω̄ scan shows spurious structure at box modes | Pre-compute the box spectrum; mark those frequencies before reading any Arnold tongue |
+| T5 | dt cost of the high-ω̄ (Kapitza) window: resolving ω̄ needs dt ≪ 2π/ω̄; the high-frequency window may be far more expensive than the lock window | Numerics pre-check before committing the scan budget |
+
 ## 7. ANTICIPATED OBJECTIONS (named upfront, answers on record)
 
 | Objection | Answer |
@@ -93,14 +146,14 @@ The structural reason the import is attractive: each side's validated strength c
 | The M5.21.3-close fork | This is the third branch (fixed-J reading vs T2η lift vs background scalar); the author's call |
 | [M5.21.8](m5_21_8_task_details.md) (notebook verification) | Natural companion: the § 2 economy hypothesis (the pathology lives in the mixed block) is checkable against its results |
 | [M5.23.1](m5_23_1_task_details.md) (rendering series) | Rendering proceeds regardless (sequenced BEFORE this pilot in the reordered Backlog). Note: M5.23.1 ports the fixed-J clock into production; if this pilot delivers a lock, the clock's origin story changes (a dynamically supplied J-budget vs the hand-imposed constraint), so the pilot tells us whether the port target is the final clock or the crutch |
-| Gate | Pending author go; nothing runs before it |
+| Gate | Author go ✅ granted 2026-07-22 (the 4×4 green light); runs on user "go" at its Backlog slot (after [M5.22](m5_22_task_details.md)) |
 
 ## 9. DEFINITION OF DONE (pilot scope, draft; frozen at go)
 
 | # | Item |
 | --- | --- |
-| 1 | Pre-registration lock: κ, A, ω̄ search spaces + the § 3 three-outcome table + the boost test protocol, frozen BEFORE numerics |
-| 2 | Gates: 3D regression exact on the verified-L stack at κ = 0; χ-sector energy conservation; the drive-power ledger instrumented |
-| 3 | The lock scan: defect response vs (κ, ω̄), Arnold-tongue map, regime verdict per § 3 |
-| 4 | J and μ re-read under lock (the M5.21.5 protocol) + the two-defect force under a shared background |
+| 1 | Pre-registration lock: κ, A, ω̄ search spaces, with the two ω̄ windows (lock-resonant vs Kapitza-high, § 6b U4/T2) registered as SEPARATE experiments + the § 3 three-outcome table + the boost test protocol, frozen BEFORE numerics |
+| 2 | Gates: 3D regression exact on the verified-L stack at κ = 0; χ-sector energy conservation; the drive-power ledger instrumented; the key static observables re-measured at κ ≠ 0 with the drive on (§ 6b T3); the box-mode spectrum pre-computed (§ 6b T4); the dt cost of the high-ω̄ window pre-checked (§ 6b T5) |
+| 3 | The lock scan: defect response vs (κ, ω̄), Arnold-tongue map, regime verdict per § 3 (with the § 6b T2 lock-vs-instability discriminator) |
+| 4 | J and μ re-read under lock (the M5.21.5 protocol) + the eigenvalue-excursion read (§ 6b U3). The two-defect force under a shared background is phase B scope (§ 2c), NOT in this pilot's DoD |
 | 5 | Adversarial audit (independent implementation) before anything author-facing; method note per the house standard |


### PR DESCRIPTION
Expand the M5.27 task notes with the layered ontology frame for the background scalar, split the work into prescribed-drive phase A vs dynamical-chi phase B, and tighten the pilot's observables, tripwires, and definition of done. Also add a scope note to the M5 course so the new deeper-layer hypothesis stays consistent with the existing emergence ledger.