### PR TITLE
Add maintainer PR review standards guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,13 @@ OpenWave investigates, in one integrated simulator, four primary domains: **matt
 | 9 | [`SYS_ARCH.md`](SYS_ARCH.md) | Module structure and system architecture |
 | 10 | [`dev_docs/METHOD_NOTE.md`](dev_docs/METHOD_NOTE.md) | **MANDATORY** reporting standard for model-owner-facing output: equations first, equation-to-code map, adversarial audit recorded |
 | 11 | [`dev_docs/CROSS_MODEL_TESTING.md`](dev_docs/CROSS_MODEL_TESTING.md) | Borrowing one column's field family into another's framework; how author-gated questions are routed |
-| 12 | [`dev_docs/`](dev_docs/) | Coding, performance, markdown, coordinate, and precision standards (listed under Code Style below) |
-| 13 | `openwave/xperiments/<model>/__M<x>_model_briefing.md` | Each column's own front door: identity, profile, honest status, help wanted |
-| 14 | `openwave/xperiments/<model>/research/` | **The results of record**: roadmaps, question trackers, task documents, findings, scripts, data, plots |
-| 15 | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) | Community expectations |
+| 12 | [`dev_docs/PR_REVIEW_STANDARDS.md`](dev_docs/PR_REVIEW_STANDARDS.md) | The maintainer-side review procedure: blast-radius tiers, the claim-to-artifact recompute, the adversarial pass, and the evidence bar for moving a `MODELS.md` cell |
+| 13 | [`dev_docs/`](dev_docs/) | Coding, performance, markdown, coordinate, and precision standards (listed under Code Style below) |
+| 14 | `openwave/xperiments/<model>/__M<x>_model_briefing.md` | Each column's own front door: identity, profile, honest status, help wanted |
+| 15 | `openwave/xperiments/<model>/research/` | **The results of record**: roadmaps, question trackers, task documents, findings, scripts, data, plots |
+| 16 | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) | Community expectations |
 
-Claims about this repository that cannot be traced to a runnable script or a research note under row 14 are not claims of this repository.
+Claims about this repository that cannot be traced to a runnable script or a research note under row 15 are not claims of this repository.
 
 ### Theoretical Advisors and Candidate Frameworks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ See `/dev_docs` for coding standards and development guidelines
 - [Performance Guidelines](dev_docs/PERFORMANCE_GUIDELINES.md)
 - [Loop Optimization Patterns](dev_docs/LOOP_OPTIMIZATION.md)
 - [Markdown Style Guide](dev_docs/MARKDOWN_STYLE_GUIDE.md)
+- [PR Review Standards](dev_docs/PR_REVIEW_STANDARDS.md): what a maintainer checks when reviewing your PR, so nothing in the review is a surprise
 - [AI Hygiene](AI_HYGIENE.md): working with automated intelligence, the dos, don'ts, and verification habits that keep the science human-owned  
 
 *This is the Way!*

