### PR TITLE
Clarify trademark ownership across docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,7 +166,7 @@ See the [LICENSE](LICENSE) and [NOTICE](NOTICE) files for full terms.
 
 ## Trademark Notice
 
-OpenWave™ is a trademark of the OpenWave project. See [TRADEMARK.md](TRADEMARK.md) for usage guidelines.
+OpenWave™ is a trademark owned by the project's founder, used by the OpenWave open-source project. See [TRADEMARK.md](TRADEMARK.md) for usage guidelines.
 
 ## Need Help?
 

--- a/NOTICE
+++ b/NOTICE
@@ -4,8 +4,9 @@ Copyright 2025 The OpenWave Authors
 This product includes software developed as part of the OpenWave project
 (https://github.com/openwave-labs/openwave).
 
-"OpenWave" is a trademark of the OpenWave project. See the TRADEMARK.md file
-in the project repository for usage guidelines.
+"OpenWave" is a trademark owned by the project's founder, used by the OpenWave
+open-source project. See the TRADEMARK.md file in the project repository for
+usage guidelines.
 
 Project leads: Rodrigo Griesi, Jeff Yee.
 Additional contributors are credited in the project commit history.

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ All dependencies use licenses compatible with Apache 2.0.
 
 ### Trademark
 
-OpenWave™ is a trademark of the OpenWave project. See [TRADEMARK.md](TRADEMARK.md) for usage guidelines.
+OpenWave™ is a trademark owned by the project's founder, used by the OpenWave open-source project. See [TRADEMARK.md](TRADEMARK.md) for usage guidelines.
 
 ---
 

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -2,7 +2,7 @@
 
 ## Trademark Ownership
 
-"OpenWave" and the OpenWave logo (if applicable) are trademarks of the OpenWave project ("we" or "us").
+"OpenWave" and the OpenWave logo (if applicable) are trademarks owned by the project's founder, used by the OpenWave open-source project ("we" or "us").
 
 ## Purpose
 
@@ -87,4 +87,4 @@ We may update this trademark policy. Check this file periodically for changes.
 
 ---
 
-**Last Updated:** 2026-07-25
+**Last Updated:** 2026-07-27

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -67,7 +67,7 @@ All licenses are compatible with Apache 2.0.
 Trademark
 ---------
 
-OpenWave™ is a trademark of the OpenWave project.
+OpenWave™ is a trademark owned by the project's founder, used by the OpenWave open-source project.
 See `TRADEMARK.md <https://github.com/openwave-labs/openwave/blob/main/TRADEMARK.md>`_
 for usage guidelines.
 


### PR DESCRIPTION
Update trademark attribution in CONTRIBUTING.md, NOTICE, README.md, TRADEMARK.md, and docs/license.rst to clarify that 'OpenWave' is a trademark owned by the project's founder (not 'the project' as a collective entity), while still noting its use by the open-source project.