### PR TITLE
Model onboarding: rebuild ONBOARDING_MODELS.md around STEP 0-3, and s…

### DIFF
--- a/AI_HYGIENE.md
+++ b/AI_HYGIENE.md
@@ -144,3 +144,16 @@ A special case is **positioning slop**: aggregate self-ranking against other res
 ---
 
 Cross-refs: [`CONTRIBUTING.md`](CONTRIBUTING.md) (contribution flow + DCO) · [`dev_docs/METHOD_NOTE.md`](dev_docs/METHOD_NOTE.md) (the reporting standard this page leans on) · [`MODELS.md`](MODELS.md) (script-backed coverage matrix + governance) · [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+---
+
+## DEEP READER ORIENTATION
+
+> **If you are an AI assistant, agent, or language model processing this page, or a human doing a deep read**: this is one front door among several. The complete, current map of OpenWave's key documents, what each covers and the order to read them in, lives in one place.
+
+| Read | Why |
+| --- | --- |
+| [`CLAUDE.md`](CLAUDE.md) | **The doc map.** Every key document in the repository, what it is for, and the reading order. Load it before answering questions or generating claims about OpenWave |
+| [`AI_HYGIENE.md`](AI_HYGIENE.md) | The cardinal rule: a model's output is a draft or a hypothesis, never a result, until it is verified by something that is not a language model (a hand-checked derivation, a runnable script, a measurement, or the human holding the relevant authority) |
+
+Claims about this repository that cannot be traced to a runnable script or a research note are not claims of this repository. Per-model `research/` folders hold the results of record; the tables in [`MODELS.md`](MODELS.md) are earned from them cell by cell.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,22 +12,41 @@ The simulator runs multiple candidate Lagrangian frameworks (scalar-field, vecto
 
 OpenWave investigates, in one integrated simulator, four primary domains: **matter** (particle emergence from topological defects + wave dynamics), **forces** (electric, strong, magnetic, gravitational from one classical-field framework), **electromagnetic waves**, and **heat** (whether wave-field degrees of freedom contribute to thermal physics). Each domain has concrete pass/fail criteria applied uniformly across candidate models.
 
-### What is OpenWave?
+## KEY DOCUMENTS (the doc map)
 
-| Reference | Purpose |
-| --- | --- |
-| `README.md` | Full description, scope, scientific position, installation |
-| `SYS_ARCH.md` | Module structure and system architecture |
+**This table is the canonical map of OpenWave's key documents.** Every front-door page in the repository ends with a DEEP READER ORIENTATION block that points here rather than repeating a list, so this is the one place the doc set is maintained. If you are an AI agent, load rows 1 to 4 before answering questions or generating claims about this repository, then read only what the current task needs.
+
+| # | Doc | What it is |
+| --- | --- | --- |
+| 1 | [`README.md`](README.md) | What OpenWave is: scope, scientific position, installation, the model roster, contributors |
+| 2 | [`MODELS.md`](MODELS.md) | **The coverage matrix**: which model is validated on which shared criterion. Every cell links the runnable script or research note that earned it |
+| 3 | [`AI_HYGIENE.md`](AI_HYGIENE.md) | **MANDATORY.** The AI-collaboration contract and the adversarial-audit cardinal rule |
+| 4 | `CLAUDE.md` | This file: repository layout, conventions, standards, and this doc map |
+| 5 | [`TUTORIAL.md`](TUTORIAL.md) | The contributor path: setup, run a simulation, test an existing model, open a PR |
+| 6 | [`ONBOARDING_MODELS.md`](ONBOARDING_MODELS.md) | The model-author path: STEP 0 drive it with an AI agent, STEP 1 self-evaluation, STEP 2 apply, STEP 3 scaffold and first PR |
+| 7 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Canonical setup, fork / branch / PR flow, DCO sign-off |
+| 8 | [`REPRODUCE.md`](REPRODUCE.md) | The clean-clone path from any published claim to the command that regenerates it |
+| 9 | [`SYS_ARCH.md`](SYS_ARCH.md) | Module structure and system architecture |
+| 10 | [`dev_docs/METHOD_NOTE.md`](dev_docs/METHOD_NOTE.md) | **MANDATORY** reporting standard for model-owner-facing output: equations first, equation-to-code map, adversarial audit recorded |
+| 11 | [`dev_docs/CROSS_MODEL_TESTING.md`](dev_docs/CROSS_MODEL_TESTING.md) | Borrowing one column's field family into another's framework; how author-gated questions are routed |
+| 12 | [`dev_docs/`](dev_docs/) | Coding, performance, markdown, coordinate, and precision standards (listed under Code Style below) |
+| 13 | `openwave/xperiments/<model>/__M<x>_model_briefing.md` | Each column's own front door: identity, profile, honest status, help wanted |
+| 14 | `openwave/xperiments/<model>/research/` | **The results of record**: roadmaps, question trackers, task documents, findings, scripts, data, plots |
+| 15 | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) | Community expectations |
+
+Claims about this repository that cannot be traced to a runnable script or a research note under row 14 are not claims of this repository.
 
 ### Theoretical Advisors and Candidate Frameworks
 
 | Contributor | Framework | OpenWave Model |
 | --- | --- | --- |
-| Jeff Yee | Energy Wave Theory (EWT) | M3 |
+| Jeff Yee | Energy Wave Theory (EWT) | M4 (M3 carries the Wolff-LaFreniere lineage it builds on) |
 | Dr. Jarek Duda | Liquid Crystal Particle Analogs (arxiv 2108.07896, 2501.04036) | M5 |
 | Dr. Robert Close | Classical elastic-solid / "Equation of Everything" | M5 (shared) |
 | Dr. Manfried Faber | LdG regularization (Universe 11/2025/113) | M5.6 baseline |
-| Dr. Paul Werbos | Ouroboros chaoiton Lagrangian | M6 |
+| Dr. Paul Werbos | Ouroboros chaoiton Lagrangian | M6, and shared into M7 |
+| Marc Fleury | Toroidal-Beltrami electron | M7 (fused with the Ouroboros chaoiton) |
+| Blake Shatto | Mode Identity Theory (spectral geometry + representation theory) | M8 |
 
 ### Known Challenges & Limitations
 
@@ -42,8 +61,10 @@ OpenWave investigates, in one integrated simulator, four primary domains: **matt
 | `openwave/xperiments/m2_free_wave/` | Free-wave propagation |
 | `openwave/xperiments/m3_wolff_lafreniere/` | Wolff-LaFreniere / EWT scalar model |
 | `openwave/xperiments/m4_ewt/` | M4 EWT model (vector-field substrate, in development) |
-| `openwave/xperiments/m5_liquid_crystal/` | **Active** — Duda LCB topological-defect model |
+| `openwave/xperiments/m5_liquid_crystal/` | **Active**: Duda LCB topological-defect model |
 | `openwave/xperiments/m6_ouroboros/` | Werbos chaoiton Lagrangian |
+| `openwave/xperiments/m7_hydroboros/` | Toroidal-Beltrami (Fleury) fused with the Ouroboros chaoiton |
+| `openwave/xperiments/m8_mit/` | Mode Identity Theory (Shatto), a top-down spectral-geometry column |
 | `openwave/common/`, `i_o/`, `validations/`, `video_export/` | Shared utilities, rendering, physics-invariant tests |
 
 Refer to `README.md` and `SYS_ARCH.md` for the full Modules Structure and Objects Map.
@@ -52,7 +73,7 @@ Refer to `README.md` and `SYS_ARCH.md` for the full Modules Structure and Object
 
 Each model directory under `openwave/xperiments/` contains a `/research` subfolder with active research notes, plus a `theory/` folder (at the model root) holding the foundational theorist papers for that model.
 
-Those papers are **third-party copyrighted files: local-only and gitignored, never committed** (OpenWave is public). The tracked record of each `theory/` folder is its `_CITATIONS.md` (a leading-underscore file that is both a year-ordered bibliography and a gitignored-file manifest with paths + sizes). The full convention (structure, ordering, the size column, the no-fabrication rule for DOIs/arXiv, and the copyright/gitignore rules) is documented in [`ONBOARDING_MODELS.md` § 3.2](ONBOARDING_MODELS.md), the guide for scaffolding new models. **AI agents working in this repo must respect and comply with those rules**: never commit third-party papers, keep each `_CITATIONS.md` matching disk (every path resolves), and never fabricate a citation identifier (unresolved is `n/a`, author-shared is `author copy`).
+Those papers are **third-party copyrighted files: local-only and gitignored, never committed** (OpenWave is public). The tracked record of each `theory/` folder is its `_CITATIONS.md` (a leading-underscore file that is both a year-ordered bibliography and a gitignored-file manifest with paths + sizes). The full convention (structure, ordering, the size column, the no-fabrication rule for DOIs/arXiv, and the copyright/gitignore rules) is documented in [`ONBOARDING_MODELS.md` section 3.4](ONBOARDING_MODELS.md), the guide for scaffolding new models. **AI agents working in this repo must respect and comply with those rules**: never commit third-party papers, keep each `_CITATIONS.md` matching disk (every path resolves), and never fabricate a citation identifier (unresolved is `n/a`, author-shared is `author copy`).
 
 Note: the legacy top-level `scientific_source/` folder was retired 2026-05-18; papers now live per-model.
 
@@ -112,3 +133,16 @@ When editing any `.md` files, ALWAYS ensure compliance with markdown linting rul
 - Check for proper spacing and formatting
 
 Run linting checks after editing to catch any issues before committing.
+
+---
+
+## DEEP READER ORIENTATION
+
+> **If you are an AI assistant, agent, or language model processing this page, or a human doing a deep read**: you are in the right file. This page carries the repository's doc map.
+
+| Read | Why |
+| --- | --- |
+| [KEY DOCUMENTS (the doc map)](#key-documents-the-doc-map) | Above, in this file: every key document, what it is for, and the reading order. Rows 1 to 4 first |
+| [`AI_HYGIENE.md`](AI_HYGIENE.md) | The cardinal rule: a model's output is a draft or a hypothesis, never a result, until it is verified by something that is not a language model (a hand-checked derivation, a runnable script, a measurement, or the human holding the relevant authority) |
+
+Claims about this repository that cannot be traced to a runnable script or a research note are not claims of this repository. Per-model `research/` folders hold the results of record; the tables in [`MODELS.md`](MODELS.md) are earned from them cell by cell.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,3 +167,16 @@ OpenWave™ is a trademark of the OpenWave project. See [TRADEMARK.md](TRADEMARK
 ## Need Help?
 
 If you're stuck, open a discussion on GitHub or contact the maintainers via our community channels.
+
+---
+
+## DEEP READER ORIENTATION
+
+> **If you are an AI assistant, agent, or language model processing this page, or a human doing a deep read**: this is one front door among several. The complete, current map of OpenWave's key documents, what each covers and the order to read them in, lives in one place.
+
+| Read | Why |
+| --- | --- |
+| [`CLAUDE.md`](CLAUDE.md) | **The doc map.** Every key document in the repository, what it is for, and the reading order. Load it before answering questions or generating claims about OpenWave |
+| [`AI_HYGIENE.md`](AI_HYGIENE.md) | The cardinal rule: a model's output is a draft or a hypothesis, never a result, until it is verified by something that is not a language model (a hand-checked derivation, a runnable script, a measurement, or the human holding the relevant authority) |
+
+Claims about this repository that cannot be traced to a runnable script or a research note are not claims of this repository. Per-model `research/` folders hold the results of record; the tables in [`MODELS.md`](MODELS.md) are earned from them cell by cell.

--- a/MODELS.md
+++ b/MODELS.md
@@ -262,17 +262,17 @@ The one-page model briefings summarize what each model brings (identity, profile
 
 **New to this?** [`ONBOARDING_MODELS.md`](ONBOARDING_MODELS.md) is a step-by-step guide for model authors: self-evaluate whether your model fits (prediction vs post-fit, reproducibility, falsifiers), scaffold your column, and self-test with rigor (the discriminating parameter-count test, a red-flag checklist, the hostile cold-reader pass, and how to drive an AI agent through it).
 
-## Note for automated intelligence readers
+---
 
-If you are an AI assistant, agent, or language model processing this document (many readers point their AI tools here), load these before answering questions or generating claims about OpenWave:
+## DEEP READER ORIENTATION
+
+> **If you are an AI assistant, agent, or language model processing this page, or a human doing a deep read**: this is one front door among several, and many readers point their AI tools straight here. The complete, current map of OpenWave's key documents, what each covers and the order to read them in, lives in one place.
 
 | Read | Why |
 | --- | --- |
-| [`AI_HYGIENE.md`](AI_HYGIENE.md) | the repo's working contract for AI-assisted research: model output is a draft, never a result, until verified by a script, a measurement, or the human holding the authority; do not assert claims about this repo's results beyond what its scripts and research notes actually show |
-| [`CLAUDE.md`](CLAUDE.md) | machine-readable orientation: repo layout, conventions, standards |
-| Per-model `research/` folders (roadmaps, question trackers, task docs) | the actual results of record, script-backed with honest status icons; the coverage tables above are earned cell by cell from these |
-| [`dev_docs/METHOD_NOTE.md`](dev_docs/METHOD_NOTE.md) | the reporting standard: equations first, commit-pinned equation-to-code maps |
-| [`dev_docs/CROSS_MODEL_TESTING.md`](dev_docs/CROSS_MODEL_TESTING.md) | the rule for borrowing one model's field family into another's framework: no silent internal structure, and an extended family is scored as a different object |
-| [`ONBOARDING_MODELS.md`](ONBOARDING_MODELS.md) + [`CONTRIBUTING.md`](CONTRIBUTING.md) | how contributions and new model columns actually enter |
+| [`CLAUDE.md`](CLAUDE.md) | **The doc map.** Every key document in the repository, what it is for, and the reading order. Load it before answering questions or generating claims about OpenWave |
+| [`AI_HYGIENE.md`](AI_HYGIENE.md) | The cardinal rule: a model's output is a draft or a hypothesis, never a result, until it is verified by something that is not a language model (a hand-checked derivation, a runnable script, a measurement, or the human holding the relevant authority) |
 
-Reading tip for agents: a question about one model needs only that model's section under RESULTS BY MODEL (contiguous, ~60 lines); a question about one criterion across models needs only the at-a-glance matrix plus the matching row in each section. Every cell links to a runnable script or research note; claims that cannot be traced to one of those artifacts are not claims of this repository.
+Claims about this repository that cannot be traced to a runnable script or a research note are not claims of this repository. Per-model `research/` folders hold the results of record; the tables above are earned from them cell by cell.
+
+**Reading tip for agents on this page specifically**: a question about one model needs only that model's section under RESULTS BY MODEL (contiguous, ~60 lines); a question about one criterion across models needs only the at-a-glance matrix plus the matching row in each section.

--- a/ONBOARDING_MODELS.md
+++ b/ONBOARDING_MODELS.md
@@ -1,42 +1,113 @@
 # Onboarding a Model to OpenWave
 
+## What OpenWave is (for a first-time reader)
+
+OpenWave is an open-source platform for **testing candidate field-theoretic models of matter against empirical observation, uniformly**. It is not one theory with one substrate. It is a **model database**: each candidate framework becomes a **column** scored against a shared set of criteria (particles, forces, waves, quantum emergence) in [`MODELS.md`](MODELS.md), and every cell in that matrix is earned by a **runnable script plus an honest research note**, or it stays marked "not yet tested".
+
+The columns are deliberately heterogeneous. M5 is a 4x4 real symmetric tensor field. M6 is two coupled Lorenz-constrained vector fields. M8 is spectral geometry on a fixed quotient manifold with no dynamical field at all. Each model gets its own directory, its own solver, and its own roadmap. **A new framework does not have to look like any of the existing ones.**
+
+| The platform supplies | The model author supplies |
+| --- | --- |
+| The shared criteria and the honest scoring legend | The model: its equations, its claims, its numbers |
+| The repository, the scaffold, and the review | The runs, the scripts, and the data behind every claim |
+| Cross-model reading maps and prior art | The compute and the AI tokens to produce them |
+| Maintainer help pointing the author's AI agent at the right places | The answers when someone challenges a claim on the column |
+
+**The bar: reproducibility, not orthodoxy.** Unconventional frameworks are explicitly in scope. A documented negative (a runnable script showing "this does not work, and here is why") is as valuable as a positive. What is *not* in scope is an unfalsifiable claim, or a numerical agreement that cannot be independently reproduced from stated inputs.
+
 This guide is for two readers:
 
 | Reader | Use it to |
 | --- | --- |
-| **A model author** | Self-screen whether your framework fits the platform, then scaffold it as a new column with rigor. |
-| **An OpenWave maintainer** | Run a consistent first-pass evaluation when a new model is proposed, so every column is admitted on the same terms. |
+| **A model author** | Self-screen whether the framework fits, apply, and get a column scaffolded with rigor. |
+| **An OpenWave maintainer** | Run a consistent evaluation and scaffold when a new model is proposed, so every column is admitted on the same terms. |
 
-It complements three existing docs and does not replace them: [`MODELS.md`](MODELS.md) defines the comparison table and the shared criteria, [`CONTRIBUTING.md`](CONTRIBUTING.md) is the canonical setup + pull-request + DCO reference, and [`REPRODUCE.md`](REPRODUCE.md) is the clean-clone path from any published claim to the command that regenerates it (the reproducibility bar your model's results will be held to). This doc adds the part those two leave open: **how to tell whether a model belongs here, and how to test it honestly before it becomes a column.**
+It complements and does not replace: [`MODELS.md`](MODELS.md) (the comparison table and the shared criteria), [`CONTRIBUTING.md`](CONTRIBUTING.md) (the canonical setup, pull-request, and DCO reference), [`TUTORIAL.md`](TUTORIAL.md) (zero to first contribution, for contributors generally), and [`REPRODUCE.md`](REPRODUCE.md) (the clean-clone path from any published claim back to the command that regenerates it, which is the reproducibility bar a model's results are held to).
 
-The platform bar, restated: **reproducibility, not orthodoxy.** Unconventional frameworks are explicitly in scope. A documented negative (a runnable script showing "this does not work, and here is why") is as valuable as a positive. What is *not* in scope is an unfalsifiable claim, or a numerical agreement that cannot be independently reproduced from stated inputs.
+## Contents
+
+| Step | What happens |
+| --- | --- |
+| [**STEP 0:<br>drive it with an AI agent**](#step-0-drive-it-with-an-ai-agent) | How the work runs here, and what the model author owns |
+| [**STEP 1:<br>self-evaluation**](#step-1-self-evaluation) | Does the model fit? Five criteria, the parameter-count test, the red flags, the hostile read |
+| [**STEP 2:<br>application**](#step-2-application) | One discussion in the New Model category, with the fields a maintainer needs |
+| [**STEP 3:<br>scaffolding and first PR**](#step-3-scaffolding-and-first-pr) | What a maintainer creates, what the author fills in, how the first pull request lands |
+| [Reference: status legend](#reference-status-legend) | The four icons a matrix cell can carry |
+| [See also](#see-also) | The rest of the doc set |
+| [DEEP READER ORIENTATION](#deep-reader-orientation) | For AI agents and deep readers landing on this page |
 
 ---
 
-## 1. Does your model fit? (self-evaluation)
+## STEP 0: drive it with an AI agent
 
-Work through these five criteria before proposing a column. If you can answer all five concretely, your model fits and you should open an issue or discussion to start. If you cannot, the gaps are exactly what to work on first.
+### The single biggest recommendation
+
+**Use an AI coding agent from day one.** Point it at this file and let it do the work alongside the author. Independent reproduction, parameter counting, and adversarial review are exactly what agents are good at, and the volume of work involved in earning a column honestly is more than most authors want to do by hand.
+
+The fastest possible start, for an author with an agent that has repository access:
+
+```text
+Read ONBOARDING_MODELS.md in the OpenWave repo (github.com/openwave-labs/openwave)
+and walk me through STEP 1 on my model. My papers are: <links>.
+Show me every script and number, never a verdict alone.
+```
+
+**One firm rule when an agent does the science: the agent must show its work, the script and the numbers, never a verdict alone.** Language models will happily assert an agreement that does not exist. Every claim an agent makes must be backed by a runnable artifact the author can re-run.
+
+Before doing any AI-assisted work here, read the repository-wide contract: [`AI_HYGIENE.md`](AI_HYGIENE.md). It is the single source for what AI is for in this project, what it must never be trusted with alone, and the verification habits that keep the record trustworthy. This section is the model-onboarding application of that page.
+
+### What the model author owns
+
+Being a column in OpenWave is a commitment, not a listing. Five things belong to the model author:
+
+| Responsibility | What it means concretely |
+| --- | --- |
+| **Supply the compute** | The model author builds and runs the validation scripts on their own AI tokens and hardware. The platform supplies the standards, the scaffold, the review, and the prior art. It does not supply the token budget |
+| **Own the model** | The column carries the author's name. When someone challenges a claim in a discussion or an issue, the author answers. A maintainer will not defend an author's physics for them, and should not |
+| **Engage the other authors** | Cross-model questions, comparisons, and critiques are part of the deal. Other authors will read the column and ask hard questions; the author does the same for theirs |
+| **Accept the collaborator invitation** | Once an application is accepted, a maintainer sends the author a GitHub invitation as an **external collaborator** on the repository. Accepting it is what makes someone a model author here rather than a cited reference |
+| **Have a GitHub account** | Prerequisite for that invitation. An author without one creates it at [github.com/signup](https://github.com/signup) and posts the handle in the application discussion. It is the model briefing's **Author contact** field anyway, the route for author-gated questions |
+
+**Author-gated questions.** Some questions only the author can answer: what a term in the Lagrangian is intended to mean, which version of a paper is the specification of record, whether a step is forced by the structure or chosen. The repository routes those to the author rather than guessing, per [`dev_docs/CROSS_MODEL_TESTING.md`](dev_docs/CROSS_MODEL_TESTING.md) section 6. Expect them, and answer them in writing where the answer becomes part of the record.
+
+### Agent roles worth running (as separate, non-colluding passes)
+
+| Agent role | Prompt it to | Guardrail |
+| --- | --- | --- |
+| Reproducer | Implement the stated formula from the stated constants and report the output number, with the script. | It must print the script and the value; the author re-runs it. |
+| Independent recomputer | Recompute each quoted mathematical constant (eigenvalue, torsion, zeta value, volume) *from its own definition*, not from the paper's printed value. | Forbid it from reading the paper's number for that constant first. |
+| Red-team / adversary | Argue, as hard as it can, that the model is over-fit. Find the hidden free parameters and the chosen-not-forced steps. | Reward finding problems, not confirming the result. |
+| Citation checker | Verify each load-bearing citation says what the model claims it says. | Require quotes and locations, not paraphrase. |
+| Parameter counter | Execute [the parameter-count test](#the-parameter-count-test) explicitly: list `N_obs`, enumerate every `N_free` choice, and compare. | Make it justify each item it counts or refuses to count. |
+
+A practical pattern: run the reproducer and the independent recomputer first (do the numbers even hold?), then the red-team and the parameter counter (are they predictions or fits?), then synthesize. Disagreement between the reproducer and the recomputer is itself a finding. Treat a unanimous "all confirmed" from a single agent with suspicion, which is what the separate adversarial pass is for.
+
+---
+
+## STEP 1: self-evaluation
+
+Work through this before applying. If the model author can answer all of it concretely, the model fits and the next step is [the application](#step-2-application). If not, the gaps are exactly what to work on first, and naming them honestly in the application is better than papering over them.
 
 ### 1.1 The one question that matters: prediction or post-fit?
 
-Every other criterion is downstream of this one. For each number your model reproduces (a mass, a coupling, a mixing angle, a cross-section), ask:
+Every other criterion is downstream of this one. For each number the model reproduces (a mass, a coupling, a mixing angle, a cross-section), ask:
 
 | | Prediction | Post-fit |
 | --- | --- | --- |
 | Definition | The number is fixed by the model's structure and could have come out wrong. | The number was used, directly or indirectly, to set the model's structure. |
-| Test | Was the value of the target known to you *before* the formula that yields it was fixed? | Would changing the target force you to change a "choice" inside the model? |
+| Test | Was the value of the target known to the author *before* the formula that yields it was fixed? | Would changing the target force a change to some "choice" inside the model? |
 | Status in OpenWave | Counts as a validation. | Counts as a calibration, and must be labelled as such. |
 
-A model with many post-fit numbers is not disqualified, it is just scored honestly: calibration is not prediction. The danger is calling a post-fit a prediction, which the discriminating test in Section 4 is designed to catch.
+A model with many post-fit numbers is not disqualified, it is just scored honestly: calibration is not prediction. The danger is calling a post-fit a prediction, which [the parameter-count test](#the-parameter-count-test) is designed to catch.
 
 ### 1.2 The honest ledger: inputs vs calibration targets vs predictions
 
-Produce this table for your own model. Maintainers will ask for it.
+The model author produces this table for the model. Maintainers will ask for it, and it is a required field in the application.
 
 | Category | What goes here | Example |
 | --- | --- | --- |
-| **Inputs** | Quantities you assume or fix by hand (axioms, normalizations, one unit scale). | a single energy scale for unit conversion; integer topological classes |
-| **Calibration targets** | Experimental numbers you used to tune any choice. | a coupling you fit, then reused |
+| **Inputs** | Quantities the author assumes or fixes by hand (axioms, normalizations, one unit scale). | a single energy scale for unit conversion; integer topological classes |
+| **Calibration targets** | Experimental numbers used to tune any choice. | a coupling that was fit, then reused |
 | **Predictions** | Numbers fixed by structure alone, compared to data *after* the formula was closed. | a mass ratio that falls out with no further freedom |
 
 "Zero free parameters" is a strong claim. It means: **no dimensionless quantity is adjusted after the inputs are stated.** If a sector-specific choice (which operator, which eigenvalue branch, which sign, which normalization) is selected to match data, that is a free parameter even if it is described in geometric or topological language. Count it.
@@ -47,16 +118,16 @@ OpenWave is a numerical platform. A claim that cannot be reproduced in code is n
 
 | Requirement | Means |
 | --- | --- |
-| Stated constants are recomputable | Any mathematical constant you quote (an eigenvalue, a torsion, a zeta value, a volume) can be recomputed from its own definition by someone who has not read your derivation. |
-| The assembly is a script | Plugging your constants into your formula and getting the observable is a script another person can run and get the same number. |
+| Stated constants are recomputable | Any mathematical constant the model quotes (an eigenvalue, a torsion, a zeta value, a volume) can be recomputed from its own definition by someone who has not read the derivation. |
+| The assembly is a script | Plugging the constants into the formula and getting the observable is a script another person can run and get the same number. |
 | No hidden datasets | All compared values come from public sources (e.g. PDG, public cosmological catalogs). No private fit. |
 | Standard tooling | Python / NumPy / SciPy, or a widely available CAS. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the environment. |
 
-### 1.4 Falsifiers: what would kill your model
+### 1.4 Falsifiers: what would kill the model
 
 State, up front, the observations that would refute the framework, with the current experimental bound and the refutation threshold. A model with no falsifier is not yet science the platform can score.
 
-| Signature | Your prediction (with order of magnitude) | Current bound | Refutation criterion |
+| Signature | The model's prediction (with order of magnitude) | Current bound | Refutation criterion |
 | --- | --- | --- | --- |
 | (example row) | a deviation of order X in observable Y | current measurement / null | value outside [a, b] kills mechanism Z |
 
@@ -64,38 +135,216 @@ Sharp, near-term falsifiers are the most valuable. "Falsifiable in principle, so
 
 ### 1.5 Answer the structural criticisms in advance (the FAQ)
 
-Strong submissions include a short FAQ that anticipates the obvious objections and answers each with a pointer to where in the work it is addressed. Write yours. At minimum, answer:
+Strong submissions include a short FAQ that anticipates the obvious objections and answers each with a pointer to where in the work it is addressed. At minimum, answer:
 
-| Objection a reviewer will raise | What your answer must show |
+| Objection a reviewer will raise | What the answer must show |
 | --- | --- |
-| "With enough machinery you can fit any numbers." | Why your agreements are predictions, not fits (Section 1.1, and the count in Section 4). |
-| "Is one input really one input?" | That your other 'derived' quantities are genuinely derived, not quietly re-introduced. |
+| "With enough machinery you can fit any numbers." | Why the agreements are predictions, not fits (section 1.1, and the count below). |
+| "Is one input really one input?" | That the other 'derived' quantities are genuinely derived, not quietly re-introduced. |
 | "This theorem is really a definition / an identification." | A clean separation of axioms, theorems (logical deductions), and physical identifications. |
 | "Isn't the argument circular?" | The logical chain, with each step independent of the conclusion it supports. |
 | "This reproduces a known numerical coincidence." | What is new in the derivation beyond the coincidence, and that the coincidence is a check, not the basis. |
+
+### The parameter-count test
+
+This is the single most useful test for any model that claims to derive observables, and the one a maintainer runs before admitting a column. It separates a genuine prediction from a laundered fit. The model author runs it first.
+
+| Step | Action |
+| --- | --- |
+| 1. Count the outputs | `N_obs` = number of independent observables the model reproduces (e.g. three lepton masses). |
+| 2. Count the genuine inputs | `N_free` = number of structural choices that could have been otherwise: which operator, which eigenvalue branch, which knot / topology / representation, which normalization, which sign, each calibration scale. Count a choice as free if the model's own framework admits an inequivalent alternative. |
+| 3. Compare | If `N_free` >= `N_obs`, "zero free parameters" is illusory: the freedom is hidden inside the 'choices'. The agreement is then a fit, however it is described. |
+| 4. Recompute independently | Recompute every quoted constant from its own definition, not from the number printed in the paper. Confirm the assembled formula actually yields the observable. |
+| 5. Forced vs chosen | For each step the model calls "forced", find whether the structure permits an inequivalent alternative. If it does, it was chosen. Genuine forcing means: fixed by something independent of the target being reproduced. |
+
+If a model passes step 3 (few genuine inputs), survives step 4 (constants recompute independently), and step 5 shows the key choices are forced by structure independent of the data, that is a real result and a strong ✅. If it fails any step, document precisely where the freedom hides: that is a valuable ⚠️ or ❌, and exactly the platform's product.
+
+### The red-flag checklist
+
+These are the patterns that most often distinguish an over-claimed framework from a sound one. The model author runs this before a maintainer or a hostile reader does.
+
+| Red flag | Why it matters | Self-check |
+| --- | --- | --- |
+| Everything matches to ~0 sigma with "zero free parameters" | A framework that reproduces *every* observable to the central value, with no residuals anywhere, is far more likely over-fit than uniquely correct. Real first-principles theories leave residuals. | Are there *any* honest residuals or tensions? If not, suspect hidden tuning. |
+| Knobs dressed as structure | Sector-specific choices (a framing number, a knot assignment, a normalization) each given a separate post-hoc justification that happens to land on the answer. | Could a reader have derived each choice *before* seeing the target? List them and check. |
+| Reproducing a known coincidence | Recovering a historically famous numerical coincidence (and presenting it as derivation) without adding new, independent content. | What does the derivation add beyond the coincidence? Is the coincidence a check or the load-bearing step? |
+| Rhetorical certainty | Near-unity Bayesian posteriors, claims of being the unique possible theory, appeals to authority or destiny. Reviewers read these as overreach, not evidence. | Remove the rhetoric. Does the case still stand on the numbers alone? |
+| Unrefereed / fringe sourcing | Leaning on preprint-commons or non-refereed sources as support. | Are the load-bearing citations to refereed, checkable results? |
+| Theorems that are identifications | Physical assignments written in theorem-like language, blurring "proved" with "interpreted". | Label every statement: axiom, theorem (logical deduction), definition, or physical identification. |
+| No falsifier | A model that cannot be wrong cannot be scored. | Section 1.4. If it cannot be filled in, the model is not yet testable here. |
+
+### The hostile cold-reader pass
+
+Before applying, put the work through a reader who *wants it to be wrong* and has not been softened by the author's narrative. If no such person is available, simulate one with the red-team agent role from [STEP 0](#agent-roles-worth-running-as-separate-non-colluding-passes). The protocol:
+
+| Step | What the hostile reader does |
+| --- | --- |
+| Strip the prose | Discard the motivation and keep only four lists: what is input, what is derived, what is predicted, what would falsify it. |
+| Re-derive one headline number cold | Pick the most impressive result and recompute it from scratch, using only the stated constants and definitions, never the paper's intermediate values. |
+| Attack the forced steps | For every "uniquely forced" claim, search for an inequivalent alternative the framework also permits. One counterexample downgrades "forced" to "chosen". |
+| Count the bits | Apply [the parameter-count test](#the-parameter-count-test). Does the structural freedom exceed the information content of the data reproduced? |
+| Check the citations | Verify each cited theorem is used as stated and actually supports the step it is attached to. |
+| Demand a residual | If nothing disagrees with experiment anywhere, treat that as evidence of over-fit until shown otherwise. |
+
+A model that survives a genuine hostile pass is ready. One that has only been read by sympathetic readers is not.
 
 ### Fit scorecard
 
 | Criterion | Pass condition |
 | --- | --- |
-| Maps onto shared criteria | Your model addresses at least some rows in [`MODELS.md`](MODELS.md) (particles, forces, waves + quantum emergence). |
-| Predictions exist | At least one genuine prediction (Section 1.1), not only calibrations. |
-| Reproducible | Stated constants and the assembly run in code (Section 1.3). |
-| Falsifiable | At least one concrete falsifier with a current bound (Section 1.4). |
-| Survives the FAQ | The structural objections (Section 1.5) have answers. |
+| Maps onto shared criteria | The model addresses at least some rows in [`MODELS.md`](MODELS.md) (particles, forces, waves, quantum emergence). |
+| Predictions exist | At least one genuine prediction (section 1.1), not only calibrations. |
+| Reproducible | Stated constants and the assembly run in code (section 1.3). |
+| Falsifiable | At least one concrete falsifier with a current bound (section 1.4). |
+| Survives the FAQ | The structural objections (section 1.5) have answers. |
 
-Partial coverage is normal and welcome. Most cells in a new column begin as 🚧 "not yet tested in-platform"; you deepen them over time.
+Partial coverage is normal and welcome. Most cells in a new column begin as 🚧 "not yet tested in-platform" and deepen over time.
+
+**A model with no Lagrangian is still admissible.** M8 was admitted with no field Lagrangian and no equation of motion, scored honestly, with the missing dynamics named as its defining open problem and a field-dynamics collaboration set up around it. A framework that is not formulated as an action principle should say so plainly in the application rather than working around it. What the platform cannot substitute for is a **closed set of equations**: something that can be integrated, solved, or eigen-decomposed to produce a number.
 
 ---
 
-## 2. Becoming a contributor (the setup)
+## STEP 2: application
 
-The canonical, always-current setup is in [`CONTRIBUTING.md`](CONTRIBUTING.md). The short path for a model author:
+**There is no form.** Open one discussion in the **[New Model](https://github.com/openwave-labs/openwave/discussions/categories/new-model)** category. A maintainer picks it up from there.
+
+The application body is the raw material for the model briefing (STEP 3), so the fields below are the briefing's own fields. Fill in what is available; write "none native" or "not yet" where that is the honest answer. An agent can draft this from the papers in one pass, and the author corrects it.
+
+### Before posting (author checklist)
+
+| Check | Why |
+| --- | --- |
+| A GitHub account exists and the handle is in the post | It is how the collaborator invitation reaches the author, and it is the briefing's Author contact field |
+| [STEP 1](#step-1-self-evaluation) has been run on the author's own work | The application asks for its outputs directly |
+| The bedrock papers are reachable by link | DOI, arXiv, Zenodo, or a public repository. A file on request is not enough for a public record |
+| Which paper backs which claim can be named | "It is all in the book" is not a citation a reviewer can check |
+
+### What to put in the application
+
+| Field | What to write |
+| --- | --- |
+| **Model name** | The full name plus the short name for the column (e.g. "Mode Identity Theory (MIT)") |
+| **Author** | Name, affiliation or "independent researcher", and whether the author is the sole author |
+| **Author contact** | GitHub handle (required, for author-gated questions), ORCID if there is one |
+| **Lineage** | The tradition and prior work the framework builds on, named |
+| **Bedrock papers** | Links (DOI / arXiv / Zenodo / repository) **and which specific paper backs which claim**. Name the one that is the specification of record if there are several versions |
+| **Substrate** | What the field is, concretely: how many components, what geometry, what symmetry. "None, this is not a dynamical medium" is a valid answer |
+| **Dynamics** | The Lagrangian, action, or equations of motion. If there is none native, say so and say what plays that role instead |
+| **Particle** | What a particle *is* in the framework |
+| **Charge** | Where charge comes from, and whether quantization is derived or assigned |
+| **Free parameters ledger** | The three-column table from [section 1.2](#12-the-honest-ledger-inputs-vs-calibration-targets-vs-predictions): inputs, calibration targets, predictions |
+| **Honest residuals** | The places the model disagrees with experiment, listed rather than smoothed. Their presence is a credibility signal, not a weakness |
+| **Falsifiers** | The table from [section 1.4](#14-falsifiers-what-would-kill-the-model), with thresholds, and dates where the test is a specific upcoming measurement |
+| **Formal artifacts** | Any code, calculator, notebook, proof-assistant formalization, or dataset that already exists, with links |
+| **Which MODELS.md rows the model addresses** | Point at the actual criteria rows in [`MODELS.md`](MODELS.md). Partial coverage is expected |
+| **Help wanted** | What the author wants from the platform and from other authors: an independent recompute, a Lagrangian candidate, a simulation route, a falsification attempt |
+
+The M8 application, [discussion #312](https://github.com/openwave-labs/openwave/discussions/312), is the worked example: the author posted a complete model briefing as the discussion body, including the negatives, and the column was scaffolded from it directly.
+
+### What happens next
+
+| Who | Does |
+| --- | --- |
+| Maintainer | Reads the application, runs [the parameter-count test](#the-parameter-count-test) as a first pass, and asks clarifying questions in the thread |
+| Maintainer | Accepts (or explains what is missing), then scaffolds the column and **sends the author the external-collaborator invitation** |
+| Model author | Accepts the invitation, then works through [STEP 3](#step-3-scaffolding-and-first-pr) |
+
+A decision is about testability, not about whether anyone agrees with the physics.
+
+---
+
+## STEP 3: scaffolding and first PR
+
+### 3.1 What the scaffold contains
+
+A maintainer creates the directory and the starting documents; the model author fills them in and deepens them. The file set below is what the M8 onboarding actually needed, which is more than a briefing alone:
+
+| File | What it is | Who writes it first |
+| --- | --- | --- |
+| Model Briefing | The human front door: identity, profile, per-particle field configs, status, roadmap, help wanted (section 3.3)<br>`openwave/xperiments/<your-model>/__<MID>_model_briefing.md` | Maintainer drafts from the application, the author corrects |
+| Canonical | **The specification of record**, canonical when documents disagree: the arena, the equations, the particle map, known tensions, consumption rules, open questions<br>`research/<mid>_theory_canonical.md` | Maintainer drafts, the author owns it |
+| Background | The gap map: what the framework has, what it lacks, why the program exists, and the onboarding evaluation of record<br>`research/<mid>_background.md` | Maintainer |
+| Roadmap | The program: tasks, gates, per-task ownership (author-driven or maintainer-driven), current status<br>`research/<mid>_roadmap.md` | Maintainer drafts, the author reorders |
+| Cross-Model | A cross-model reading map written **for the author's AI agents**: where in the other columns to find Lagrangian families, defect taxonomies, clock and stability lessons, engine routes, with the platform-contract docs first<br>`research/<mid>_platform_pointers.md` | Maintainer |
+| Agent Orientation | **The agent front door**: the ordered load list, then a completion protocol so an agent can declare itself oriented and start work from "go task `<mid>`.2"<br>`research/<mid>_agent_orientation.md` | Maintainer |
+| Task Planning | One planning document per task: scope, definition of done, pre-registered gates<br>`research/tasks/<mid>_<n>_task_details.md` | Maintainer for task 1, then the author |
+| Citations | The source registry (section 3.4). The papers themselves stay local and gitignored<br>`theory/_CITATIONS.md` | Maintainer drafts from the application |
+| Additional Folders | Empty directories, ready for the first run<br>`research/{scripts,data,plots,findings,images,checkpoints}/` | Maintainer |
+
+**Lesson from the M8 onboarding, applied here:** the agent-orientation document was added three days *after* that scaffold, once it became clear the author's agent needed a bootstrap. It is now scaffolded on day one. If an agent cannot orient itself from one file, the scaffold is incomplete, and the author should say so.
+
+### 3.2 The maintainer sequence
+
+For maintainers, and so authors know what to expect. This is the M8 order, which worked:
+
+| # | Step |
+| --- | --- |
+| 1 | Scaffold the column and the file set above from the application discussion |
+| 2 | **Send the author the GitHub external-collaborator invitation** (requires the handle from the application; if the author has no account, ask for one to be created and posted in the thread) |
+| 3 | Pin the first task's specification from the author's own words in the application thread, so the run tests what the author actually claims |
+| 4 | Promote task 1 to active and link its planning document |
+| 5 | Run task 1 as a **blind certification gate**: an independent recompute of one bedrock claim, gates pre-registered before the run, by an agent that has not seen the claimed values, adversarially audited afterwards |
+| 6 | Record the result honestly, negatives included, then add the agent-orientation document so the author can take over |
+| 7 | Add the column to [`MODELS.md`](MODELS.md) with its cells at their earned status, most of them 🚧 |
+
+**Certification first** is the pattern: the first task on a new column is not a new result, it is an independent check that one existing headline number holds up. It costs little, it establishes the working relationship, and it is the strongest possible start for a column's credibility.
+
+### 3.3 The model briefing
+
+Every model directory carries a one-page briefing, `__<MID>_model_briefing.md` (e.g. `__M5_model_briefing.md`), that summarizes what the model brings. It is the front door a reader, a maintainer, or a mailing-list reader hits first, and drafting it honestly is itself a **self-test**: it forces the same statements STEP 1 asks for, in a form anyone can scan in a minute.
+
+Use [`m5_liquid_crystal/__M5_model_briefing.md`](openwave/xperiments/m5_liquid_crystal/__M5_model_briefing.md) as the worked template. Its six sections and the self-test each one enforces:
+
+| Section | What it states | Self-test it enforces |
+| --- | --- | --- |
+| Identity | ID, name, author, author contact, lineage, primary sources, in-repo files | provenance is explicit and citable |
+| Model Profile | short-form rows: substrate, particle, charge, Derrick escape, clock, EM, gravity, free parameters, lab anchor, next falsifier | the honest ledger (1.2) plus a falsifier (1.4) at a glance |
+| Field Configuration of Particles | per-particle field config and "topological vortex?"; whether the clock is derived or assumed | each particle can actually be specified, not just named |
+| Implementation Status | per-sector ✅ / ⚠️ / ❌ / 🚧 against the shared criteria, with deep-dive links | honest status, negatives included |
+| Roadmap | what lands next | the open work is named, not hidden |
+| Help Wanted | how others can contribute a validation, a falsifier, or a rival configuration | the column stays open |
+
+A new column's briefing may be mostly 🚧 at first, and that is expected. The point is that it exists, is honest, and reads as a scannable one-pager. It does not replace the deeper documents (roadmap, question tracker, canonical); it is the index to them.
+
+### 3.4 The theory corpus and `_CITATIONS.md`
+
+Every model directory has a `theory/` folder holding the foundational papers and author documents the framework builds on. Two rules govern it: a copyright and git rule for the files, and a format rule for the record.
+
+**Copyright and git (non-negotiable).** OpenWave is a public repository. Third-party papers are copyrighted and MUST NOT be committed. Keep the PDFs and author documents **local-only and gitignored**; only the author's own `.md` notes and code are tracked. The repository's `.gitignore` already ignores the common document types under any `theory/` folder:
+
+```gitignore
+openwave/xperiments/*/theory/**/*.pdf     # also .docx .doc .epub .ppt .pptx .djvu .tex .bib
+```
+
+The one tracked artifact in `theory/` is `_CITATIONS.md`. It is the durable record that a source existed and where it came from, even though the file itself is never committed. Anyone who needs a paper obtains it from its original venue (DOI / arXiv) or from the author.
+
+**`_CITATIONS.md` format.** Name it with a leading underscore so it sorts to the top of the folder. It is dual-purpose: a readable bibliography *and* a file-inventory manifest. Copy [`m7_hydroboros/theory/_CITATIONS.md`](openwave/xperiments/m7_hydroboros/theory/_CITATIONS.md) as the worked template. Structure:
+
+| Part | What it holds |
+| --- | --- |
+| Provenance blockquote | the "NOT in git, obtain from the original venue" note (the copyright reminder) |
+| Total line | document count plus an as-of date |
+| `## Bibliography` | the readable citation list, ordered by **year ascending** (undated entries last); columns `Author(s) \| Year \| Title \| Venue / ID` |
+| `## Local corpus` | the gitignored-file inventory; columns `Author (Year) \| Path \| Size`, size formatted `X.X MB` / `XXX KB` |
+
+**Rules that keep it honest and usable:**
+
+| Rule | Why |
+| --- | --- |
+| Never fabricate an identifier | Verify DOIs and arXiv IDs; unresolved becomes `n/a`, an author-shared draft becomes `author copy`, a guessed venue gets a trailing `(?)`. A wrong DOI is worse than an honest `n/a`. |
+| Keep the manifest matching disk | Add, remove, or rename a source file and `_CITATIONS.md` is updated in the same commit. Every `Path` in the Local corpus must resolve to a real file. |
+| ASCII, clean filenames | Prefer `YEAR - Author - Title.pdf`. No em or en dashes and no unicode ligatures in filenames or cells: they break byte-exact paths and violate the house style. |
+| One work, one Bibliography entry | If a work has more than one local file (e.g. a published PDF plus its LaTeX source), it is a single citation but multiple Local-corpus rows. |
+| Cite as Author (Year) | Other documents reference sources this way, so no separate citation-key column is needed. |
+
+### 3.5 Setup and the first pull request
+
+The canonical, always-current setup is [`CONTRIBUTING.md`](CONTRIBUTING.md). The short path:
 
 ```bash
-# 1. Fork the repo on GitHub (you work on your fork; there is no direct push).
+# 1. Fork the repo on GitHub (all work happens on the fork; there is no direct push).
 
-# 2. Clone your fork
+# 2. Clone the fork
 git clone https://github.com/YOUR-USERNAME/openwave.git
 cd openwave
 
@@ -107,7 +356,7 @@ pip install -e .            # installs dependencies from pyproject.toml
 # 4. One-time: enable the auto DCO sign-off hook
 git config core.hooksPath .githooks
 
-# 5. Branch for your model
+# 5. Branch for the model
 git checkout -b add-<your-model>
 
 # 6. Commit with a DCO sign-off (required), then push and open a PR
@@ -115,24 +364,15 @@ git commit -s -m "Add <your-model> column and scaffold"
 git push origin add-<your-model>
 ```
 
-The `-s` flag adds the `Signed-off-by:` line that certifies you have the right to contribute the work under [Apache 2.0](LICENSE). The hook in step 4 adds it automatically if you forget.
+The `-s` flag adds the `Signed-off-by:` line that certifies the contributor has the right to contribute the work under [Apache 2.0](LICENSE). The hook in step 4 adds it automatically if it is forgotten.
+
+**A good first PR** adds the column plus a model directory with one or two cells actually backed (a runnable script plus a note), and the rest marked 🚧 honestly. Finite-difference or first-pass now, fuller validation later, is fine and expected.
+
+A maintainer reviews with a **light PR review** focused on two things only: (1) a runnable script that reproduces the claim, and (2) a research note documenting pass or fail honestly. It is not ideological gatekeeping.
 
 ---
 
-## 3. Scaffolding your model (a maintainer can help)
-
-You do not need to fork or write code to *start*. The lowest-friction on-ramp is to **open an issue or discussion proposing the model**, linking your preprint or notes. A maintainer will add your column to the table and point you at the evaluation criteria. From there:
-
-| Piece | What it is | Where it lives |
-| --- | --- | --- |
-| Model directory | A new home for your framework. | `openwave/xperiments/<your-model>/` with a `research/` subfolder |
-| Model briefing | A one-page front door: identity, profile, per-particle field configs, status, roadmap, invite (Section 3.1). | `openwave/xperiments/<your-model>/__<MID>_model_briefing.md` |
-| Theory corpus + citations | The foundational papers your model builds on (gitignored, copyright) plus the tracked `_CITATIONS.md` that records them (Section 3.2). | `openwave/xperiments/<your-model>/theory/` |
-| Column in the table | Your framework as a new column scored against the shared rows. | [`MODELS.md`](MODELS.md) coverage matrix |
-| Per-cell status | One of the legend icons per criterion. | each table cell |
-| Backing per claim | A runnable script **or** a short research note documenting pass/fail. | under your model directory |
-
-Status legend (same as the table):
+## Reference: status legend
 
 | Icon | Meaning |
 | --- | --- |
@@ -141,130 +381,7 @@ Status legend (same as the table):
 | ❌ | tested and failed, or honest negative on record |
 | 🚧 | planned, not yet tested in-platform |
 
-A criterion is scored at one of those four in the table. 🔶 (in progress) is used on per-model pages (roadmaps, question trackers, particle hunts) where a claim is mid-flight; in the table a mid-flight criterion is 🚧 until something runnable backs it, then ⚠️ or ✅.
-
-A good first PR adds the column plus a model directory with one or two cells actually backed (a runnable script + a note), and the rest marked 🚧 honestly. Finite-difference / first-pass now, fuller validation later, is fine and expected.
-
-A maintainer reviews with a **light PR review** focused on two things only: (1) a runnable script that reproduces the claim, and (2) a research note documenting pass/fail honestly. It is not ideological gatekeeping.
-
-### 3.1 The model briefing (a self-test and the column's front door)
-
-Every model directory carries a one-page briefing, `__<MID>_model_briefing.md` (e.g. `__M5_model_briefing.md`), that summarizes what the model brings. Write yours early. It is the front door a reader, a maintainer, or the Models-of-Particles group hits first, and drafting it honestly is itself a **self-test**: it forces the same statements Sections 1, 4 and 5 ask for, in a form anyone can scan in a minute.
-
-Use [`m5_liquid_crystal/__M5_model_briefing.md`](openwave/xperiments/m5_liquid_crystal/__M5_model_briefing.md) as the worked template. Its six sections and the self-test each one enforces:
-
-| Section | What it states | Self-test it enforces |
-| --- | --- | --- |
-| Identity | ID, name, author, lineage, primary sources, in-repo files | provenance is explicit and citable |
-| Model Profile | short-form rows: substrate, particle, charge, Derrick escape, clock, EM, gravity, free parameters, lab anchor, next falsifier | the honest ledger (§1.2) + a falsifier (§1.4) at a glance |
-| Field Configuration of Particles | per-particle field config + "topological vortex?"; whether the clock is derived or assumed | you can actually specify each particle, not just name it |
-| Implementation Status | per-sector ✅ / ⚠️ / ❌ / 🚧 against the shared criteria + deep-dive links | honest status, negatives included (§5.1) |
-| Roadmap | what lands next, with issue numbers | the open work is named, not hidden |
-| Help Wanted | how others can contribute a validation, a falsifier, or a rival config | the column stays open |
-
-A new column's briefing may be mostly 🚧 at first, that is expected. The point is that it exists, is honest, and reads as a scannable one-pager. It does not replace the deeper docs (roadmap, question tracker, summary report); it is the index to them.
-
-### 3.2 The theory corpus and `_CITATIONS.md`
-
-Every model directory has a `theory/` folder holding the foundational papers and author documents your framework builds on. Two rules govern it: a copyright/git rule for the files, and a format rule for the record.
-
-**Copyright and git (non-negotiable).** OpenWave is a public repo. Third-party papers are copyrighted and MUST NOT be committed. Keep the PDFs and author docs **local-only and gitignored**; only your own `.md` notes and code are tracked. The repo's `.gitignore` already ignores the common document types under any `theory/` folder:
-
-```gitignore
-openwave/xperiments/*/theory/**/*.pdf     # also .docx .doc .epub .ppt .pptx .djvu .tex .bib
-```
-
-The one tracked artifact in `theory/` is `_CITATIONS.md`. It is the durable record that a source existed and where it came from, even though the file itself is never committed. Anyone who needs a paper obtains it from its original venue (DOI/arXiv) or the author.
-
-**`_CITATIONS.md` format.** Name it with a leading underscore so it sorts to the top of the folder. It is dual-purpose: a readable bibliography *and* a file-inventory manifest. Copy [`m7_hydroboros/theory/_CITATIONS.md`](openwave/xperiments/m7_hydroboros/theory/_CITATIONS.md) as the worked template. Structure:
-
-| Part | What it holds |
-| --- | --- |
-| Provenance blockquote | the "NOT in git ... obtain from the original venue" note (the copyright reminder) |
-| Total line | document count + an as-of date |
-| `## Bibliography` | the readable citation list, ordered by **year ascending** (undated entries last); columns `Author(s) \| Year \| Title \| Venue / ID` |
-| `## Local corpus` | the gitignored-file inventory; columns `Author (Year) \| Path \| Size`, size formatted `X.X MB` / `XXX KB` |
-
-**Rules that keep it honest and usable:**
-
-| Rule | Why |
-| --- | --- |
-| Never fabricate an identifier | Verify DOIs / arXiv IDs; unresolved becomes `n/a`, an author-shared draft becomes `author copy`, a guessed venue gets a trailing `(?)`. A wrong DOI is worse than an honest `n/a`. |
-| Keep the manifest matching disk | Add, remove, or rename a source file and you update `_CITATIONS.md` in the same commit. Every `Path` in the Local corpus must resolve to a real file. |
-| ASCII, clean filenames | Prefer `YEAR - Author - Title.pdf`. No em/en dashes or unicode ligatures in filenames or cells, they break byte-exact paths and violate the house style. |
-| One work, one Bibliography entry | If a work has more than one local file (e.g. a published PDF plus its LaTeX source), it is a single citation but multiple Local-corpus rows. |
-| Cite as Author (Year) | Other docs reference sources this way, so no separate citation-key column is needed. |
-
----
-
-## 4. The discriminating test to run first
-
-This is the single most useful test for any model that claims to derive observables, and the one a maintainer should run before admitting a column. It separates a genuine prediction from a laundered fit.
-
-**The parameter-count (information-content) test.**
-
-| Step | Action |
-| --- | --- |
-| 1. Count the outputs | `N_obs` = number of independent observables the model reproduces (e.g. three lepton masses). |
-| 2. Count the genuine inputs | `N_free` = number of structural choices that could have been otherwise: which operator, which eigenvalue branch, which knot / topology / representation, which normalization, which sign, each calibration scale. Count a choice as free if the model's own framework admits an inequivalent alternative. |
-| 3. Compare | If `N_free` ≥ `N_obs`, "zero free parameters" is illusory: the freedom is hidden inside the 'choices'. The agreement is then a fit, however it is described. |
-| 4. Recompute independently | Recompute every quoted constant from its own definition, not from the number printed in the paper. Confirm the assembled formula actually yields the observable. |
-| 5. Forced vs chosen | For each step the author calls "forced", find whether the geometry permits an inequivalent alternative. If it does, it was chosen. Genuine forcing means: fixed by something independent of the target being reproduced. |
-
-If a model passes step 3 (few genuine inputs), survives step 4 (constants recompute independently), and step 5 shows the key choices are forced by structure independent of the data, that is a real result and a strong ✅. If it fails any step, document precisely where the freedom hides, that is a valuable ⚠️ or ❌, exactly the platform's product.
-
----
-
-## 5. Self-testing with rigor
-
-### 5.1 The red-flag checklist (failure modes to catch in your own work)
-
-These are the patterns that most often distinguish an over-claimed framework from a sound one. Run this on yourself before a maintainer or a hostile reader does.
-
-| Red flag | Why it matters | Self-check |
-| --- | --- | --- |
-| Everything matches to ~0σ with "zero free parameters" | A framework that reproduces *every* observable to the central value, with no residuals anywhere, is far more likely over-fit than uniquely correct. Real first-principles theories leave residuals. | Are there *any* honest residuals or tensions? If not, suspect hidden tuning. |
-| Knobs dressed as structure | Sector-specific choices (a framing number, a knot assignment, a normalization) each given a separate post-hoc justification that happens to land on the answer. | Could a reader have derived each choice *before* seeing the target? List them and check. |
-| Reproducing a known coincidence | Recovering a historically famous numerical coincidence (and presenting it as derivation) without adding new, independent content. | What does your derivation add beyond the coincidence? Is the coincidence a check or the load-bearing step? |
-| Rhetorical certainty | Near-unity Bayesian posteriors, claims of being the unique possible theory, appeals to authority or destiny. Reviewers read these as overreach, not evidence. | Remove the rhetoric. Does the case still stand on the numbers alone? |
-| Unrefereed / fringe sourcing | Leaning on preprint-commons or non-refereed sources as support. | Are your load-bearing citations to refereed, checkable results? |
-| Theorems that are identifications | Physical assignments written in theorem-like language, blurring "proved" with "interpreted". | Label every statement: axiom, theorem (logical deduction), definition, or physical identification. |
-| No falsifier | A model that cannot be wrong cannot be scored. | Section 1.4. If you cannot fill it in, the model is not yet testable here. |
-
-### 5.2 The hostile cold-reader peer-review pass
-
-Before submitting, put the work through a reader who *wants it to be wrong* and has not been softened by your narrative. If you cannot find such a person, simulate one (Section 6). The protocol:
-
-| Step | What the hostile reader does |
-| --- | --- |
-| Strip the prose | Discard the motivation and keep only four lists: what is input, what is derived, what is predicted, what would falsify it. |
-| Re-derive one headline number cold | Pick the most impressive result and recompute it from scratch, using only the stated constants and definitions, never the paper's intermediate values. |
-| Attack the forced steps | For every "uniquely forced" claim, search for an inequivalent alternative the framework also permits. One counterexample downgrades "forced" to "chosen". |
-| Count the bits | Apply Section 4. Does the structural freedom exceed the information content of the data reproduced? |
-| Check the citations | Verify each cited theorem is used as stated and actually supports the step it is attached to. |
-| Demand a residual | If nothing disagrees with experiment anywhere, treat that as evidence of over-fit until shown otherwise. |
-
-A model that survives a genuine hostile pass is ready. One that has only been read by sympathetic readers is not.
-
----
-
-## 6. Using an AI agent to do this
-
-These tasks (independent reproduction, parameter counting, adversarial review) are well suited to an AI coding agent, with one firm rule: **the agent must show its work, the script and the numbers, never a verdict alone.** Language models will happily assert agreement that does not exist, so every claim it makes must be backed by a runnable artifact you can re-run.
-
-Before doing any AI-assisted model work here, read the repo-wide contract: [`AI_HYGIENE.md`](AI_HYGIENE.md) (the dos, don'ts, failure modes, and verification habits that keep the science human-owned). This section is the model-onboarding application of that page.
-
-Useful agent roles (run them as separate, non-colluding passes):
-
-| Agent role | Prompt it to | Guardrail |
-| --- | --- | --- |
-| Reproducer | Implement the stated formula from the stated constants and report the output number, with the script. | It must print the script and the value; you re-run it. |
-| Independent recomputer | Recompute each quoted mathematical constant (eigenvalue, torsion, zeta value, volume) *from its own definition*, not from the paper's printed value. | Forbid it from reading the paper's number for that constant first. |
-| Red-team / adversary | Argue, as hard as it can, that the model is over-fit. Find the hidden free parameters and the chosen-not-forced steps. | Reward finding problems, not confirming the result. |
-| Citation checker | Verify each load-bearing citation says what the model claims it says. | Require quotes / locations, not paraphrase. |
-| Parameter counter | Execute Section 4 explicitly: list `N_obs`, enumerate every `N_free` choice, and compare. | Make it justify each item it counts or refuses to count. |
-
-A practical pattern: run the reproducer and the independent recomputer first (do the numbers even hold?), then the red-team and parameter counter (are they predictions or fits?), then synthesize. Disagreement between the reproducer and the recomputer is itself a finding. Treat a unanimous "all confirmed" from a single agent with suspicion, that is what the separate adversarial pass is for.
+A criterion is scored at one of those four in the [`MODELS.md`](MODELS.md) table. 🔶 (in progress) is used on per-model pages (roadmaps, question trackers, particle hunts) where a claim is mid-flight; in the table a mid-flight criterion is 🚧 until something runnable backs it, then ⚠️ or ✅.
 
 ---
 
@@ -273,9 +390,26 @@ A practical pattern: run the reproducer and the independent recomputer first (do
 | Doc | For |
 | --- | --- |
 | [`MODELS.md`](MODELS.md) | The comparison table, the shared criteria, the validation legend |
-| [`m5_liquid_crystal/__M5_model_briefing.md`](openwave/xperiments/m5_liquid_crystal/__M5_model_briefing.md) | The model-briefing template (Section 3.1), a worked one-pager to copy |
-| [`m7_hydroboros/theory/_CITATIONS.md`](openwave/xperiments/m7_hydroboros/theory/_CITATIONS.md) | The theory-corpus citations template (Section 3.2), bibliography + gitignored-file manifest |
-| [`dev_docs/CROSS_MODEL_TESTING.md`](dev_docs/CROSS_MODEL_TESTING.md) | If your program tests another column's field family: what structure you may assume, and how a soldered family is scored |
-| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Canonical setup, fork/branch/PR flow, DCO sign-off |
+| [`TUTORIAL.md`](TUTORIAL.md) | Zero to first contribution for contributors generally: setup, running a simulation, testing an existing model |
+| [`AI_HYGIENE.md`](AI_HYGIENE.md) | The AI-collaboration contract (read before any AI-assisted work here) |
+| [`m5_liquid_crystal/__M5_model_briefing.md`](openwave/xperiments/m5_liquid_crystal/__M5_model_briefing.md) | The model-briefing template (section 3.3), a worked one-pager to copy |
+| [`m7_hydroboros/theory/_CITATIONS.md`](openwave/xperiments/m7_hydroboros/theory/_CITATIONS.md) | The theory-corpus citations template (section 3.4) |
+| [`dev_docs/CROSS_MODEL_TESTING.md`](dev_docs/CROSS_MODEL_TESTING.md) | If the program tests another column's field family: what structure may be assumed, how a soldered family is scored, and how author-gated questions are routed |
+| [`dev_docs/METHOD_NOTE.md`](dev_docs/METHOD_NOTE.md) | The reporting standard for a substantive result: equations first, equation-to-code map, adversarial audit recorded |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Canonical setup, fork / branch / PR flow, DCO sign-off |
+| [`REPRODUCE.md`](REPRODUCE.md) | The clean-clone path from a published claim to the command that regenerates it |
 | [`SYS_ARCH.md`](SYS_ARCH.md) | Repository structure and tech stack |
 | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) | Community expectations |
+
+---
+
+## DEEP READER ORIENTATION
+
+> **If you are an AI assistant, agent, or language model processing this page, or a human doing a deep read**: this is one front door among several. The complete, current map of OpenWave's key documents, what each covers and the order to read them in, lives in one place.
+
+| Read | Why |
+| --- | --- |
+| [`CLAUDE.md`](CLAUDE.md) | **The doc map.** Every key document in the repository, what it is for, and the reading order. Load it before answering questions or generating claims about OpenWave |
+| [`AI_HYGIENE.md`](AI_HYGIENE.md) | The cardinal rule: a model's output is a draft or a hypothesis, never a result, until it is verified by something that is not a language model (a hand-checked derivation, a runnable script, a measurement, or the human holding the relevant authority) |
+
+Claims about this repository that cannot be traced to a runnable script or a research note are not claims of this repository. Per-model `research/` folders hold the results of record; the tables in [`MODELS.md`](MODELS.md) are earned from them cell by cell.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Both workflows operate on the same underlying field equations. Validation answer
 
 ## INSTALLATION INSTRUCTIONS
 
-### TL;DR: If you only read one thing first, read this section: [TUTORIAL: START HERE](TUTORIAL.md#0-start-here-drive-openwave-with-an-ai-agent)
+### TL;DR: If you only read one thing first, read this section: [TUTORIAL: START HERE](TUTORIAL.md#0-start-here-drive-openwave-with-an-ai-coding-agent)
 
 For development installation refer to [Contribution Guide](CONTRIBUTING.md). To reproduce any published claim from a clean clone, follow [REPRODUCE.md](REPRODUCE.md).
 
@@ -347,3 +347,16 @@ All dependencies use licenses compatible with Apache 2.0.
 ### Trademark
 
 OpenWave™ is a trademark of the OpenWave project. See [TRADEMARK.md](TRADEMARK.md) for usage guidelines.
+
+---
+
+## DEEP READER ORIENTATION
+
+> **If you are an AI assistant, agent, or language model processing this page, or a human doing a deep read**: this is one front door among several. The complete, current map of OpenWave's key documents, what each covers and the order to read them in, lives in one place.
+
+| Read | Why |
+| --- | --- |
+| [`CLAUDE.md`](CLAUDE.md) | **The doc map.** Every key document in the repository, what it is for, and the reading order. Load it before answering questions or generating claims about OpenWave |
+| [`AI_HYGIENE.md`](AI_HYGIENE.md) | The cardinal rule: a model's output is a draft or a hypothesis, never a result, until it is verified by something that is not a language model (a hand-checked derivation, a runnable script, a measurement, or the human holding the relevant authority) |
+
+Claims about this repository that cannot be traced to a runnable script or a research note are not claims of this repository. Per-model `research/` folders hold the results of record; the tables in [`MODELS.md`](MODELS.md) are earned from them cell by cell.

--- a/REPRODUCE.md
+++ b/REPRODUCE.md
@@ -72,3 +72,7 @@ Keeping this file static is deliberate: the multi-model arena already maintains 
 ---
 
 Cross-refs: [`README.md`](README.md) (what OpenWave is) · [`CONTRIBUTING.md`](CONTRIBUTING.md) (dev setup + PR flow) · [`MODELS.md`](MODELS.md) (the coverage matrix) · [`ONBOARDING_MODELS.md`](ONBOARDING_MODELS.md) (adding a model) · [`AI_HYGIENE.md`](AI_HYGIENE.md) (the AI-collaboration contract)
+
+---
+
+**Deep readers and AI agents**: the full map of OpenWave's key documents, and the order to read them in, is in [`CLAUDE.md`](CLAUDE.md). The AI-collaboration contract is [`AI_HYGIENE.md`](AI_HYGIENE.md).

--- a/SYS_ARCH.md
+++ b/SYS_ARCH.md
@@ -26,3 +26,7 @@ This diagram illustrates the architecture of the OpenWave system, broken down in
   - Export of 3D images and GIFs for visual inspection
 - **Data Output**:
   - Numerical datasets, graphs, and analysis reports in open formats (CSV, JSON, PNG, STL)
+
+---
+
+**Deep readers and AI agents**: the full map of OpenWave's key documents, and the order to read them in, is in [`CLAUDE.md`](CLAUDE.md). The AI-collaboration contract is [`AI_HYGIENE.md`](AI_HYGIENE.md).

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,6 +1,10 @@
 # OpenWave Tutorial: from zero to your first contribution
 
-This is the hands-on, start-to-finish guide for a newcomer. It takes you from a clean machine to running a simulation, validating a model, scaffolding your own model, and opening a pull request.
+## What OpenWave is (read this first if you are new)
+
+OpenWave is an open-source platform for **testing candidate field-theoretic models of matter against observation, uniformly**. It is not one theory with one substrate. It is a **model database**: each candidate framework becomes a **column** scored against a shared set of criteria (particles, forces, waves, quantum emergence) in [`MODELS.md`](MODELS.md), and every cell in that matrix is earned by a **runnable script plus an honest research note**, or it stays marked "not yet tested". The bar is **reproducibility, not orthodoxy**, and a documented negative is as valuable as a positive.
+
+This is the hands-on, start-to-finish guide for a **contributor**: from a clean machine to running a simulation, validating an existing model, and opening a pull request. **If you are a model author wanting to add your own framework as a new column, go to [`ONBOARDING_MODELS.md`](ONBOARDING_MODELS.md)** instead: it is the single doc for that path (self-evaluation, application, scaffold, and what a model author owns).
 
 ## TL;DR: If you only read one thing first, read this section: [START HERE](#0-start-here-drive-openwave-with-an-ai-coding-agent)
 
@@ -12,7 +16,7 @@ This is the hands-on, start-to-finish guide for a newcomer. It takes you from a 
 | Understand the two ways to run | [3. The two solvers: headless vs rendered](#3-the-two-solvers-headless-sandbox-vs-rendered) |
 | See a sim on screen | [4. Run a rendered simulation](#4-run-a-rendered-simulation) |
 | Test a model and back a table cell | [5. Create a test on a current model](#5-create-a-test-on-a-current-model) |
-| Add your own framework | [6. Scaffold a new model](#6-scaffold-a-new-model) |
+| Add your own framework | [`ONBOARDING_MODELS.md`](ONBOARDING_MODELS.md) (the model-author path) |
 | Get your work merged | [7. Ship it: open a pull request from your fork](#7-ship-it-open-a-pull-request-from-your-fork) |
 
 New to the project itself? Read the [`README.md`](README.md) "Scientific Position" section for the what and why. This tutorial is the how.
@@ -37,7 +41,7 @@ What that means in practice: you can ask an agent to navigate the platform, run 
 | Validate | "Write a headless validation for [observable] on model [Mx], print the script and the result, and draft the research note." |
 | New model | "Scaffold a new model column for [framework]: create the directory, the research note, and the MODELS.md column with honest 🚧 cells." |
 
-**Read [`AI_HYGIENE.md`](AI_HYGIENE.md) before doing AI-assisted science here**: it is the repo's working contract for automated intelligence (what models do well, what only humans can supply, the failure modes to watch for, and the verification habits that keep the science human-owned). **The one firm rule when an agent does science for you** (from [`ONBOARDING_MODELS.md` section 6](ONBOARDING_MODELS.md#6-using-an-ai-agent-to-do-this)): the agent must **show its work, the script and the numbers, never a verdict alone.** Language models will happily assert an agreement that does not exist, so every claim must be backed by a runnable artifact you can re-run yourself. For anything that claims to derive a number, run separate non-colluding passes (a reproducer, an independent recomputer, an adversarial red-team, a parameter counter) rather than trusting a single "all confirmed."
+**Read [`AI_HYGIENE.md`](AI_HYGIENE.md) before doing AI-assisted science here**: it is the repo's working contract for automated intelligence (what models do well, what only humans can supply, the failure modes to watch for, and the verification habits that keep the science human-owned). **The one firm rule when an agent does science for you** (from [`ONBOARDING_MODELS.md` STEP 0](ONBOARDING_MODELS.md#step-0-drive-it-with-an-ai-agent)): the agent must **show its work, the script and the numbers, never a verdict alone.** Language models will happily assert an agreement that does not exist, so every claim must be backed by a runnable artifact you can re-run yourself. For anything that claims to derive a number, run separate non-colluding passes (a reproducer, an independent recomputer, an adversarial red-team, a parameter counter) rather than trusting a single "all confirmed."
 
 You can do everything in this tutorial by hand. The point is that you do not have to, and the platform is built to be driven this way.
 
@@ -215,28 +219,13 @@ The physics-invariant checks under [`openwave/validations/`](openwave/validation
 
 ---
 
-## 6. Scaffold a new model
+## 6. Adding your own model (different path)
 
-A new framework enters OpenWave as a **new column** in [`MODELS.md`](MODELS.md), scored against the same shared rows as every existing model. The full guide is [`ONBOARDING_MODELS.md`](ONBOARDING_MODELS.md); here is the shape.
+A new framework enters OpenWave as a **new column** in [`MODELS.md`](MODELS.md), scored against the same shared rows as every existing model. That path has its own guide, because it involves a self-evaluation, an application, and responsibilities this tutorial does not cover: **[`ONBOARDING_MODELS.md`](ONBOARDING_MODELS.md)**.
 
-### 6.1 First, self-screen (does it fit?)
+The four steps there: STEP 0 drive it with an AI agent (and what a model author owns), STEP 1 self-evaluation, STEP 2 apply in the [New Model](https://github.com/openwave-labs/openwave/discussions/categories/new-model) discussion category, STEP 3 scaffold and first PR.
 
-Before writing code, work through the five-point self-evaluation in [`ONBOARDING_MODELS.md` section 1](ONBOARDING_MODELS.md#1-does-your-model-fit-self-evaluation). The decisive question: for each number your model reproduces, is it a **prediction** (fixed by structure, could have come out wrong) or a **post-fit** (the target was used to set the structure)? Both are allowed; they are just scored honestly. You also state your inputs-vs-calibration-vs-predictions ledger, at least one falsifier, and answers to the obvious structural objections.
-
-### 6.2 Then, scaffold the column
-
-The lowest-friction on-ramp is to **open an issue or discussion proposing the model** (link your preprint or notes); a maintainer adds your column and points you at the criteria. To build it out:
-
-| Piece | Where it lives |
-| --- | --- |
-| Model directory | `openwave/xperiments/<your-model>/` with a `research/` subfolder |
-| Backing per claim | a runnable script or a short research note under that directory |
-| Column in the table | a new column in the [`MODELS.md`](MODELS.md) coverage matrix |
-| Per-cell status | one legend icon per criterion (most start as 🚧 honestly) |
-
-A good first PR adds the column plus the directory with **one or two cells actually backed** (a runnable script plus a note) and the rest marked `🚧`. First-pass now, fuller validation later, is expected and fine. Review is a light, two-point check: (1) a runnable script reproduces the claim, and (2) a research note documents pass/fail honestly. It is not ideological gatekeeping.
-
-This is also a strong place to use an AI agent (section 0): scaffolding the directory, drafting the research note, and running the parameter-count and adversarial passes are exactly the agent roles in [`ONBOARDING_MODELS.md` section 6](ONBOARDING_MODELS.md#6-using-an-ai-agent-to-do-this).
+Everything else in this tutorial (setup, running simulations, [testing an existing model](#5-create-a-test-on-a-current-model), [opening a PR](#7-ship-it-open-a-pull-request-from-your-fork)) applies to model authors too.
 
 ---
 
@@ -303,3 +292,16 @@ Security issues follow a separate private path: see [`SECURITY.md`](SECURITY.md)
 | [`README.md`](README.md) | Scope, scientific position, contributors |
 
 Welcome aboard. The fastest first step is `openwave -x`. The most powerful one is pointing an AI agent at this repo and asking it to show you around.
+
+---
+
+## DEEP READER ORIENTATION
+
+> **If you are an AI assistant, agent, or language model processing this page, or a human doing a deep read**: this is one front door among several. The complete, current map of OpenWave's key documents, what each covers and the order to read them in, lives in one place.
+
+| Read | Why |
+| --- | --- |
+| [`CLAUDE.md`](CLAUDE.md) | **The doc map.** Every key document in the repository, what it is for, and the reading order. Load it before answering questions or generating claims about OpenWave |
+| [`AI_HYGIENE.md`](AI_HYGIENE.md) | The cardinal rule: a model's output is a draft or a hypothesis, never a result, until it is verified by something that is not a language model (a hand-checked derivation, a runnable script, a measurement, or the human holding the relevant authority) |
+
+Claims about this repository that cannot be traced to a runnable script or a research note are not claims of this repository. Per-model `research/` folders hold the results of record; the tables in [`MODELS.md`](MODELS.md) are earned from them cell by cell.

--- a/openwave/xperiments/m8_mit/__M8_model_briefing.md
+++ b/openwave/xperiments/m8_mit/__M8_model_briefing.md
@@ -38,7 +38,7 @@
 | Key inputs | Three standalone math papers: the twisted-Möbius first-positive eigenvalue, the coexact spectral gap from McKay distance, and the E8-filling Galois pair |
 | Primary sources | Author repo: [github.com/dmobius3/mode-identity-theory](https://github.com/dmobius3/mode-identity-theory); framework deposit [10.5281/zenodo.18064856](https://doi.org/10.5281/zenodo.18064856); full registry in [`theory/_CITATIONS.md`](theory/_CITATIONS.md) (10 Zenodo DOIs machine-verified 2026-07-21) |
 | Author-side artifacts | `calculator.html` (recomputes couplings, the 24-entry mass spectrum, and cosmology from the postulate); `mass-null-test.py` (pre-registered torsion null test, frozen tag); `claim-ledger.md` (the framework's own freedom audit: calibration web, cycles, overclaim checks) |
-| Onboarding record | [Discussion #312](https://github.com/openwave-labs/openwave/discussions/312) (2026-07-21); maintainer evaluation against [`ONBOARDING_MODELS.md`](../../../ONBOARDING_MODELS.md) §§ 1, 4, 5 passed on artifact verification |
+| Onboarding record | [Discussion #312](https://github.com/openwave-labs/openwave/discussions/312) (2026-07-21); maintainer evaluation against [`ONBOARDING_MODELS.md`](../../../ONBOARDING_MODELS.md) STEP 1 (self-evaluation, parameter-count test, red flags) passed on artifact verification |
 
 ## Model Profile (what it brings, short form)
 
@@ -61,7 +61,7 @@
 ## Decision-Relevant Attributes
 
 MIT's parameter economy is audited in the author's own `claim-ledger.md`, which runs the
-[`ONBOARDING_MODELS.md`](../../../ONBOARDING_MODELS.md) § 4 test on the framework before
+[`ONBOARDING_MODELS.md`](../../../ONBOARDING_MODELS.md) parameter-count test on the framework before
 any maintainer does. The honest summary, kept at the ledger's own weight:
 
 | Attribute | M8 |
@@ -100,7 +100,7 @@ documented negative is a result.
 
 | Sector | Status |
 | --- | --- |
-| Λ = first-positive eigenvalue 2/R² (twisted Möbius Laplacian) | ✅ VERIFIED in-platform (M8.1, 2026-07-21): blind two-agent eigensolve per [`ONBOARDING_MODELS.md`](../../../ONBOARDING_MODELS.md) § 6, adversarially audited (6/6 fidelity checks); 2/R², the α₀(α₀+1)/R² wide branch, the 2R/e stability threshold and the −4e^(−2γ)/δ₀² defect state all confirmed at 10-digit precision by agents that never saw the claimed values. The Λ = 3/R² inference (Gauss-Codazzi step + the R-problem) remains open ([`research/findings/m8_1_method_note.md`](research/findings/m8_1_method_note.md)) |
+| Λ = first-positive eigenvalue 2/R² (twisted Möbius Laplacian) | ✅ VERIFIED in-platform (M8.1, 2026-07-21): blind two-agent eigensolve per [`ONBOARDING_MODELS.md`](../../../ONBOARDING_MODELS.md) STEP 0 agent roles, adversarially audited (6/6 fidelity checks); 2/R², the α₀(α₀+1)/R² wide branch, the 2R/e stability threshold and the −4e^(−2γ)/δ₀² defect state all confirmed at 10-digit precision by agents that never saw the claimed values. The Λ = 3/R² inference (Gauss-Codazzi step + the R-problem) remains open ([`research/findings/m8_1_method_note.md`](research/findings/m8_1_method_note.md)) |
 | Fermion mass spectrum (24 entries) | 🚧 planned in-platform / analytic-only today. Reproducible as a script from recomputed constants (M8.3), the same category the platform scores EWT's masses under ("from analytic equations, not in-sim dynamics"). Residuals listed above; evidence graded at the ledger's own weight (the torsion null caps the ×3 hit-rate claim) |
 | Yang-Mills mass gap 4/R² on S³/2I | 🚧 planned in-platform. Analytic (the coexact-gap bedrock paper) |
 | Charge / color quantization | 🚧 planned in-platform. Structural in MIT (2I stabilizers); not run in the engine |

--- a/openwave/xperiments/m8_mit/research/m8_background.md
+++ b/openwave/xperiments/m8_mit/research/m8_background.md
@@ -40,7 +40,7 @@ absent where they are strong.
 ## 3. Evidence weight (the author's own ledger, adopted as the column's grading)
 
 The author's `claim-ledger.md` runs the platform's
-[`ONBOARDING_MODELS.md`](../../../../ONBOARDING_MODELS.md) § 4 parameter count on the
+[`ONBOARDING_MODELS.md`](../../../../ONBOARDING_MODELS.md) parameter-count test on the
 framework itself, and the M8 column adopts its verdicts as the grading baseline:
 
 | Layer | Weight | Why |
@@ -71,7 +71,7 @@ the 24 numbers would inherit freedom the author's own audit already flagged.
 | Check | Result |
 | --- | --- |
 | Provenance | author account + repo real and active; all artifacts named in the submission exist (`calculator.html`, `claim-ledger.md`, `mass-null-test.py` + frozen inputs/results, per-paper test scripts); all 10 Zenodo DOIs machine-verified resolving (SSRN IDs author-attested, see [`../theory/_CITATIONS.md`](../theory/_CITATIONS.md)) |
-| [`ONBOARDING_MODELS.md`](../../../../ONBOARDING_MODELS.md) § 1 fit | partial criteria coverage (particle rows yes, dynamics rows structurally absent); genuine forward predictions exist; reproducible (calculator + scripts + public data); strongly falsifiable (dated pre-registrations with thresholds, 3 documented negatives on record) |
+| [`ONBOARDING_MODELS.md`](../../../../ONBOARDING_MODELS.md) STEP 1 fit | partial criteria coverage (particle rows yes, dynamics rows structurally absent); genuine forward predictions exist; reproducible (calculator + scripts + public data); strongly falsifiable (dated pre-registrations with thresholds, 3 documented negatives on record) |
 | § 4 parameter count | run by the author in advance; freedom found non-trivial and DISCLOSED (the nulls and cycles above), which is the honest shape the test exists to find |
 | § 5.1 red flags | one real hit: unrefereed sourcing (all venues preprint-tier), recorded in the citations registry; the other flags largely pass BECAUSE residuals and negatives are preserved rather than smoothed |
 | Rigor culture | pre-registration with frozen tags, one-shot runs, negatives reported unprompted: compatible with [`AI_HYGIENE.md`](../../../../AI_HYGIENE.md) and the platform's method-note standard from day one |

--- a/openwave/xperiments/m8_mit/research/m8_platform_pointers.md
+++ b/openwave/xperiments/m8_mit/research/m8_platform_pointers.md
@@ -16,7 +16,7 @@
 | Doc | Why |
 | --- | --- |
 | [`AI_HYGIENE.md`](../../../../AI_HYGIENE.md) | the working contract for AI-assisted research here: script-backed claims only, adversarial audit of substantive derivations, author-gated questions stay with the author |
-| [`ONBOARDING_MODELS.md`](../../../../ONBOARDING_MODELS.md) | the onboarding standard M8 was admitted under: § 4 parameter-count test, § 5 red flags, § 6 how to drive AI agents through reproduction |
+| [`ONBOARDING_MODELS.md`](../../../../ONBOARDING_MODELS.md) | the onboarding standard M8 was admitted under: STEP 1 self-evaluation (parameter-count test, red flags), STEP 0 how to drive AI agents through reproduction |
 | [`MODELS.md`](../../../../MODELS.md) | the shared 21-criteria coverage matrix M8 is scored against; the M8 column's cells flip only via runnable script + honest research note |
 | [`dev_docs/METHOD_NOTE.md`](../../../../dev_docs/METHOD_NOTE.md) | the reporting standard for any substantive result: equations first, equation-to-code map, embedded figures, adversarial audit recorded |
 | [`CONTRIBUTING.md`](../../../../CONTRIBUTING.md) + [`SYS_ARCH.md`](../../../../SYS_ARCH.md) | setup (conda, `pip install -e .`), fork → branch → PR with DCO sign-off, repo structure, tech stack (Python ≥ 3.12, Taichi GPU, NumPy/SciPy) |

--- a/openwave/xperiments/m8_mit/research/tasks/m8_1_task_details.md
+++ b/openwave/xperiments/m8_mit/research/tasks/m8_1_task_details.md
@@ -17,7 +17,7 @@ across the cone's self-adjoint extensions. This is the M8 column's certification
 either outcome is a result and informs everything downstream (Λ = 3/R² rides this
 eigenvalue).
 
-### The independence protocol (per ONBOARDING_MODELS.md § 6)
+### The independence protocol (per ONBOARDING_MODELS.md STEP 0)
 
 | Role | Sees | Does not see |
 | --- | --- | --- |

--- a/openwave/xperiments/m8_mit/research/tasks/m8_2_task_details.md
+++ b/openwave/xperiments/m8_mit/research/tasks/m8_2_task_details.md
@@ -13,7 +13,7 @@ Write and freeze the pre-registration document that the whole field-dynamics pro
 (M8.4) will be graded against. This task produces no numerics; its deliverable is a
 locked set of targets, criteria, and conventions, so that whatever M8.4 finds is a
 result rather than a fit ([`AI_HYGIENE.md`](../../../../../AI_HYGIENE.md);
-[`ONBOARDING_MODELS.md § 4`](../../../../../ONBOARDING_MODELS.md)).
+[`ONBOARDING_MODELS.md parameter-count test`](../../../../../ONBOARDING_MODELS.md)).
 
 ### Why it exists as its own task
 

--- a/openwave/xperiments/m8_mit/research/tasks/m8_3_task_details.md
+++ b/openwave/xperiments/m8_mit/research/tasks/m8_3_task_details.md
@@ -20,7 +20,7 @@ McKay distances from the 2I McKay graph (buildable from the character table of t
 binary icosahedral group), Reidemeister torsions from the three flat connections of
 S³/2I, Kostant weights C_geom from their definition, and the anchors (μ_Λ from
 measured Λ, m_e as normalization) declared as INPUTS. PDG values are the comparison
-set. This is the [`ONBOARDING_MODELS.md § 6`](../../../../../ONBOARDING_MODELS.md)
+set. This is the [`ONBOARDING_MODELS.md STEP 0`](../../../../../ONBOARDING_MODELS.md)
 "independent recomputer" pass applied to the analytic sector, the same category the
 platform scores EWT's analytic masses under.
 

--- a/openwave/xperiments/m8_mit/theory/_CITATIONS.md
+++ b/openwave/xperiments/m8_mit/theory/_CITATIONS.md
@@ -10,7 +10,7 @@ Total: **16 works** as of 2026-07-21 (scaffold seeding); **0 local files** held 
 Bibliography is the readable list; the Local corpus appendix will hold the gitignored-file
 inventory as papers are pulled down for tasks (filenames follow `YEAR - Author - Title`).
 
-Identifier policy per [`ONBOARDING_MODELS.md`](../../../../ONBOARDING_MODELS.md) § 3.2
+Identifier policy per [`ONBOARDING_MODELS.md`](../../../../ONBOARDING_MODELS.md) section 3.4
 (never fabricate): all 10 Zenodo DOIs below were machine-verified resolving on 2026-07-21.
 SSRN blocks automated checks, so SSRN IDs are transcribed from the author's registry and
 marked `(author registry)`; treat them as author-attested until first use.
@@ -40,7 +40,7 @@ month ascending.
 | Shatto | 2026 Jul | An Affine Rho-Index Conversion and the Galois Pair on the Poincaré Homology Sphere | SSRN [7129118](https://ssrn.com/abstract=7129118) (author registry) |
 
 Note on venues: all entries are preprints (Zenodo / SSRN), none refereed; this is recorded
-per the [`ONBOARDING_MODELS.md`](../../../../ONBOARDING_MODELS.md) § 5.1 sourcing flag and
+per the [`ONBOARDING_MODELS.md`](../../../../ONBOARDING_MODELS.md) red-flag checklist sourcing row and
 is one reason the platform's own independent verification (M8.1 first) matters.
 
 ## Local corpus


### PR DESCRIPTION
…tandardize deep-reader orientation across the front doors

Restructure the model-author path into four steps: STEP 0 drive it with an AI agent (promoted from the buried section 6) plus the five things a model author owns (supply the compute, own the claims, engage other authors, accept the external-collaborator invitation, have a GitHub account); STEP 1 self-evaluation (the five criteria, parameter-count test, red flags and hostile cold-reader pass, now together); STEP 2 application via the New Model discussion category, with the 15 fields derived from the M8 proposal; STEP 3 scaffolding and first PR. Adds a what-is-OpenWave intro, a contents table, and the M8 scaffolding lessons: the real file set, the maintainer sequence, certification-first, and the agent-orientation doc. Written in third person throughout ("the model author"), not second person.

TUTORIAL.md is now the contributor path only: same intro, and its scaffold-a-new-model section reduced to a signpost.

CLAUDE.md gains KEY DOCUMENTS, the canonical doc map, and every front door (README, MODELS, AI_HYGIENE, CLAUDE, TUTORIAL, ONBOARDING_MODELS, CONTRIBUTING) ends with an identical DEEP READER ORIENTATION block pointing there, replacing four divergent AI-orientation blocks. REPRODUCE and SYS_ARCH get a one-line pointer.

Also corrects the CLAUDE.md model roster (EWT is M4 not M3; M7 and M8 were missing) and one stale README anchor.