### PR TITLE
Fix data and plot paths broken by the utils/ move

### DIFF
--- a/openwave/xperiments/m2_free_wave/utils/instrumentation.py
+++ b/openwave/xperiments/m2_free_wave/utils/instrumentation.py
@@ -16,7 +16,8 @@ from openwave.common import colormap, constants
 # Module-level Constants (computed once at import)
 # ================================================================
 
-_MODULE_DIR = Path(__file__).parent
+# The model root, one level above utils/, so data and plots stay where they always were.
+_MODULE_DIR = Path(__file__).resolve().parent.parent
 DATA_DIR = _MODULE_DIR / "data"
 PLOT_DIR = _MODULE_DIR / "plots"
 

--- a/openwave/xperiments/m3_wolff_lafreniere/utils/instrumentation.py
+++ b/openwave/xperiments/m3_wolff_lafreniere/utils/instrumentation.py
@@ -16,7 +16,8 @@ from openwave.common import colormap, constants
 # Module-level Constants (computed once at import)
 # ================================================================
 
-_MODULE_DIR = Path(__file__).parent
+# The model root, one level above utils/, so data and plots stay where they always were.
+_MODULE_DIR = Path(__file__).resolve().parent.parent
 DATA_DIR = _MODULE_DIR / "data"
 PLOT_DIR = _MODULE_DIR / "plots"
 

--- a/openwave/xperiments/m5_liquid_crystal/utils/instrumentation.py
+++ b/openwave/xperiments/m5_liquid_crystal/utils/instrumentation.py
@@ -16,7 +16,8 @@ from openwave.common import colormap
 # Module-level Constants (computed once at import)
 # ================================================================
 
-_MODULE_DIR = Path(__file__).parent
+# The model root, one level above utils/, so data and plots stay where they always were.
+_MODULE_DIR = Path(__file__).resolve().parent.parent
 DATA_DIR = _MODULE_DIR / "data"
 PLOT_DIR = _MODULE_DIR / "plots"
 


### PR DESCRIPTION
instrumentation.py resolved DATA_DIR and PLOT_DIR from Path(__file__).parent. After moving the module into <model>/utils/ in #344 that resolved one level too deep, so runs would write into <model>/utils/data and <model>/utils/plots instead of the model's own folders. Resolve from the model root instead.

m1 has no such constant. m4's copies of the same bug are fixed on PR #340, where that model's move happens.