### PR TITLE
M8.5-A: adopt the author's three directions from #382

### DIFF
--- a/dev_docs/tasks/t4_task_details.md
+++ b/dev_docs/tasks/t4_task_details.md
@@ -56,13 +56,20 @@ containment is that no part of the packet is capable of carrying a target:
 | Part | Audit |
 | --- | --- |
 | `PROTOCOL.md` | a verbatim copy of the frozen protocol, so `diff` against the repository file is the whole audit and no authorship enters |
-| `GROUP_INPUT.md` | two generators as unit quaternions. The audit is mechanical: closure gives exactly 120 elements, and the file carries no labels, dimensions, distances, or character values |
+| `GROUP_INPUT.md` | two generators as unit quaternions, supplied by the model author. The audit is mechanical: closure gives exactly the expected order, and the file carries no labels, dimensions, distances, or character values |
 | `TASK.md` | operational instructions only: the added gates, the § 6 declaration, output paths. Its mathematical content is generic identities, not values |
 
-**Generators, not the full element set.** G1 gates group order and closure. Handing over all
-120 icosians makes G1 true by construction, which is precisely the class of check the column
-banned after `m7_trivial_ok`. Handing two generators makes the agent build the closure and G1
-becomes a check that can fail.
+**Generators, not the full element set.** G1 gates group order and closure. Handing over the
+complete element set makes G1 true by construction, which is precisely the class of check the
+column banned after `m7_trivial_ok`. Handing two generators makes the agent build the closure
+and G1 becomes a check that can fail.
+
+**Canonicalize before hashing.** The packet hash is what preserves provenance across the run,
+and it is only meaningful if the same group always produces the same bytes. Generator
+components are generally irrational, so a supplied decimal rendering fixes a hash to a
+transcription rather than to a group. Canonicalization (a declared exact form, or a declared
+precision and ordering) happens in block A before the hash is taken, and the canonical form
+is what enters the room.
 
 **Implementer eligibility.** Any context that has read the M8.2 generator, the maintainer
 reconstruction, or the pre-registration § 6.1 is permanently disqualified, whatever it later
@@ -86,7 +93,7 @@ holding the targets defeats the firewall no matter how innocuous the sentence lo
 
 | Block | Work | Commit boundary |
 | --- | --- | --- |
-| A | assemble the packet, audit it (closure to exactly 120, no derived annotations, `diff` on the protocol copy) | the packet, committed first so its timestamp predates the run |
+| A | receive the author's generators; audit the packet (closure to the expected order, no derived annotations, `diff` on the protocol copy), canonicalize it, record its SHA-256 | the packet and its hash, committed first so the timestamp predates the run |
 | B | the clean-room session: implementation, gates, runnable mutation harness, the § 6 module, raw output and JSON | none; the agent writes only inside the room |
 | C | copy artifacts out, generate SHA-256, write the environment record and method-note draft | **the § 9 commitment.** Nothing is unsealed before it lands |
 | D | unseal; build the § 7 comparison harness with its transcription mutation; adjudicate | second, separately dated commit |

--- a/openwave/xperiments/m8_mit/research/tasks/m8_5_task_details.md
+++ b/openwave/xperiments/m8_mit/research/tasks/m8_5_task_details.md
@@ -114,9 +114,11 @@ land as a systematically shifted table, so they report as **partial disagreement
 structural failure. That is a false negative on reproduction, the expensive direction, since the
 fresh implementation reads as having failed to reproduce a correct table.
 
