### PR TITLE
Bump version to 1.6.5

### DIFF
--- a/openwave/__init__.py
+++ b/openwave/__init__.py
@@ -5,4 +5,4 @@ to study particle and force emergence. GPU-accelerated.
 
 """
 
-__version__ = "1.6.4"
+__version__ = "1.6.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "OPENWAVE"
 # - MAJOR: Breaking changes (incompatible API changes)
 # - MINOR: New features (backward-compatible)
 # - PATCH: Bug fixes (backward-compatible)
-version = "1.6.4"
+version = "1.6.5"
 
 requires-python = ">=3.12"
 


### PR DESCRIPTION
Updates the package version from 1.6.4 to 1.6.5 in both `pyproject.toml` and `openwave/__init__.py` to keep release metadata consistent.