### PR TITLE
Bump version to 1.6.6

### DIFF
--- a/openwave/__init__.py
+++ b/openwave/__init__.py
@@ -5,4 +5,4 @@ to study particle and force emergence. GPU-accelerated.
 
 """
 
-__version__ = "1.6.5"
+__version__ = "1.6.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "OPENWAVE"
 # - MAJOR: Breaking changes (incompatible API changes)
 # - MINOR: New features (backward-compatible)
 # - PATCH: Bug fixes (backward-compatible)
-version = "1.6.5"
+version = "1.6.6"
 
 requires-python = ">=3.12"
 


### PR DESCRIPTION
This pull request updates the package version from 1.6.5 to 1.6.6 to reflect recent changes. No other code or feature changes are included.

* Updated the version number in `openwave/__init__.py` to "1.6.6"
* Updated the version number in `pyproject.toml` to "1.6.6"