-Raised in the [PR #380](https://github.com/openwave-labs/openwave/pull/380) review. Whether they
-also enter the frozen floor as a § 11 dated addendum is the author's call; step 2 runs them
-either way.
+Raised in the [PR #380](https://github.com/openwave-labs/openwave/pull/380) review; the author
+accepted them into the frozen floor as a narrow dated addendum (2026-07-30). The reason given
+is the one that matters and was not the reason they were proposed: an implementer-added gate
+binds one implementation, while the floor binds every implementation and every rerun, and these
+two catch defects that make a CORRECT target table appear not to reproduce.
 
 #### Operational items, settled (2026-07-30)
 
@@ -133,13 +135,15 @@ identifies `Q` from the elements themselves through `χ_Q(g) = 2cos θ(g)` rathe
 declaration, so the element set fixes the `standard` and `galois` column assignment with no
 free parameter left to whoever hands it over. The standard 120 icosians (8 units, 16 Hurwitz,
 96 golden-set even permutations) are what object 2 built, and its C4 and C8 confirm that set
-agrees with § 6.1 on all 9 rows. What remains is provenance rather than correctness: the
-protocol reads as the author supplying the packet and the maintainer auditing it, which keeps
-the audit a cross-check instead of a self-audit. Asked in
-[PR #382](https://github.com/openwave-labs/openwave/pull/382); if it goes unanswered, the
-maintainer assembles the packet from the public icosian construction and records the
-self-audit as a stated limitation, following this column's standing rule that author silence
-is a valid terminal state ([roadmap § CONVENTIONS](../m8_roadmap.md#conventions)).
+agrees with § 6.1 on all 9 rows. What remained was provenance rather than correctness, and the
+author settled it in [PR #382](https://github.com/openwave-labs/openwave/pull/382)
+(2026-07-30): **the author supplies the raw embedded generators; the maintainer audits,
+canonicalizes, and hashes the packet.** The audit stays a cross-check rather than a self-audit,
+and the packet hash is an addition beyond § 4, which requires only the consulted-files
+manifest. Canonicalization is what makes the hash meaningful, since the components are
+irrational in `φ` and an uncanonicalized decimal rendering hashes differently for the same
+group. The maintainer's own pre-verified pair is retained as a cross-check on the supplied
+generators, never as the packet.
 
 **Planned § 9 declaration: the § 6 coexact module RUNS.** Fixed at the commitment, before
 anything is unsealed, and unavailable afterwards. The cost is the implementer deriving the

--- a/openwave/xperiments/m8_mit/research/tasks/m8_8_task_details.md
+++ b/openwave/xperiments/m8_mit/research/tasks/m8_8_task_details.md
@@ -26,6 +26,14 @@ point at.
 | Not in scope | the mass comparison itself (M8.3 verified its arithmetic), and the dead-zone entries' physical status (open on the source page) |
 | Precedent to follow | the M8.5-A shape: gates that can go red, a coverage-enforced mutation harness, an explicit list of what is not verified |
 
+**The implementer must be a fresh context** (author direction, 2026-07-30). Whoever runs this
+may not be the context that produced the M8.3 computation, on the same reasoning that shaped
+M8.5-A: a context holding the closed forms and their derived fixtures cannot serve as its own
+reproducer however separately the second implementation is written. The owner therefore stays
+deliberately unassigned rather than defaulting to the nearest available context. Protocol
+authorship can be assigned later without compromising the reproduction, and nothing on the
+dynamics path waits on either.
+
 **Gated by**: M8.3 ✅ (2026-07-28) and an owner. The sign convention is fixed once on the `R7`
 closed form and declared, so the remaining forms are genuine checks rather than circular
 ([`m8_3_method_note.md § 4`](../findings/m8_3_method_note.md)).


### PR DESCRIPTION
Take G11 and G12 into the frozen floor on the author's reason rather than ours: an implementer-added gate binds one implementation, the floor binds every implementation and rerun. The addendum is the author's to file.

Settle packet provenance. The author supplies the raw embedded generators; the maintainer audits, canonicalizes, and hashes. The hash goes beyond section 4, which asks only for the manifest, and it forces canonicalization first: components are irrational in phi, so hashing a decimal rendering pins the hash to a transcription rather than to a group.

Record on M8.8 that the implementer must be a fresh context and that the owner stays deliberately unassigned rather than defaulting to the M8.3 computation context.