### PR TITLE
Clarify clean-room packet audit boundaries

### DIFF
--- a/dev_docs/tasks/t4_task_details.md
+++ b/dev_docs/tasks/t4_task_details.md
@@ -20,7 +20,7 @@ physics and files on the [M8 roadmap](../../openwave/xperiments/m8_mit/research/
 under M8.5-A, where its planning already sits in
 [`m8_5_task_details.md`](../../openwave/xperiments/m8_mit/research/tasks/m8_5_task_details.md).
 
-**Deliverable**: `dev_docs/CLEAN_ROOM.md` (created at block E; linked from here when it
+**Deliverable**: `dev_docs/CLEAN_ROOM.md` (written at block F; linked from here when it
 exists), a standard written from an exercise rather than in the abstract, in the shape of [`METHOD_NOTE.md`](../METHOD_NOTE.md)
 and [`CROSS_MODEL_TESTING.md`](../CROSS_MODEL_TESTING.md). It is written after the first run,
 not before, so it records what actually held; if the M8.5-A run refutes the procedure, the
@@ -57,7 +57,7 @@ uses; the machinery does not make a run blind.
 | Location | any directory with no `CLAUDE.md` anywhere on its ancestor path, and outside every repository working tree. The concrete path is a local choice and stays out of the repository |
 | Launch | `claude --disallowedTools "WebSearch,WebFetch"` |
 | Write scope | the implementer writes only inside the room and never reaches the repository; a maintainer copies artifacts out and performs every commit |
-| Teardown | the room is deleted at the end of the run, block F below. Not before: a rerun under § 3 needs it, and it is the only copy until block C has copied the artifacts out |
+| Teardown | the room is deleted at the end of the run, block G below. Not before: a rerun under § 3 needs it, it is the only copy until block C has copied the artifacts out, and block F may need to check a detail against it |
 
 **The ancestor-path rule is the load-bearing one, and it is easy to get wrong.** A folder
 alongside the repository looks isolated and is not: any `CLAUDE.md` above it loads on the first
@@ -100,6 +100,37 @@ is what enters the room.
 reconstruction, or the pre-registration § 6.1 is permanently disqualified, whatever it later
 forgets. That includes the session that writes the packet.
 
+**Author-side verification evidence is not the audit.** An author may ship a verification
+script and report alongside the packet. It stays outside the room, and it does not discharge
+the maintainer audit: an audit that reads the supplier's report and concurs is a review of the
+report, not an independent check of the packet. Run the audit from the packet alone, then set
+the two results side by side as a cross-check. Where the author states a hash of the delivered
+bytes, record it as the INCOMING hash and state whether canonicalization changed it, so the
+chain from delivery to room is complete either way.
+
+**Prepared artifacts must outlive the session that wrote them.** The packet's non-supplied
+parts are drafted before the run, and a scratch directory is not a home for them:
+
+| Artifact | Home |
+| --- | --- |
+| `TASK.md` | committed with the packet at block A. Committing it before the room opens is what stops it being read as retrofitted to the outcome |
+| the packet audit script and its output | committed with the packet at block A, into the column's `scripts/` and `data/` |
+| the opening prompt | § The opening prompt below |
+
+### The opening prompt
+
+The message that starts the clean-room session is deliberately near-empty, because everything
+the implementer needs is already in the room:
+
+> Read `PROTOCOL.md`, `TASK.md`, and `GROUP_INPUT.md` in this directory, in that order, then do
+> what `TASK.md` says. Everything you need is here; nothing outside this directory is available
+> or needed.
+
+Anything beyond this belongs in `TASK.md`, where it enters the audited packet and the commit
+record. An instruction delivered as chat text is invisible to the packet hash, absent from the
+manifest, and composed by a context holding the targets, which is the one information channel
+§ 4 forbids. The near-empty prompt is a firewall property, not a style preference.
+
 ### Running it beside a live maintainer session
 
 The two sessions are independent processes and may run side by side. The information rule is
@@ -118,19 +149,29 @@ holding the targets defeats the firewall no matter how innocuous the sentence lo
 
 | Block | Work | Commit boundary |
 | --- | --- | --- |
-| A | receive the author's generators; audit the packet (closure to the expected order, no derived annotations, `diff` on the protocol copy), canonicalize it, record its SHA-256 | the packet and its hash, committed first so the timestamp predates the run |
+| A | receive the author's generators; audit the packet FROM THE PACKET ALONE (closure to the expected order, no derived annotations, `diff` on the protocol copy); record the incoming author hash, canonicalize, issue the authoritative SHA-256 | the packet, `TASK.md`, the audit script and its output, committed first so the timestamp predates the run |
 | B | the clean-room session: implementation, gates, runnable mutation harness, the § 6 module, raw output and JSON | none; the agent writes only inside the room |
 | C | copy artifacts out, generate SHA-256, write the environment record and method-note draft | **the § 9 commitment.** Nothing is unsealed before it lands |
 | D | unseal; build the § 7 comparison harness with its transcription mutation; adjudicate | second, separately dated commit |
-| E | method note per [`METHOD_NOTE.md`](../METHOD_NOTE.md), then the adversarial audit by a second agent | final |
-| F | **delete the room.** Keep its session transcript | none |
+| E | method note per [`METHOD_NOTE.md`](../METHOD_NOTE.md), then the adversarial audit by a second agent | M8.5-A close-out, in the M8 column |
+| F | **write the standard**: `dev_docs/CLEAN_ROOM.md` from the deviations log, the failure modes actually hit, and the manifest-against-transcript comparison. Amend or retract whatever this planning doc got wrong | T4 close-out, in `dev_docs/` |
+| G | **delete the room.** Keep its session transcript | none |
 
 Blocks A through D are one sitting. Block E is not promised in the same sitting: an adversarial
 audit that is rushed to fit a day is not an adversarial audit.
 
-**Block F is a required step, not housekeeping.** A room left on disk is a room that gets
+**Block F is the task, not its write-up.** Everything before it produces one model's evidence;
+F is the only block that produces platform machinery, and skipping it leaves the procedure as
+tribal knowledge in a closed task document. It is deliberately last, because a standard written
+before the run records intentions. It is also the block that can conclude the procedure does not
+work: per § Why this is platform work, a refutation is recorded here and no standard ships, and
+that closes T4 as legitimately as a standard does.
+
+**Block G is a required step, not housekeeping.** A room left on disk is a room that gets
 reused, and its second occupant is not context-isolated: the folder holds the packet, the
-implementation, and by then the unsealed comparison. Delete it once block E closes.
+implementation, and by then the unsealed comparison. Delete it once block F closes, not at E:
+the standard is written from the run, and the room is the last place to check a detail the
+transcript renders ambiguously.
 
 Keep the session transcript, which lives under the agent's own project-history directory rather
 than inside the room, so deleting the room does not touch it. It is worth keeping because it
@@ -152,7 +193,8 @@ check it is an attestation, and this column already ruled against those.
 
 | Risk | Guard |
 | --- | --- |
-| The standard is written from this plan rather than from the run, so it records intentions | block E writes it, after adjudication, with a deviations log kept throughout |
+| The standard is written from this plan rather than from the run, so it records intentions | block F writes it, after adjudication, with a deviations log kept throughout |
+| The M8 evidence lands, attention moves on, and block F never runs | F carries its own commit boundary and its own close-out, so T4 stays open on the roadmap until the standard exists or a refutation is recorded |
 | A future room is placed by copying the path rather than applying the rule | the standard leads with the ancestor-path check and the sibling-folder near-miss that motivated it |
 | The packet audit becomes a rubber stamp because the same person assembles and audits | each part has a mechanical audit (`diff`, closure count) rather than a judgment call |
 | Withholding web tools is mistaken for an offline requirement | the standard states plainly that the network stays up and only the search tools are withheld |

--- a/openwave/xperiments/m8_mit/research/tasks/m8_5_task_details.md
+++ b/openwave/xperiments/m8_mit/research/tasks/m8_5_task_details.md
@@ -151,6 +151,25 @@ irrational in `φ` and an uncanonicalized decimal rendering hashes differently f
 group. The maintainer's own pre-verified pair is retained as a cross-check on the supplied
 generators, never as the packet.
 
+**Delivered 2026-07-31** ([PR #386](https://github.com/openwave-labs/openwave/pull/386)
+thread), in two deliberately separate archives: the packet, and the author's own verification
+evidence marked to stay outside the room. The generators are exact in `Q(φ)` with every
+component written `(a + b·φ)/2` over integer `a` and `b`, so no decimal rendering exists to
+canonicalize away and the hash pins a group rather than a transcription. The author's
+separation of packet from evidence was unprompted, and it is the containment the protocol
+wanted; the audit still runs from the packet alone, per
+[`../../../../../dev_docs/tasks/t4_task_details.md`](../../../../../dev_docs/tasks/t4_task_details.md).
+
+**Landing map for the block A packet commit** (committed before the room opens, so the
+timestamp predates the run; contents subject to the block A leakage scan):
+
+| Artifact | Repo destination |
+| --- | --- |
+| the canonical packet | `../data/m8_5a_packet.json` |
+| the clean-room task file | `../data/m8_5a_cleanroom_task.md` |
+| the maintainer packet audit | `../scripts/m8_5a_packet_audit.py`, `../data/m8_5a_packet_audit.json` |
+| the author's verification evidence, as received | `../data/m8_5a_packet_author_evidence/` |
+
 **Landing map for the § 9 commitment** (fixed before the run so the copy-out is mechanical;
 one commit, nothing unsealed until it lands):
 


### PR DESCRIPTION
Strengthens T4 clean-room protocol language to require packet-only auditing, separate author evidence from maintainer audit, and pre-commit persistent artifacts before room execution. It also adds the near-empty opening prompt rule and updates block A commitments to include incoming hash tracking, TASK.md, and packet-audit artifacts. M8.5 task details now record the 2026-07-31 delivery split (packet vs author evidence) and define the block A landing map for canonical packet, clean-room task file, audit script/output, and preserved author evidence.