--- a/dev_docs/PR_REVIEW_STANDARDS.md
+++ b/dev_docs/PR_REVIEW_STANDARDS.md
@@ -1,0 +1,323 @@
+# Pull Request Review Standards
+
+> The procedure a maintainer (or an AI coding agent acting for one) follows when reviewing a pull request, especially one from an external contributor. It exists so that review quality does not depend on who is on duty, and so that the repository's DNA survives contact with contributions it did not plan for.
+>
+> **This is a live file.** Every PR that teaches us something new gets folded back into it: a new gate, a sharper command, or a row in the [lessons log](#13-lessons-log). If a review turns up a failure mode not covered here, add it before closing the PR.
+
+## What review is, and is not
+
+[`MODELS.md`](../MODELS.md) promises contributors a **light PR review, focused on reproducibility and honest documentation, not ideological gatekeeping**. That promise is binding. This document does not raise the bar on *which physics is allowed*; it makes concrete what "reproducible and honestly documented" means, and it adds the checks that protect the shared surfaces every other contributor depends on.
+
+| Review IS | Review is NOT |
+| --- | --- |
+| Does the claim trace to something runnable, and does the artifact actually say what the text says | Does the maintainer agree with the framework |
+| Does the change stay inside its own model's blast radius | Does the code match the maintainer's personal style |
+| Does a shared file, another author's column, or a front-door doc change safely | A demand that the contributor fix pre-existing repository debt |
+| Is the claim's strength proportional to the evidence | A demand that the result be positive |
+
+A documented negative is a merge-worthy contribution. An overstated positive is not.
+
+## Contents
+
+| Section | What it covers |
+| --- | --- |
+| [1. Intake](#1-intake) | the five things to establish before reading a line of code |
+| [2. Blast-radius map](#2-blast-radius-map) | which paths get which level of scrutiny |
+| [3. Gate A: safety and hygiene](#3-gate-a-safety-and-hygiene) | large files, encoding, copyright, secrets, dangling references |
+| [4. Gate B: scope containment](#4-gate-b-scope-containment) | model-folder discipline, shared files, root documents |
+| [5. Gate C: claim to artifact](#5-gate-c-claim-to-artifact) | recompute the headline number from the shipped data yourself |
+| [6. Gate D: the adversarial pass](#6-gate-d-the-adversarial-pass) | is the mechanism wired, is the signal above the noise, do the knobs manufacture the result |
+| [7. Gate E: MODELS.md cell changes](#7-gate-e-modelsmd-cell-changes) | the evidence bar for moving a cell |
+| [8. Gate F: other authors' work](#8-gate-f-other-authors-work) | not damaging a column you do not own |
+| [9. Gate G: policy sweep](#9-gate-g-policy-sweep) | AI hygiene, conduct, contributing, reproduce, onboarding, style |
+| [10. Fairness rules](#10-fairness-rules) | measure against the enforced baseline, not the aspirational one |
+| [11. Verdict and how to write it](#11-verdict-and-how-to-write-it) | the ladder, and open-source review etiquette |
+| [12. Command appendix](#12-command-appendix) | copy-paste checks |
+| [13. Lessons log](#13-lessons-log) | what past PRs taught us |
+
+## 1. Intake
+
+Establish these five before reading any code. They set how heavy the rest of the review needs to be.
+
+| # | Establish | How | Why it matters |
+| --- | --- | --- | --- |
+| 1 | **Who** and **prior history** | `gh pr view <N> --json author` then `gh pr list --state all --author <login>` | A returning contributor's past review threads tell you what they already know and what they had to be asked twice |
+| 2 | **DCO sign-off on every commit** | `gh pr checks <N>`, plus `git log main..pr-<N> --format='%(trailers:key=Signed-off-by,valueonly)'` | Apache 2.0 provenance. Non-negotiable, and it is a one-time config fix, not a rejection (see [lessons log](#13-lessons-log)) |
+| 3 | **Blast radius** | `gh pr view <N> --json files` | Drives everything below. A PR entirely inside one model folder is a different review from one touching `common/` or a root document |
+| 4 | **What the PR claims** | the PR body plus any added research note | Write the headline claim down in one sentence. Gates C and D are tested against that sentence |
+| 5 | **Source branch** | `headRefName` | A PR from a fork's `main` is workable but fragile: the contributor cannot start a second PR without entangling it. Worth a friendly note, never a blocker |
+
+## 2. Blast-radius map
+
+Scrutiny scales with how many people a file can break. Classify every changed path.
+
+| Tier | Paths | Standard |
+| --- | --- | --- |
+| **T1 model-local** | `openwave/xperiments/<model>/` (except the briefing) | Light review. The column's author owns the physics. Check reproducibility, honesty, and that it does not reach outside |
+| **T2 model front door** | `__M<x>_model_briefing.md`, that model's `research/` roadmap and trackers | The column's public face. Check that status language matches what the artifacts support |
+| **T3 shared code** | `openwave/common/`, `openwave/gui/`, anything imported by more than one model | Heavy review. A defect here is every column's defect. Trace every caller before approving |
+| **T4 shared surfaces** | [`MODELS.md`](../MODELS.md), [`README.md`](../README.md), [`CLAUDE.md`](../CLAUDE.md), [`AI_HYGIENE.md`](../AI_HYGIENE.md), [`CONTRIBUTING.md`](../CONTRIBUTING.md), [`REPRODUCE.md`](../REPRODUCE.md), [`ONBOARDING_MODELS.md`](../ONBOARDING_MODELS.md), [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md), `SECURITY.md`, `TRADEMARK.md`, `LICENSE`, `NOTICE`, `.github/` | Maintainer-owned. Default answer to an external edit here is "let us handle it in a separate maintainer PR", unless the change is a plain factual correction |
+| **T5 another model's folder** | any `xperiments/<other model>/` | See [Gate F](#8-gate-f-other-authors-work). Requires the other column's author in the loop |
+
+**Print the tier split explicitly in the review.** A contributor should never discover after the fact that one line in their diff was the part that needed care.
+
+## 3. Gate A: safety and hygiene
+
+Mechanical checks. Run them all; they take under a minute and they catch the things a physics read will not.
+
+| # | Check | Bar | Command |
+| --- | --- | --- | --- |
+| A1 | **No large data files** | Tracked data is summary-scale: JSON, CSV, plots, manifests. Heavy arrays (`.npz`, `.npy`, raw fields, videos) stay local and gitignored, with a `_DATASETS.md` manifest recording the regeneration script instead | `git ls-tree -r -l pr-<N>` sorted by size, and diff the total against `main` |
+| A2 | **Valid UTF-8, no BOM** | Every text file decodes as UTF-8 and starts without a byte-order mark | [see appendix](#12-command-appendix). A single CP1252 byte silently breaks `grep`, `black`, and some editors |
+| A3 | **No third-party copyrighted material** | Citations, DOIs, and links only. Papers and author documents live in the gitignored `theory/` folder and are recorded in that model's `theory/_CITATIONS.md`. Contributor's own work, DCO-signed, is fine and does not need to be hidden | Read every added `.md` and `.pdf`. Check the reference list resolves to citations, not reproduced text |
+| A4 | **Citations registered** | New DOIs or author documents referenced by the PR appear in the model's `theory/_CITATIONS.md`, and stale "unpublished / DOI n/a" entries get updated | `git diff main...pr-<N> -- '*_CITATIONS.md'` |
+| A5 | **No secrets or personal data** | No keys, tokens, absolute home paths, emails beyond the commit trailer | grep the diff for `key`, `token`, `secret`, `/Users/`, `C:\Users` |
+| A6 | **Deleted files leave no dangling references** | Every deletion is either unreferenced or every referencing import and link is repointed in the same PR | grep the deleted basenames across the PR branch, `.py` and `.md` both |
+| A7 | **New files follow the folder convention** | A new subfolder inside a model folder must match what the other columns use (`research/`, `theory/`, `data/`, `plots/`, `xparameters/`). A novel folder name is a convention fork | `ls -d openwave/xperiments/*/*/` and compare |
+| A8 | **Repository language is English** | Code comments, docstrings, and documentation in English, so every author and cold reader can read every column | scan added comment lines for non-English text |
+
+## 4. Gate B: scope containment
+
+The default expectation is that a model contribution touches only its own model folder.
+
+| Question | If the answer is yes |
+| --- | --- |
+| Does the PR change a **T3 shared file**? | Enumerate every consumer (`grep -rn "<module>"`), and confirm the change is backward-compatible for all of them. Behaviour changes to shared code need their own justification in the PR body, not a line buried in a feature diff |
+| Does the PR change a **T4 shared surface**? | Ask for it to be split out, unless it is a plain factual correction. Front-door documents carry the project's voice and are maintainer-owned |
+| Does the PR change **defaults** that other experiments read? | Defaults are shared state. A default that only the new work needs belongs in the new work's own configuration file, not in the shared default block |
+| Does the PR **remove an existing gate or option**? | Removing a flag (for example an instrumentation on/off switch) changes behaviour for everyone using that model. Ask for it to be preserved or for the removal to be stated as intentional |
+| Does the PR **silently change a tuning constant** used by existing results? | Any constant that existing published cells were earned under is load-bearing. Changing it invalidates those cells until re-run. Ask for it to be moved into the per-experiment configuration instead |
+
+## 5. Gate C: claim to artifact
+
+This is the gate [`REPRODUCE.md`](../REPRODUCE.md) and [`AI_HYGIENE.md`](../AI_HYGIENE.md) exist to enforce, and it is where most real problems surface.
+
+**The rule: do not read the numbers, recompute them.** If the PR ships the data, write your own short script, from the raw artifact, using your own definition of the metric, and compare. This is the [adversarial audit](../AI_HYGIENE.md#1-the-stance) applied to review.
+
+| # | Check | Bar |
+| --- | --- | --- |
+| C1 | **Every claim links something runnable** | A number in a research note traces to a script in the PR, or to a configuration file plus a command. Prose-only numbers do not merge |
+| C2 | **The analysis step is shipped too** | Shipping raw logs is not enough if the note's tables were produced by an unshared script. The script that turns logs into the reported table is part of the claim |
+| C3 | **The reported numbers match the shipped data** | Recompute at least the headline metric and one table. Report any disagreement with both numbers |
+| C4 | **The metric is defined unambiguously** | "Drift" must say whether it is a Euclidean norm, a per-axis component, or a maximum over axes. Mixed definitions inside one document are a defect even when each number is individually defensible |
+| C5 | **Internal consistency** | The same quantity carries the same value in the abstract, the summary table, and the detail table. Cross-check them against each other before checking either against the data |
+| C6 | **The reproduction route is written down** | A reader with a clean clone can get from the claim to the command. Per [`REPRODUCE.md`](../REPRODUCE.md) that lives in the research note, once |
+| C7 | **Claim strength matches evidence strength** | "Within the explored parameter range, X" is a result. "Proof of X" from an empirical sweep is not. Words like *proof*, *confirmed*, *uniquely*, and *demonstrates* each need the artifact that earns them |
+
+## 6. Gate D: the adversarial pass
+
+Gate C asks whether the numbers are real. Gate D asks whether they mean what the author says they mean. Run this on any PR that claims a physics result.
+
+| # | Question | Why it catches things |
+| --- | --- | --- |
+| D1 | **Is the proposed mechanism actually wired in the code path that produced the result?** | Follow the named mechanism from the configuration file, through the launcher, into the kernel, and confirm it is non-zero for the mode actually used. A new term added to an `if / elif` chain with no branch for the selected mode contributes exactly zero |
+| D2 | **Is the independent variable coupled to the dynamics at all?** | If the claim is "X selects the outcome", find the term through which X enters. If diagnostics are identical across every value of X, the likeliest explanation is that X is not in the loop, not that the diagnostic is insensitive |
+| D3 | **Is the discriminator larger than the known systematic error?** | If the note itself lists integrator drift, rounding, or a truncation asymmetry as open bugs, compare their size to the gap between the "pass" and "fail" cases. A signal of the same order as the acknowledged error is not a result yet |
+| D4 | **Do the knobs manufacture the outcome?** | Damping, clamping, a reduced timestep, and a shortened run all suppress the very motion being measured. Check what the tuning constants do over the full run length before accepting "it stayed put" as physics |
+| D5 | **Has anything converged?** | Plot the discriminating metric against time. If every configuration is still rising monotonically at the last sample, the finding is a rate difference, not a stability difference. Say so |
+| D6 | **Is the run long enough in physical time?** | Step counts are not time. A run at a tenth of the usual CFL safety factor covers a tenth of the physical duration for the same step count |
+| D7 | **Do any two runs agree suspiciously well?** | Bit-identical trajectories from configurations that should differ are a wiring diagnostic, not a coincidence |
+| D8 | **Are the controls controls?** | A control must differ from the test case in exactly the intended variable. Check the configuration files, not the file names |
+| D9 | **What would falsify this?** | If the note cannot say, ask. A model author who can name the falsifier is describing a result; one who cannot is describing a hope |
+
+Findings from this gate are **questions to the author**, not verdicts. The author owns the physics; the reviewer owns the demand that the claim and the artifact agree.
+
+## 7. Gate E: MODELS.md cell changes
+
+[`MODELS.md`](../MODELS.md) is the platform's product. Cells move in both directions, and they are earned one at a time.
+
+| Situation | What the maintainer does |
+| --- | --- |
+| The PR **proposes a cell change** | Open the linked artifact and re-derive the icon from it, using the status semantics in [`MODELS.md`](../MODELS.md). A cell claim is not accepted on the PR body's description of the artifact |
+| The PR **produces a result but proposes no cell change** | Correct default for an external contributor. The maintainer decides separately whether the result now merits a cell move, in a maintainer PR, after Gates C and D pass |
+| The result is real but **weaker than the cell it would claim** | ⚠️ partial with the caveat inline, not ✅. The caveat belongs in the cell, not in an appendix |
+| The result is a **documented negative** | ❌ is a result. It merges on the same evidence bar as a positive |
+| The result **contradicts an existing cell in the same column** | Both cells are the author's. Route through the column's author before either changes |
+| The PR is **mid-flight work** | 🔶 lives on per-model pages, not in the shared matrix. 🚧 stays until something runnable exists |
+
+Before approving any cell move, run `python3 dev_docs/check_models_md.py` and confirm the summary counts still add up.
+
+## 8. Gate F: other authors' work
+
+Every column carries a person's name. Protecting that is a maintainer duty, and it is the part of review an author cannot do for themselves.
+
+| # | Rule |
+| --- | --- |
+| F1 | A contributor extending a column they do not own contributes **under their own name**, and the research note says whose extension it is. The scoring rules for borrowed structure are in [`CROSS_MODEL_TESTING.md`](CROSS_MODEL_TESTING.md) |
+| F2 | A change that **invalidates results another author earned** (a tuning constant, a shared kernel, a removed diagnostic) is a blocking finding until either the results are re-run or the change is scoped so they are untouched |
+| F3 | Never let a review thread turn into a defence of someone else's physics. The maintainer checks reproducibility and containment; the author answers challenges to the model, per [`ONBOARDING_MODELS.md`](../ONBOARDING_MODELS.md) |
+| F4 | A **regression in shared infrastructure** is the maintainer's to catch, because no single author will see it. Trace the callers |
+
+### 8.1 When the contributor is not the model author
+
+Check this on every PR that touches `openwave/xperiments/<model>/`: is the contributor the author of that column? The Identity table in the model briefing is the record (`Author` and `Author contact` rows; an `Extension` row names contributors who extend the column without owning it).
+
+**If the contributor is not the column's author, the review carries a model-author note**: a short block naming the author, **@-mentioning the author's GitHub handle**, and stating which findings are the author's call and which are not. The contributor learns from the review itself who holds authority over what, rather than discovering it after a merge.
+
+The @-mention is the mechanism, not a courtesy. GitHub notifies on `@handle` and on nothing else: writing the author's name in prose delivers no notification, and neither does a link to the briefing. Rules for it:
+
+| # | Rule |
+| --- | --- |
+| M1 | Take the handle from the model briefing's **`Author contact`** row, which is where it is maintained. Do not guess it from the author's name |
+| M2 | Put the `@handle` in the **first sentence** of the model-author note, not buried in a table cell or a closing line. It is what makes the routing real |
+| M3 | Mention **once**, in the review body. Repeating it in every subsequent comment turns the channel into noise, which is the thing [`AI_HYGIENE.md`](../AI_HYGIENE.md) § 3 warns about |
+| M4 | Say in the same sentence **what is being asked**. A bare mention reads as a summons; "tagging @handle on the two rows below, the rest is mine" is actionable |
+| M5 | If the briefing carries **no handle**, that is a gap in the briefing. Route by the contact that does exist, say so in the thread, and open a follow-up to fill the Identity table |
+| M6 | Mention the author, not the whole org or a team alias. One named person owns the column |
+
+What that note routes is decided per finding, not per PR:
+
+| Finding type | Author-gated? | Who decides |
+| --- | --- | --- |
+| Engine, kernel, or solver change to the column | ✅ yes | The author. It changes what the column *is* |
+| Change to defaults or tuning constants existing cells were earned under | ✅ yes | The author, since it is the author's results that are revalued |
+| A headline physics claim about the column, or a `MODELS.md` cell move | ✅ yes | The author, on the science. The maintainer still holds the evidence bar in [Gate E](#7-gate-e-modelsmd-cell-changes) |
+| Reinterpreting what an existing cell or a past result means | ✅ yes | The author. This is intent and provenance, and [`AI_HYGIENE.md`](../AI_HYGIENE.md) makes it structurally unanswerable by anyone else |
+| A new experiment, configuration, or geometry added alongside the existing ones | ❌ no | The maintainer. Additive, changes nothing the author already owns |
+| Code regression, dangling import, encoding defect, formatting | ❌ no | The maintainer. Mechanical correctness is not a physics question |
+| Documentation, cross-links, citation registration, folder conventions | ❌ no | The maintainer |
+| Numbers in a note disagreeing with the shipped data | ❌ no | The maintainer, against the artifact. Only the *interpretation* of the corrected numbers is author-gated |
+
+**A PR with no author-gated findings does not need the author in the loop.** Merge it. Pulling an author into every additive contribution burns the one channel that matters for the questions only the author can answer, which is the failure mode [`AI_HYGIENE.md`](../AI_HYGIENE.md) § 3 warns about ("keep such asks as small as possible, one item per ask").
+
+**Where there is at least one author-gated finding, the author has the final say on those findings**, and the PR does not merge past them on the maintainer's opinion alone. The maintainer's own blocking findings (the ❌ rows above) stay the maintainer's and are fixed regardless.
+
+Author-gated does not mean author-blocked forever. If the author does not respond, the maintainer may merge the non-gated part and keep the gated part open as an issue, saying so in the thread.
+
+## 9. Gate G: policy sweep
+
+Fast pass over the standing policies. Most PRs clear this in a minute.
+
+| Policy | What to check |
+| --- | --- |
+| [`AI_HYGIENE.md`](../AI_HYGIENE.md) | Claims script-backed, not model-fluent. Status attached to AI-assisted findings. No aggregate self-ranking or cross-program scoreboards. Substantive claims carry an adversarial check, and the review itself is one |
+| [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) | Applies to the review thread as much as the contribution. Critique the artifact, never the contributor |
+| [`CONTRIBUTING.md`](../CONTRIBUTING.md) | DCO, Apache 2.0, fork and branch flow, PEP 8 and Black as the style target (see [fairness](#10-fairness-rules) on how hard to press this) |
+| [`REPRODUCE.md`](../REPRODUCE.md) | Reproduction route recorded once, in the research note. Nothing result-shaped lands in `REPRODUCE.md` itself |
+| [`ONBOARDING_MODELS.md`](../ONBOARDING_MODELS.md) | For a new column: scaffold set complete, briefing filled, author responsibilities accepted, collaborator invitation sent |
+| [`MARKDOWN_STYLE_GUIDE.md`](MARKDOWN_STYLE_GUIDE.md) | Blank lines around headings and lists, single trailing newline, fenced blocks carry a language |
+| [`METHOD_NOTE.md`](METHOD_NOTE.md) | Required shape for anything that will be reported to a theory owner or an external physicist: equations first, equation-to-code map, the not-computed list, the audit recorded |
+| [`CODING_STANDARDS.md`](CODING_STANDARDS.md) | Naming, docstrings, type hints, Taichi kernel guidance |
+
+## 10. Fairness rules
+
+These exist so review stays honest in both directions.
+
+| # | Rule |
+| --- | --- |
+| G1 | **Measure the PR against the enforced baseline, not the aspirational one.** Before citing a standard, check whether `main` itself passes it. If the repository has drift, that is the maintainer's debt, not the contributor's blocker. Say so out loud in the review |
+| G2 | **Separate blocking from optional, explicitly.** Every finding is labelled: blocking, requested, or note. A contributor should be able to count the blockers on one hand and know exactly what merges the PR |
+| G3 | **Ask, do not silently fix.** Pushing corrections into someone else's branch removes their chance to understand the standard. Fix it yourself only when they ask, or when it is a maintainer-owned file |
+| G4 | **Give the command, not just the complaint.** The one-time DCO config, the exact reformat invocation, the recompute script. Reviews that ship commands get resolved in one round |
+| G5 | **A negative result is not a weak PR.** Neither is a small one |
+| G6 | **State what you verified and what you did not.** A review that implies more checking than happened is the same failure mode as an overstated claim |
+| G7 | **Findings from an AI-assisted review are findings, not verdicts,** until they carry the command that reproduces them. Same contract as everything else here |
+
+## 11. Verdict and how to write it
+
+| Verdict | When | Action |
+| --- | --- | --- |
+| ✅ **Approve and merge** | All gates clear, or only notes remain | Merge. Record anything learned in the [lessons log](#13-lessons-log) |
+| 🔶 **Approve with follow-ups** | Gates clear; requested items are real but not load-bearing | Merge, and open issues for the follow-ups so they do not evaporate |
+| ⚠️ **Changes requested** | Blocking findings exist, all of them fixable by the contributor | Post the findings with commands. Re-review only the deltas |
+| 🚧 **Split requested** | The contribution is sound but mixes tiers (model work plus shared-surface edits) | Ask for the shared-surface part to come out; merge the rest |
+| ❌ **Decline** | Provenance cannot be established, or the contribution cannot be made reproducible | Rare. Explain which gate failed and what would change the answer |
+
+**Review structure that works:**
+
+1. One sentence on what the PR does and what it claims.
+2. The tier split, so the blast radius is visible.
+3. ✅ what passed, briefly. Contributors deserve to see the checks that cleared.
+4. Blocking findings, each with: the file and line, what you ran, what you got, and what would fix it.
+5. Requested and note items, clearly separated.
+6. The physics questions from Gate D, framed as questions to the author.
+7. The **model-author note**, when the contributor is not the column's author ([§ 8.1](#81-when-the-contributor-is-not-the-model-author)): the author's `@handle` in the opening sentence so the notification actually fires, then which findings are the author's call.
+8. What you did not check.
+
+Findings are about artifacts. "This table disagrees with the shipped data" is a finding; "you were careless" is not. Where a finding could read as a challenge to the author's model rather than to the artifact, say which one you mean.
+
+## 12. Command appendix
+
+Fetch and isolate the PR:
+
+```bash
+gh pr view <N> --json number,title,author,body,files,changedFiles,additions,deletions,headRefName,mergeable
+gh pr checks <N>
+git fetch origin pull/<N>/head:pr-<N>
+git log main..pr-<N> --format='%H%n  %an <%ae>%n  signoff: %(trailers:key=Signed-off-by,valueonly)%n  %s'
+git worktree add --detach /tmp/pr-<N> pr-<N>     # review without disturbing your tree
+```
+
+Blast radius and size:
+
+```bash
+git diff main...pr-<N> --stat
+git diff main...pr-<N> --name-only --diff-filter=D          # deletions
+git ls-tree -r -l pr-<N> | awk '{print $4, $5}' | sort -rn | head -20
+```
+
+Encoding audit (A2), the check that catches what `grep` cannot report:
+
+```bash
+python3 - <<'PY'
+import subprocess, os
+files = subprocess.run(["git","diff","main...pr-<N>","--name-only","--diff-filter=d"],
+                       capture_output=True, text=True).stdout.split()
+for f in files:
+    if not os.path.exists(f):
+        continue
+    d = open(f, "rb").read()
+    if d.startswith(b"\xef\xbb\xbf"):
+        print("BOM:", f)
+    try:
+        d.decode("utf-8")
+    except UnicodeDecodeError as e:
+        print("NOT UTF-8: %s byte %s line %d" % (f, hex(d[e.start]), d[:e.start].count(b"\n") + 1))
+PY
+```
+
+Dangling references after a deletion (A6):
+
+```bash
+for f in $(git diff main...pr-<N> --name-only --diff-filter=D); do
+  base=$(basename "$f" .py)
+  echo "--- $base"; git grep -n "$base" pr-<N> -- '*.py' '*.md'
+done
+```
+
+Style and import sanity, on the PR worktree:
+
+```bash
+cat filelist.txt | tr '\n' '\0' | xargs -0 python3 -m black --check
+python3 -m py_compile <changed files>
+python3 dev_docs/check_models_md.py
+```
+
+## 13. Lessons log
+
+One row per PR that taught us something. Newest at the bottom.
+
+| PR | Lesson | Where it landed |
+| --- | --- | --- |
+| [#196](https://github.com/openwave-labs/openwave/pull/196) | A DCO block is a configuration problem, not a rejection. Shipping the exact four commands, customized to the contributor's branch, resolved it in one round. Warn that a force-push dismisses the standing approval | Intake row 2, fairness rule G4 |
+| [#297](https://github.com/openwave-labs/openwave/pull/297) | Two things a diff read catches that a claim read does not: a backend left on CPU, and inline comments stripped by an auto-formatter. Those comments were there for cold readers, so their removal is a real loss even though no behaviour changed | Gate B (removing an existing option), Gate G |
+| [#340](https://github.com/openwave-labs/openwave/pull/340) | Recomputing the headline table from the shipped data disagreed with the note, and following the named mechanism through the code showed it contributing zero in the mode actually used. Both were invisible from the PR body. Also: one CP1252 byte in a shared module made `grep` silently skip the file during review | Gate C (recompute, do not read), Gate D rows 1 and 2, Gate A row A2 |
+| [#340](https://github.com/openwave-labs/openwave/pull/340) | The contributor was extending a column owned by someone else, and the PR changed that column's engine defaults while claiming its headline open problem. Nothing in the process said when the column's author has to be in the loop and when that would just be noise, so the per-finding routing was written down | Gate F § 8.1, review structure item 7 |
+
+---
+
+## See also
+
+| Doc | Why |
+| --- | --- |
+| [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | The contributor's side of this process: setup, fork and branch flow, DCO |
+| [`../AI_HYGIENE.md`](../AI_HYGIENE.md) | The adversarial-audit cardinal rule that Gates C and D implement |
+| [`../MODELS.md`](../MODELS.md) | The coverage matrix, its status semantics, and the light-review promise |
+| [`../REPRODUCE.md`](../REPRODUCE.md) | What "reproducible" means here, and where reproduction commands live |
+| [`../ONBOARDING_MODELS.md`](../ONBOARDING_MODELS.md) | Model-author responsibilities and the scaffolding sequence for a new column |
+| [`CROSS_MODEL_TESTING.md`](CROSS_MODEL_TESTING.md) | Scoring rules when a contribution reaches into another column |
+| [`METHOD_NOTE.md`](METHOD_NOTE.md) | The reporting shape required for model-owner-facing results |
+
+---
+
+**Deep readers and AI agents**: the full map of OpenWave's key documents, and the order to read them in, is in [`../CLAUDE.md`](../CLAUDE.md). The AI-collaboration contract is [`../AI_HYGIENE.md`](../AI_HYGIENE.md).


### PR DESCRIPTION
Introduces `dev_docs/PR_REVIEW_STANDARDS.md`, a comprehensive maintainer-facing review playbook covering intake, blast-radius tiers, safety/hygiene gates, claim-to-artifact recompute checks, adversarial review, `MODELS.md` cell criteria, and verdict rules. Also updates `CLAUDE.md`’s key document map to include the new standard and adjusts row references, and adds a link in `CONTRIBUTING.md` so contributors can align with review expectations up front.