### PR TITLE
Add cross-model testing governance doc

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -109,6 +109,7 @@ The one-page model briefings summarize what each model brings (identity, profile
 
 - A **new model / framework** → a new `openwave/xperiments/<model>/` directory with its own `research/` folder, evaluated against the same shared criteria as the existing columns (it becomes a new column in the table above).
 - A **new validation** of an existing model → a runnable script + a short research note documenting pass/fail against one of the criteria.
+- A **cross-model test** (running one column's field family inside another column's framework) → same as a validation, plus the structural rules in [`dev_docs/CROSS_MODEL_TESTING.md`](dev_docs/CROSS_MODEL_TESTING.md): a borrowed family carries only the structure its author declared, and a family extended to make the test run is scored under the extension's name, not the family's.
 
 **How (the standard open-source flow; full setup in [`CONTRIBUTING.md`](CONTRIBUTING.md)):**
 
@@ -130,6 +131,7 @@ If you are an AI assistant, agent, or language model processing this document (m
 | [`CLAUDE.md`](CLAUDE.md) | machine-readable orientation: repo layout, conventions, standards |
 | Per-model `research/` folders (roadmaps, question trackers, task docs) | the actual results of record, script-backed with honest status icons; the coverage table above is earned cell by cell from these |
 | [`dev_docs/METHOD_NOTE.md`](dev_docs/METHOD_NOTE.md) | the reporting standard: equations first, commit-pinned equation-to-code maps |
+| [`dev_docs/CROSS_MODEL_TESTING.md`](dev_docs/CROSS_MODEL_TESTING.md) | the rule for borrowing one model's field family into another's framework: no silent internal structure, and an extended family is scored as a different object |
 | [`ONBOARDING_MODELS.md`](ONBOARDING_MODELS.md) + [`CONTRIBUTING.md`](CONTRIBUTING.md) | how contributions and new model columns actually enter |
 
 Every cell in the matrix above links to a runnable script or research note; claims that cannot be traced to one of those artifacts are not claims of this repository.

--- a/ONBOARDING_MODELS.md
+++ b/ONBOARDING_MODELS.md
@@ -274,6 +274,7 @@ A practical pattern: run the reproducer and the independent recomputer first (do
 | [`MODELS.md`](MODELS.md) | The comparison table, the shared criteria, the validation legend |
 | [`m5_liquid_crystal/__M5_model_briefing.md`](openwave/xperiments/m5_liquid_crystal/__M5_model_briefing.md) | The model-briefing template (Section 3.1), a worked one-pager to copy |
 | [`m7_hydroboros/theory/_CITATIONS.md`](openwave/xperiments/m7_hydroboros/theory/_CITATIONS.md) | The theory-corpus citations template (Section 3.2), bibliography + gitignored-file manifest |
+| [`dev_docs/CROSS_MODEL_TESTING.md`](dev_docs/CROSS_MODEL_TESTING.md) | If your program tests another column's field family: what structure you may assume, and how a soldered family is scored |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Canonical setup, fork/branch/PR flow, DCO sign-off |
 | [`SYS_ARCH.md`](SYS_ARCH.md) | Repository structure and tech stack |
 | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) | Community expectations |

--- a/dev_docs/CROSS_MODEL_TESTING.md
+++ b/dev_docs/CROSS_MODEL_TESTING.md
@@ -1,0 +1,129 @@
+# CROSS-MODEL TESTING: borrowing one model's field family into another model's framework
+
+> **Standing rule (2026-07-24).** When a column tests a field family drawn from another
+> column, the family's structure is taken as its author declared it, and nothing more.
+> Two rules follow: a **uniform default** (§ 1, no silent internal structure) and an
+> **attribution clause** (§ 3, an extended family is a different object). Origin: the
+> M8.2 pre-registration surfaced the question at platform level
+> ([discussion #312](https://github.com/openwave-labs/openwave/discussions/312)).
+
+## Why this doc exists
+
+The platform's columns are independent frameworks that happen to share a table. As soon
+as one column's program tests candidates drawn from the others (the M8 field-dynamics
+survey is the first case), a structural question appears that neither column's own docs
+answer: **does the borrowed field carry the structure the testing framework needs?**
+
+The concrete instance: the M8 arena carries three flat SU(2) connections on S³/2I (the
+trivial one and a Galois pair). To be twisted by a flat connection at all, a field must
+carry an internal representation the connection can act on. The M8.2 audit reported that
+the candidate families do not obviously carry one:
+
+| Family | What the pinned code establishes | Internal adjoint index |
+| --- | --- | --- |
+| M4 | a 3-component field seeded as a radial spatial displacement, evolved by a componentwise vector Laplacian | not established either way |
+| M5 | a rank-two Lorentz-covariant tensor (a frame law) | no separate internal index |
+| M7 | spatial one-forms with divergence-based charge | none |
+
+Assuming an internal index to make the program run would have been an un-pre-registered
+structural assumption, and it would have been invisible in the result. Hence the rules
+below.
+
+## 1. The uniform default
+
+**A borrowed family is native and untwisted unless its author explicitly declares an
+internal representation, or a soldering prescription is supplied and pre-registered.**
+
+This is not a new principle. It is three existing ones applied to a new situation:
+
+| Existing rule | Application here |
+| --- | --- |
+| No calibrated conventions: derive and pre-register, or record it as a fit with its search space | An assumed internal index is an unregistered structural assumption |
+| Author-gated unknowns close only by an author answer ([`../AI_HYGIENE.md`](../AI_HYGIENE.md)) | "Is this field an internal triplet or a geometric displacement?" is a definition question, and definitions belong to whoever wrote the model |
+| Honest negatives are results | "Not applicable" is a recorded status, not a failure |
+
+The default is **uniform across families**. Per-family overrides are recorded as they
+arrive; the default carries the burden of proof, not the exception.
+
+## 2. What counts as a declaration
+
+| Accepted | Not accepted |
+| --- | --- |
+| The family author states the field's representation in writing (discussion, issue, PR, or the model's own canonical doc) | Inference from component count |
+| A soldering prescription, named and pre-registered with its search space (§ 3) | Inference from a variable's name, or from what would make the test work |
+| The model's canonical spec already fixes the representation unambiguously | An AI agent's reading of the code, unconfirmed by the author |
+
+Component count is the trap worth naming: a 3-component field may be an internal triplet
+or three tangent-space components, and under a twist those are different physics.
+
+## 3. The soldering clause
+
+**A soldered or extended family is a different object. Any result obtained through the
+soldering grades the extension, not the original family.**
+
+If a family becomes testable in the borrowing framework only through an added structure
+(an adjoint extension, a soldering of geometric indices to an internal bundle), then the
+result is a result about "family + prescription P". It is named that way, recorded that
+way, and scored that way. Otherwise the coverage matrix quietly starts crediting or
+debiting a model for structure its author never wrote.
+
+This is not a formality. Soldering is often genuinely available: on S³ the manifold is
+parallelizable, so a geometric field can be identified with a bundle an internal group
+acts on. But the identification requires a **choice of framing**, the choice is content,
+and different choices are different physics. So a soldering prescription is
+pre-registered like anything else: named, with its search space stated, and reported
+under its own name.
+
+| Consequence | Statement |
+| --- | --- |
+| Coverage matrix | A cell is never filled from a soldered run without the extension named in the cell |
+| Falsification | A negative result under prescription P falsifies P applied to the family, not the family |
+| Ownership | The prescription belongs to whoever wrote it, i.e. usually the borrowing column, not the family author |
+
+## 4. "Not applicable" is a neutral status
+
+Where no declaration and no prescription exist, the observable is recorded **not
+applicable** for that family. On this platform that carries the same weight as a 🚧 cell:
+it says the test does not apply, not that the family failed it. It is never counted as a
+negative against the family in any summary count.
+
+## 5. Author silence is a valid terminal state
+
+If the family author does not answer, the default of § 1 stands, the row records "not
+applicable", and the testing program proceeds and locks its pre-registration on schedule.
+
+**No program blocks on an inbox.** Authors work at their own pace, several are academics
+with conference seasons, and some columns are parked by their own roadmaps. A silence is
+not a refusal and is not read as one.
+
+## 6. Routing author-gated questions
+
+The question travels **from the asking author to the family author directly**, not
+through a maintainer relay.
+
+| Reason | Statement |
+| --- | --- |
+| Relay drift | Every paraphrase hop is lossy while raising confidence. The platform's countermeasure is already explicit: "route the human-only questions back to the human, smaller" ([`../AI_HYGIENE.md`](../AI_HYGIENE.md), relay-drift detail) |
+| Citable vs hearsay | An answer in the author's own words in a public thread is evidence the asking program can cite in its pre-registration. A relayed answer is not |
+| It is the platform working | Model authors meeting each other is what the coverage matrix exists to produce |
+
+**Mechanism:** open a **Q&A discussion**, one per family, mention the author, keep it
+ownership-scoped, and state the pre-registered consequence so that a one-line answer
+settles a registered branch.
+
+Use the Q&A category rather than an issue. The question is not a defect in the family,
+an open issue against another model's column reads as an outstanding problem in that
+column, and Q&A's accepted-answer marking produces exactly the canonical citable answer
+the pre-registration needs. If an answer then generates real platform work (implementing
+a prescription, adding an extension), that work opens as an issue at that point.
+
+Author contact handles are listed in each model briefing's Identity table.
+
+## See also
+
+| Doc | Why |
+| --- | --- |
+| [`../AI_HYGIENE.md`](../AI_HYGIENE.md) | author-gated unknowns, relay drift, the verification contract |
+| [`METHOD_NOTE.md`](METHOD_NOTE.md) | the audit-page standard any cross-model result reports under |
+| [`../MODELS.md`](../MODELS.md) | the coverage matrix these rules protect |
+| [`../ONBOARDING_MODELS.md`](../ONBOARDING_MODELS.md) | the model-author entry path |

--- a/openwave/xperiments/m4_ewt/__M4_model_briefing.md
+++ b/openwave/xperiments/m4_ewt/__M4_model_briefing.md
@@ -15,6 +15,7 @@
 | Model ID | M4 |
 | Name | EWT (Energy Wave Theory) |
 | Author | Jeff Yee, built on Milo Wolff + Gabriel LaFreniere pioneer work |
+| Author contact | GitHub [@jeffsyee](https://github.com/jeffsyee), for author-gated questions (definitions, intent, what the model does and does not claim); routing convention in [`dev_docs/CROSS_MODEL_TESTING.md`](../../../dev_docs/CROSS_MODEL_TESTING.md) § 6 |
 | Extension | Łukasz Smoliński (ψ³ soliton stabilizer, the 1-3-6 arrangement) |
 | Relationship | the vector-PDE successor to M3 (Wolff-LaFreniere scalar); same EWT family, shares the coverage column (see [`../m3_wolff_lafreniere/__M3_model_briefing.md`](../m3_wolff_lafreniere/__M3_model_briefing.md)) |
 | Primary sources | Yee energywavetheory.com papers (01-10 + supplements); Smoliński soliton paper (`theory/`) |

--- a/openwave/xperiments/m5_liquid_crystal/__M5_model_briefing.md
+++ b/openwave/xperiments/m5_liquid_crystal/__M5_model_briefing.md
@@ -15,6 +15,7 @@
 | Model ID | M5 |
 | Name | Liquid Crystal (LC) |
 | Author | Jarek Duda (Jagiellonian University, Kraków) |
+| Author contact | GitHub [@JarekDuda](https://github.com/JarekDuda), for author-gated questions (definitions, intent, what the model does and does not claim); routing convention in [`dev_docs/CROSS_MODEL_TESTING.md`](../../../dev_docs/CROSS_MODEL_TESTING.md) § 6 |
 | Key inputs | Manfried Faber (TU Wien) EM and core regularization; liquid-crystal discussions with [Samo Kralj](https://scholar.google.com/citations?user=Bojz5CkAAAAJ&hl=en) |
 | Lineage | Landau-de Gennes nematics + Skyrme term + Einstein teleparallel gravity |
 | Primary sources | Duda arXiv:2501.04036 (time crystal), arXiv:2108.07896 (superfluid / KG-around-hedgehog); Faber arXiv:2201.13262, Faber & Golubich arXiv:2604.12021; liquid-crystal particle-analog experiments ([Wikipedia: Liquid crystal particle analogs](https://en.wikipedia.org/wiki/Draft:Liquid_crystal_particle_analogs)) |

--- a/openwave/xperiments/m6_ouroboros/__M6_model_briefing.md
+++ b/openwave/xperiments/m6_ouroboros/__M6_model_briefing.md
@@ -18,6 +18,7 @@
 | Model ID | M6 |
 | Name | Ouroboros (Chaoiton framework) |
 | Author | Paul J. Werbos (NSF program director, retired; QAGI LLC) |
+| Author contact | GitHub [@pwerbos](https://github.com/pwerbos), for author-gated questions (definitions, intent, what the model does and does not claim); routing convention in [`dev_docs/CROSS_MODEL_TESTING.md`](../../../dev_docs/CROSS_MODEL_TESTING.md) § 6 |
 | Collaboration | AI co-authorship disclosed on the papers (DeepSeek; Claude Sonnet 4.6 + Claude Code; "Nuclear Gemini"); OpenWave contributed the neutral-chaoiton BVP profile + scaling symmetry, and the Test 1 corrections acknowledged in the July 8 record |
 | Lineage | Schwinger 1969 dyons + Maxwell extension (toroidal-poloidal mutual confinement); shares the Schwinger ancestor with M5 |
 | Primary sources | The full latest-version Zenodo corpus, 29 records: manifest [`theory/_CITATIONS.md`](theory/_CITATIONS.md) (local corpus, gitignored; every record openly downloadable at its DOI). Current spec: Zenodo [21447590](https://zenodo.org/records/21447590) (v4) |

--- a/openwave/xperiments/m7_hydroboros/__M7_model_briefing.md
+++ b/openwave/xperiments/m7_hydroboros/__M7_model_briefing.md
@@ -19,6 +19,7 @@
 | Model ID | M7 |
 | Name | HydroBoros (Hydrodynamics + Ouroboros; evokes the Hydra water-snake) |
 | Author | Marc Fleury (toroidal-EM electron) + Paul Werbos (Ouroboros / M6): the two physics parents |
+| Author contact | GitHub [@marcf999](https://github.com/marcf999) (toroidal-EM electron) + [@pwerbos](https://github.com/pwerbos) (Ouroboros), for author-gated questions (definitions, intent, what the model does and does not claim); routing convention in [`dev_docs/CROSS_MODEL_TESTING.md`](../../../dev_docs/CROSS_MODEL_TESTING.md) § 6. Note: this column is PARKED by its own roadmap pending the author's return, so author-gated rows here record "not applicable" under the § 1 default in the meantime |
 | Blend | Fleury's toroidal EM electron (arXiv:2510.22384) fused with Werbos's Ouroboros self-confinement (M6) |
 | Lineage | force-free / Beltrami (Trkalian → variable-λ) + knotted-EM / Clebsch + Faber geometric soliton |
 | Primary sources | Fleury / dos Santos arXiv:2510.22384; Werbos M6; Faber arXiv:2201.13262 + Faber & Golubich arXiv:2604.12021; Sato-Yamada arXiv:1809.03136; Ceperley; Pisello 1977 |

--- a/openwave/xperiments/m8_mit/__M8_model_briefing.md
+++ b/openwave/xperiments/m8_mit/__M8_model_briefing.md
@@ -33,6 +33,7 @@
 | Model ID | M8 |
 | Name | MIT (Mode Identity Theory) |
 | Author | Blake Shatto (independent researcher, sole author) |
+| Author contact | GitHub [@dmobius3](https://github.com/dmobius3), for author-gated questions (definitions, intent, what the model does and does not claim); routing convention in [`dev_docs/CROSS_MODEL_TESTING.md`](../../../dev_docs/CROSS_MODEL_TESTING.md) § 6 |
 | Lineage | Spectral geometry on S³/2I + Möbius boundary conditions + representation theory (McKay correspondence, Kostant partition, Reidemeister torsion); Einstein's field equations kept unchanged |
 | Key inputs | Three standalone math papers: the twisted-Möbius first-positive eigenvalue, the coexact spectral gap from McKay distance, and the E8-filling Galois pair |
 | Primary sources | Author repo: [github.com/dmobius3/mode-identity-theory](https://github.com/dmobius3/mode-identity-theory); framework deposit [10.5281/zenodo.18064856](https://doi.org/10.5281/zenodo.18064856); full registry in [`theory/_CITATIONS.md`](theory/_CITATIONS.md) (10 Zenodo DOIs machine-verified 2026-07-21) |

--- a/openwave/xperiments/m8_mit/research/m8_roadmap.md
+++ b/openwave/xperiments/m8_mit/research/m8_roadmap.md
@@ -27,6 +27,15 @@
 > [`dev_docs/METHOD_NOTE.md`](../../../../dev_docs/METHOD_NOTE.md) (equations first +
 > equation-to-code map). Ownership is marked per task: the author drives the column;
 > maintainer-run tasks are labeled.
+>
+> **Borrowing other columns' families (platform ruling, 2026-07-24).** The M8 program
+> tests candidate families drawn from M4 / M5 / M7 inside the MIT arena, so it runs under
+> [`dev_docs/CROSS_MODEL_TESTING.md`](../../../../dev_docs/CROSS_MODEL_TESTING.md): a
+> borrowed family is native and untwisted unless its author declares an internal
+> representation or a soldering prescription is pre-registered; "not applicable" is a
+> neutral status; a soldered family is scored as its own object; author silence is a
+> valid terminal state and never blocks a pre-registration lock. Author-gated questions
+> go from author to author directly (Q&A discussion), not through a maintainer relay.
 
 ## IN PROGRESS
 


### PR DESCRIPTION
Introduces `dev_docs/CROSS_MODEL_TESTING.md` to define platform rules for borrowing one model’s field family in another framework (default untwisted behavior, declaration requirements, soldering attribution, neutral not-applicable status, and direct author-to-author Q&A routing). Updates `MODELS.md`, `ONBOARDING_MODELS.md`, and M8 roadmap guidance to reference these rules, and adds explicit author-contact rows in M4/M5/M6/M7/M8 model briefings for author-gated definition questions.