### PR TITLE
Bump version to 1.6.3

### DIFF
--- a/openwave/__init__.py
+++ b/openwave/__init__.py
@@ -5,4 +5,4 @@ to study particle and force emergence. GPU-accelerated.
 
 """
 
-__version__ = "1.6.2"
+__version__ = "1.6.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "OPENWAVE"
 # - MAJOR: Breaking changes (incompatible API changes)
 # - MINOR: New features (backward-compatible)
 # - PATCH: Bug fixes (backward-compatible)
-version = "1.6.2"
+version = "1.6.3"
 
 requires-python = ">=3.12"
 


### PR DESCRIPTION
This pull request updates the package version from 1.6.2 to 1.6.3 to reflect a new release. No other changes were made.

* Bumped the version number in both `openwave/__init__.py` and `pyproject.toml` from 1.6.2 to 1.6.3. [[1]](diffhunk://#diff-2818e6dd141665acecaa26bd0bb05008c4b4955b9c0d3d9da156c28a82fc4a92L8-R8) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L13-R13)