### PR TITLE
M8.5-A: audit the packet and seal the clean room

### DIFF
--- a/dev_docs/tasks/t4_task_details.md
+++ b/dev_docs/tasks/t4_task_details.md
@@ -55,7 +55,7 @@ uses; the machinery does not make a run blind.
 | Setting | Decision |
 | --- | --- |
 | Location | any directory with no `CLAUDE.md` anywhere on its ancestor path, and outside every repository working tree. The concrete path is a local choice and stays out of the repository |
-| Launch | `claude --disallowedTools "WebSearch,WebFetch"` |
+| Launch | `claude --disallowedTools "WebSearch,WebFetch"`, in DEFAULT permission mode. Not a bypass mode: the approval prompt is what makes a tool call reaching outside the room visible to the operator, and it is the one containment guard that does not rely on the implementer's cooperation |
 | Write scope | the implementer writes only inside the room and never reaches the repository; a maintainer copies artifacts out and performs every commit |
 | Teardown | the room is deleted at the end of the run, block G below. Not before: a rerun under § 3 needs it, it is the only copy until block C has copied the artifacts out, and block F may need to check a detail against it |
 
@@ -67,10 +67,14 @@ sits under a 7-line `CLAUDE.md` whose entire content instructs the agent to go r
 have revealed the breach. Check the whole ancestor path, and check what the file says rather
 than only whether one exists.
 
-**What loads unavoidably**: `~/.claude/CLAUDE.md`, the user-level instructions. Grepped for the
-subject terms before the run and found nothing relevant, so it enters the consulted-files
-manifest as a disclosed load rather than an unmentioned one. Project memory is keyed to the
-working directory, so a new folder starts with none.
+**What loads unavoidably**: `~/.claude/CLAUDE.md`, the user-level instructions. It enters the
+consulted-files manifest as a disclosed load rather than an unmentioned one. Grep it for the
+subject terms before the run, and read the summary of that grep carefully: at block A it came
+back free of anything answer-bearing while still naming this repository several times in
+unrelated prose (DEVIATIONS LOG). "Nothing relevant" is the conclusion to be most careful with
+here, since the file is written for a general working context and nobody edits it with a clean
+room in mind. Project memory is keyed to the working directory, so a new folder starts with
+none.
 
 ### The packet, and who may write it
 
@@ -207,7 +211,45 @@ input is forced by protocol § 5.3, and the fallback for unanswered provenance i
 
 ## DEVIATIONS LOG
 
-(none)
+Kept from block A onward, and the raw material block F writes the standard from. Each entry is
+what actually happened, including where this plan was wrong.
+
+**2026-07-31, block A. The unavoidable user-level `CLAUDE.md` names the repository, and
+§ The room understated it.** That section records the file as grepped for the subject terms
+with nothing relevant found. Re-run at block A, the grep is accurate on targets and generous in
+its summary: the file carries no group theory, no character or distance data, nothing
+answer-bearing, and it names this repository four times in unrelated prose about writing style
+and project orientation. It does not hand over an answer, and it does shorten the distance
+between the room and a tree the implementer is forbidden to read.
+
+**The same entry, sharpened: the room is isolated by withheld tools and by instruction, not by
+a sandbox.** Web search and fetch are withheld, which closes the network route. The local
+filesystem is not closed: the implementer has a shell and the quarantined tree is on the same
+disk. This plan never claimed otherwise, and it never said it out loud either, which is the
+kind of gap a standard exists to close. Three guards, added at block A:
+
+| Guard | What it does |
+| --- | --- |
+| `TASK.md` states the boundary as an obligation | the room is the implementer's whole world by rule, with the out-of-room read named as recoverable and its concealment named as not. An unstated rule cannot be honored or breached |
+| the room session runs in default permission mode | any tool call reaching outside the room surfaces as an approval prompt to the operator, who declines it and logs it here. This is the guard that does not depend on the implementer |
+| the transcript is checked against `manifest.md` at block C | already planned as the manifest's corroboration; the out-of-room question is now something it is explicitly checked for |
+
+**2026-07-31, block A. The group order is withheld, tighter than protocol § 4 permits.** The
+protocol allows supplying 120 as a construction input. `GROUP_INPUT.md` withholds it so G1
+stays falsifiable, and says so in the file, so silence does not read as an incomplete packet.
+
+**2026-07-31, block A. Canonicalization turned out to be a no-op.** § The packet anticipated
+irrational components arriving as decimals, where a hash would pin a transcription. The author
+supplied exact `Q(φ)` arithmetic instead, and the delivered bytes were already canonical under
+the declared form, so the incoming and authoritative hashes are identical. The canonicalization
+step still ran and is still recorded: the chain from delivery to room has to be complete
+whether or not it moved.
+
+**2026-07-31, block A. The mutation suite caught a defect in the audit, not in the packet.**
+The leakage check ran last and was skipped whenever an earlier format check aborted the
+sequence, so a stray key carrying a target reddened the audit for the wrong reason. Fixed by
+computing the leakage scan first and appending it unconditionally. Worth carrying into the
+standard: the mutation suite earned its place by failing something.
 
 ## FINDINGS
 

--- a/openwave/xperiments/m8_mit/research/data/m8_5a_cleanroom_group_input.md
+++ b/openwave/xperiments/m8_mit/research/data/m8_5a_cleanroom_group_input.md
@@ -1,0 +1,64 @@
+# GROUP INPUT
+
+Two generators of a finite subgroup of the unit quaternions, supplied by the model author.
+
+`m8_5a_packet.json` in this directory is the authoritative form. It is what the SHA-256 below
+pins, and it is what you should parse. The copy printed at the end of this file is a
+convenience for reading, not a second source: if the two ever disagree, the file wins.
+
+| Field | Value |
+| --- | --- |
+| file | `m8_5a_packet.json` |
+| SHA-256 | `e3b0c945bbbb15b4549fa641234c9461062c2337b3d1e372af621b614d4883a9` |
+| format version | `m8_5a-packet-v1` |
+
+## The coefficient format
+
+Every component is an exact element of the field `Q(phi)`, where `phi` satisfies
+`phi^2 = phi + 1`. Components are written `(a + b*phi)/2` with integer `a` and `b`, and the
+denominator is fixed at 2 for every component and is not reduced. The quaternion basis is
+`(1, i, j, k)`, in that order.
+
+No decimal rendering of these components exists anywhere in this packet. That is deliberate:
+exact arithmetic over `Q(phi)` is available to you through `fractions.Fraction`, and working
+exactly avoids putting a tolerance where an equality belongs.
+
+## What is deliberately not here
+
+The generators, and nothing else. No group order, no element count, no labels, no dimensions,
+no distances, no character values. `PROTOCOL.md` permits the group order to be supplied as a
+construction input; it is withheld here on purpose, so that the gate checking it stays a check
+that can fail rather than a restatement of something handed to you.
+
+## The packet, verbatim
+
+```json
+{
+  "coefficient_field": {
+    "generator": "phi",
+    "minimal_polynomial": "phi^2 - phi - 1"
+  },
+  "coefficient_form": "(a + b*phi)/2 with integer a and b; the denominator is fixed at 2 for every component and is not reduced",
+  "format_version": "m8_5a-packet-v1",
+  "generators": [
+    [
+      "(1 + 0*phi)/2",
+      "(1 + 0*phi)/2",
+      "(1 + 0*phi)/2",
+      "(1 + 0*phi)/2"
+    ],
+    [
+      "(0 + 0*phi)/2",
+      "(1 + 0*phi)/2",
+      "(-1 + 1*phi)/2",
+      "(0 + 1*phi)/2"
+    ]
+  ],
+  "quaternion_basis": [
+    "1",
+    "i",
+    "j",
+    "k"
+  ]
+}
+```

--- a/openwave/xperiments/m8_mit/research/data/m8_5a_cleanroom_task.md
+++ b/openwave/xperiments/m8_mit/research/data/m8_5a_cleanroom_task.md
@@ -1,0 +1,62 @@
+# TASK: implement the reproduction specified in PROTOCOL.md
+
+## What you are doing
+
+Implement the reproduction that `PROTOCOL.md` specifies, using the group input in
+`GROUP_INPUT.md` and the machine-readable packet it names. Those two files plus this one are
+the complete specification.
+
+## Environment
+
+Everything you need is in this directory. Nothing outside it is needed. Web search and fetch
+tools are disabled by design.
+
+**This directory is your whole world, and that is a rule, not a description of the machine.**
+The filesystem outside it is not sandboxed away from you; staying inside it is your
+obligation. Do not read, list, or search any path outside this directory, including any
+repository you may find on this disk or hear named in instructions that loaded automatically.
+If you nonetheless open something outside, that is recoverable and concealing it is not:
+record it in `manifest.md` and say so plainly in your final message.
+
+`PROTOCOL.md` is a verbatim copy of a frozen document. Its relative links point into a
+repository you do not have and must not go looking for. Nothing behind them is needed, and the
+protocol text itself is complete for your purposes.
+
+If at some point you want a reference table of characters, dimensions, graph distances, or
+first occurrences for the group in `GROUP_INPUT.md`: that table is the answer key for this
+task. Deriving it is the work. Looking it up, reconstructing it from memory of a published
+source, or asking for it invalidates the run.
+
+## Deliverables, all written into this directory
+
+| File | Content |
+| --- | --- |
+| `m8_5a_reproduction.py` | the implementation, including a `--mutation-tests` mode |
+| `raw_output.txt` | the run's stdout, verbatim |
+| `result.json` | the output schema fixed in `PROTOCOL.md` § 5 |
+| `environment.md` | interpreter and library versions, OS, hardware, seeds if any |
+| `manifest.md` | every file and reference you consulted, including any that loaded automatically without your asking |
+| `method_note_draft.md` | equations first, then an equation-to-code map |
+
+## Requirements beyond a plain reading of the protocol
+
+1. **The § 6 coexact module RUNS.** This is pre-declared and not optional. If you cannot build
+   it from your own harmonic analysis, its verdict is `not resolved` with the reason recorded.
+   That is a permitted outcome. Opening external access to rescue it is not.
+2. **Preference, not a requirement.** Construct the coefficient representation by building the
+   symmetric square explicitly and taking traces, rather than by evaluating the character
+   identity that G11 checks. Where the two routes genuinely differ, G11 is a cross-check;
+   where they are the same route, G11 confirms the declared contract was applied but not its
+   arithmetic. State which route you took, in the method note, either way.
+3. **Every tolerance is fixed in the source** and justified in the method-note draft, before
+   any comparison is run.
+4. **Fail loud.** A NOT-FOUND cell, a gate failure, or an integer-nearness violation stops the
+   run with a nonzero exit and a stated reason. Silent omission is not an option.
+5. **Report the honest outcome.** A disagreement is a finding, not a failure of this task, and
+   the result categories in the protocol are all reportable. Do not adjust a gate, a tolerance,
+   or a construction to make an output look better.
+
+## What "done" means
+
+The mutation harness exits nonzero if any gate is uncovered or any mutation fails to redden its
+target. Run it, include its output, and stop when it passes and every file above exists.

--- a/openwave/xperiments/m8_mit/research/data/m8_5a_packet.json
+++ b/openwave/xperiments/m8_mit/research/data/m8_5a_packet.json
@@ -1,0 +1,28 @@
+{
+  "coefficient_field": {
+    "generator": "phi",
+    "minimal_polynomial": "phi^2 - phi - 1"
+  },
+  "coefficient_form": "(a + b*phi)/2 with integer a and b; the denominator is fixed at 2 for every component and is not reduced",
+  "format_version": "m8_5a-packet-v1",
+  "generators": [
+    [
+      "(1 + 0*phi)/2",
+      "(1 + 0*phi)/2",
+      "(1 + 0*phi)/2",
+      "(1 + 0*phi)/2"
+    ],
+    [
+      "(0 + 0*phi)/2",
+      "(1 + 0*phi)/2",
+      "(-1 + 1*phi)/2",
+      "(0 + 1*phi)/2"
+    ]
+  ],
+  "quaternion_basis": [
+    "1",
+    "i",
+    "j",
+    "k"
+  ]
+}

--- a/openwave/xperiments/m8_mit/research/data/m8_5a_packet_audit.json
+++ b/openwave/xperiments/m8_mit/research/data/m8_5a_packet_audit.json
@@ -1,0 +1,223 @@
+{
+  "what": "M8.5-A packet audit, run from the packet alone",
+  "packet_file": "m8_5a_packet.json",
+  "incoming_sha256": "e3b0c945bbbb15b4549fa641234c9461062c2337b3d1e372af621b614d4883a9",
+  "canonical_form": "json.dumps(sort_keys=True, indent=2, ensure_ascii=True) + LF",
+  "authoritative_sha256": "e3b0c945bbbb15b4549fa641234c9461062c2337b3d1e372af621b614d4883a9",
+  "canonicalization_changed_bytes": false,
+  "checks": [
+    {
+      "id": "A1",
+      "check": "declared keys, minimal polynomial, basis; every component is (a + b*phi)/2",
+      "pass": true,
+      "observed": {
+        "keys_match": true,
+        "minimal_polynomial": "phi^2 - phi - 1",
+        "basis_match": true,
+        "shape_2x4": true,
+        "components_parse": true,
+        "parse_error": null
+      }
+    },
+    {
+      "id": "A2",
+      "check": "both generators have quaternion norm exactly 1 in Q(phi)",
+      "pass": true,
+      "observed": {
+        "norms": [
+          "1 + 0*phi",
+          "1 + 0*phi"
+        ]
+      }
+    },
+    {
+      "id": "A3",
+      "check": "closure is finite, multiplicatively closed, of order exactly 120",
+      "pass": true,
+      "observed": {
+        "order": 120,
+        "closed_under_multiplication": true,
+        "error": null
+      }
+    },
+    {
+      "id": "A4",
+      "check": "identity present and every element has an inverse in the closure",
+      "pass": true,
+      "observed": {
+        "identity_present": true,
+        "all_invertible": true
+      }
+    },
+    {
+      "id": "A5",
+      "check": "center is exactly {+1, -1}",
+      "pass": true,
+      "observed": {
+        "center_order": 2
+      }
+    },
+    {
+      "id": "A6",
+      "check": "element-order census matches 2I and rules out A5 x C2 (30 elements of order 4)",
+      "pass": true,
+      "observed": {
+        "census": {
+          "1": 1,
+          "2": 1,
+          "3": 20,
+          "4": 30,
+          "5": 24,
+          "6": 20,
+          "10": 24
+        },
+        "expected": {
+          "1": 1,
+          "2": 1,
+          "3": 20,
+          "4": 30,
+          "5": 24,
+          "6": 20,
+          "10": 24
+        },
+        "order_4_population": 30
+      }
+    },
+    {
+      "id": "A7",
+      "check": "central quotient has order 60 with the A5 order profile",
+      "pass": true,
+      "observed": {
+        "quotient_order": 60,
+        "census": {
+          "1": 1,
+          "2": 15,
+          "3": 20,
+          "5": 24
+        },
+        "expected": {
+          "1": 1,
+          "2": 15,
+          "3": 20,
+          "5": 24
+        }
+      }
+    },
+    {
+      "id": "A8",
+      "check": "no leakage vocabulary and no key outside the declared set",
+      "pass": true,
+      "observed": {
+        "token_hits": [],
+        "stray_keys": []
+      }
+    }
+  ],
+  "detail": {
+    "generator_orders": [
+      6,
+      4
+    ],
+    "element_order_census": {
+      "1": 1,
+      "2": 1,
+      "3": 20,
+      "4": 30,
+      "5": 24,
+      "6": 20,
+      "10": 24
+    },
+    "quotient_order_census": {
+      "1": 1,
+      "2": 15,
+      "3": 20,
+      "5": 24
+    },
+    "group_order": 120,
+    "center_order": 2
+  },
+  "all_checks_pass": true,
+  "mutation_suite": [
+    {
+      "mutation": "denominator_not_2",
+      "expected_red": [
+        "A1"
+      ],
+      "observed_red": [
+        "A1"
+      ],
+      "detected": true,
+      "error": null
+    },
+    {
+      "mutation": "wrong_minimal_polynomial",
+      "expected_red": [
+        "A1"
+      ],
+      "observed_red": [
+        "A1"
+      ],
+      "detected": true,
+      "error": null
+    },
+    {
+      "mutation": "norm_not_unit",
+      "expected_red": [
+        "A2"
+      ],
+      "observed_red": [
+        "A2",
+        "A3"
+      ],
+      "detected": true,
+      "error": null
+    },
+    {
+      "mutation": "second_generator_replaced_by_i",
+      "expected_red": [
+        "A3"
+      ],
+      "observed_red": [
+        "A3"
+      ],
+      "detected": true,
+      "error": null
+    },
+    {
+      "mutation": "generators_collapsed_to_one",
+      "expected_red": [
+        "A3"
+      ],
+      "observed_red": [
+        "A3"
+      ],
+      "detected": true,
+      "error": null
+    },
+    {
+      "mutation": "dimension_labels_added",
+      "expected_red": [
+        "A8"
+      ],
+      "observed_red": [
+        "A1",
+        "A8"
+      ],
+      "detected": true,
+      "error": null
+    },
+    {
+      "mutation": "mckay_distance_added",
+      "expected_red": [
+        "A8"
+      ],
+      "observed_red": [
+        "A1",
+        "A8"
+      ],
+      "detected": true,
+      "error": null
+    }
+  ],
+  "mutation_suite_all_detected": true
+}

--- a/openwave/xperiments/m8_mit/research/data/m8_5a_packet_author_evidence/README.md
+++ b/openwave/xperiments/m8_mit/research/data/m8_5a_packet_author_evidence/README.md
@@ -1,0 +1,68 @@
+# M8.5-A clean-room packet (author-side, local staging)
+
+The group input the M8.5-A protocol § 4 assigns to the author, plus the author-side
+verification evidence. Local only; nothing here is in git.
+
+## What goes to the maintainer, and in which role
+
+| File | Role |
+| --- | --- |
+| `m8_5a_packet.json` | **the packet.** Generators and format definition only. This is what the maintainer audits, canonicalizes, and hashes, and it is the only file that enters the clean room (alongside the frozen protocol itself) |
+| `verify_packet.py` | author-side verification script, exact arithmetic, with a runnable mutation suite |
+| `verification_report.json` | gate outcomes, packet hash, environment. Audit evidence, NOT part of the packet |
+
+The packet deliberately contains no irrep labels, dimensions, McKay distances, character
+values, worked examples, or any target value. It is generators and the field convention,
+nothing else.
+
+## Format
+
+Coefficients live in `Q(phi)` with `phi^2 = phi + 1`, written canonically as
+`(a + b*phi)/2` with integer `a` and `b`, the denominator fixed at 2 for every component and
+not reduced, matching the maintainer's stated form. Quaternion basis
+is `(1, i, j, k)`. Exact throughout: no decimal approximation appears in the authoritative
+packet, so there is no tolerance, no dedup ambiguity, and no closure ambiguity, and the
+packet hash is meaningful. A numerical array may be generated downstream from the exact
+packet, but must not be separately authored or hashed as a competing source of truth.
+
+## Verification, as run
+
+```
+python3 verify_packet.py --packet m8_5a_packet.json --mutation-tests
+```
+
+| Gate | Result |
+| --- | --- |
+| P1 every supplied generator has quaternion norm exactly 1 | PASS |
+| P2 the generators close under exact multiplication to exactly 120 distinct elements | PASS |
+| P3 identity present, every inverse in the set, center exactly `{+1, -1}` | PASS |
+| P4 the quotient by the center has order 60 and the `A_5` element-order profile (1, 15, 20, 24 at orders 1, 2, 3, 5; none at 4 or 6) | PASS |
+
+Two generators, of orders 6 and 4. Packet SHA-256
+`e3b0c945bbbb15b4549fa641234c9461062c2337b3d1e372af621b614d4883a9`.
+
+Mutation suite: 4 mutations, every gate reddened by at least one, coverage complete.
+`quotient_by_trivial` reddens P4 and nothing else, which is what shows P4 carries
+independent weight rather than riding on P2.
+
+## Why P4 exists, and the limit of what the mutations demonstrate
+
+Order and closure do not identify the group. The finite subgroups of `SU(2)` include a
+binary dihedral group of order 120 and a cyclic group of order 120, so a mistranscribed
+generator set could in principle close to exactly 120 elements and still not be `2I`. P4 is
+the gate that separates them, since the central quotient of `2I` is `A_5` while the binary
+dihedral quotient is dihedral.
+
+**Stated honestly:** the mutation suite demonstrates that P4 reddens when the quotient
+construction is corrupted. It does NOT exhibit a genuine competing order-120 group that
+passes P2 and fails P4, because such a group is not constructible in this packet's field: a
+cyclic or binary dihedral subgroup of that order needs `cos(pi/60)` or `cos(pi/30)`, whose
+degrees over `Q` are 16 and 8, so neither lies in the degree-2 field `Q(phi)`. That is an
+argument for why the competing case cannot arise here, not a mutation-demonstrated
+discrimination, and it is recorded as such rather than as a stronger claim.
+
+## Scope
+
+This certifies the packet's group input. It computes no characters, no irreducible
+dimensions, no McKay data, and no first-occurrence anything, and it says nothing about any
+downstream table.

--- a/openwave/xperiments/m8_mit/research/data/m8_5a_packet_author_evidence/verification_report.json
+++ b/openwave/xperiments/m8_mit/research/data/m8_5a_packet_author_evidence/verification_report.json
@@ -1,0 +1,17 @@
+{
+  "closure_order": 120,
+  "environment": {
+    "exact_arithmetic": "fractions.Fraction over Q(phi), no floating point",
+    "platform": "macOS-15.7.7-arm64-arm-64bit-Mach-O",
+    "python": "3.13.13"
+  },
+  "gates": {
+    "P1_generators_unit_norm": true,
+    "P2_closure_order_120": true,
+    "P3_identity_inverses_center": true,
+    "P4_central_quotient_is_A5": true
+  },
+  "generator_count": 2,
+  "packet_format_version": "m8_5a-packet-v1",
+  "packet_sha256": "e3b0c945bbbb15b4549fa641234c9461062c2337b3d1e372af621b614d4883a9"
+}

--- a/openwave/xperiments/m8_mit/research/data/m8_5a_packet_author_evidence/verify_packet.py
+++ b/openwave/xperiments/m8_mit/research/data/m8_5a_packet_author_evidence/verify_packet.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""
+M8.5-A clean-room packet: exact verification of the supplied group input.
+
+Author-side verification. Confirms that the generators in the packet are unit
+quaternions over Q(sqrt5) and that they close to the binary icosahedral group
+2I, and NOT merely to some order-120 subgroup of SU(2).
+
+Exact arithmetic throughout: coefficients live in Q(phi) with phi^2 = phi + 1,
+represented as Fraction pairs (p, q) meaning p + q*phi. No floating point is
+used anywhere, so there is no tolerance, no dedup ambiguity, and no closure
+ambiguity.
+
+GATES (each printed PASS line is mutation-tested; see --mutation-tests)
+
+  P1  every supplied generator has quaternion norm exactly 1
+  P2  the generators close under exact multiplication to exactly 120 distinct
+      elements
+  P3  the identity is present, every element's inverse is in the set, and the
+      center is exactly {+1, -1}
+  P4  the quotient by the center has order 60 and the element-order profile of
+      A_5 (1 of order 1, 15 of order 2, 20 of order 3, 24 of order 5, none of
+      order 4 or 6)
+
+P4 is the gate that distinguishes 2I from another order-120 subgroup: order and
+closure alone do not, which is why P2 is not sufficient on its own.
+
+WHAT THIS DOES NOT DO: it computes no characters, no irreducible dimensions, no
+McKay data, and no first-occurrence anything. It certifies the packet's group
+input and nothing downstream of it. The verification report carries gate
+outcomes and hashes only.
+
+Usage:
+  python3 verify_packet.py --packet m8_5a_packet.json [--report report.json]
+  python3 verify_packet.py --packet m8_5a_packet.json --mutation-tests
+"""
+
+import argparse
+import hashlib
+import json
+import platform
+import sys
+from fractions import Fraction
+from itertools import permutations
+
+# --------------------------------------------------------------------------
+# exact arithmetic in Q(phi), phi^2 = phi + 1
+# an element is a pair (p, q) of Fractions meaning p + q*phi
+# --------------------------------------------------------------------------
+
+ZERO = (Fraction(0), Fraction(0))
+ONE = (Fraction(1), Fraction(0))
+
+
+def qadd(a, b):
+    return (a[0] + b[0], a[1] + b[1])
+
+
+def qsub(a, b):
+    return (a[0] - b[0], a[1] - b[1])
+
+
+def qneg(a):
+    return (-a[0], -a[1])
+
+
+def qmul(a, b):
+    # (p1 + q1 phi)(p2 + q2 phi) = p1p2 + (p1q2 + q1p2) phi + q1q2 phi^2
+    # phi^2 = phi + 1
+    p = a[0] * b[0] + a[1] * b[1]
+    q = a[0] * b[1] + a[1] * b[0] + a[1] * b[1]
+    return (p, q)
+
+
+def parse_coeff(s):
+    """Parse the canonical form '(a + b*phi)/d' into a Q(phi) element."""
+    txt = s.strip()
+    if not (txt.startswith("(") and "/" in txt):
+        raise ValueError(f"coefficient not in canonical form: {s!r}")
+    body, denom = txt.rsplit("/", 1)
+    body = body.strip()
+    if not (body.startswith("(") and body.endswith(")")):
+        raise ValueError(f"coefficient not in canonical form: {s!r}")
+    body = body[1:-1]
+    d = int(denom.strip())
+    if d <= 0:
+        raise ValueError(f"denominator must be positive: {s!r}")
+    # body is 'a + b*phi' or 'a - b*phi'
+    if "+" in body:
+        a_txt, b_txt = body.split("+", 1)
+        sign = 1
+    elif "-" in body[1:]:
+        idx = body.index("-", 1)
+        a_txt, b_txt = body[:idx], body[idx + 1:]
+        sign = -1
+    else:
+        raise ValueError(f"coefficient not in canonical form: {s!r}")
+    a = int(a_txt.strip())
+    b_txt = b_txt.strip()
+    if not b_txt.endswith("*phi"):
+        raise ValueError(f"coefficient not in canonical form: {s!r}")
+    b = sign * int(b_txt[:-4].strip())
+    return (Fraction(a, d), Fraction(b, d))
+
+
+def format_coeff(x):
+    """Canonical '(a + b*phi)/d': integers, d > 0, gcd(|a|,|b|,d) = 1."""
+    p, q = x
+    d = _lcm(p.denominator, q.denominator)
+    a = int(p * d)
+    b = int(q * d)
+    g = _gcd3(abs(a), abs(b), d)
+    if g:
+        a, b, d = a // g, b // g, d // g
+    sign = "+" if b >= 0 else "-"
+    return f"({a} {sign} {abs(b)}*phi)/{d}"
+
+
+def _gcd(a, b):
+    while b:
+        a, b = b, a % b
+    return a
+
+
+def _gcd3(a, b, c):
+    return _gcd(_gcd(a, b), c)
+
+
+def _lcm(a, b):
+    return a * b // _gcd(a, b)
+
+
+# --------------------------------------------------------------------------
+# quaternions with Q(phi) coefficients, basis (1, i, j, k)
+# --------------------------------------------------------------------------
+
+QONE = (ONE, ZERO, ZERO, ZERO)
+
+
+def hmul(x, y):
+    w1, x1, y1, z1 = x
+    w2, x2, y2, z2 = y
+    w = qsub(qsub(qsub(qmul(w1, w2), qmul(x1, x2)), qmul(y1, y2)), qmul(z1, z2))
+    i = qadd(qadd(qmul(w1, x2), qmul(x1, w2)), qsub(qmul(y1, z2), qmul(z1, y2)))
+    j = qadd(qadd(qmul(w1, y2), qmul(y1, w2)), qsub(qmul(z1, x2), qmul(x1, z2)))
+    k = qadd(qadd(qmul(w1, z2), qmul(z1, w2)), qsub(qmul(x1, y2), qmul(y1, x2)))
+    return (w, i, j, k)
+
+
+def hconj(x):
+    w, i, j, k = x
+    return (w, qneg(i), qneg(j), qneg(k))
+
+
+def hnorm(x):
+    """Quaternion norm w^2 + x^2 + y^2 + z^2, exact."""
+    total = ZERO
+    for c in x:
+        total = qadd(total, qmul(c, c))
+    return total
+
+
+def hneg(x):
+    return tuple(qneg(c) for c in x)
+
+
+def horder(x, cap=600):
+    """Multiplicative order of a unit quaternion, exact."""
+    cur = x
+    for n in range(1, cap + 1):
+        if cur == QONE:
+            return n
+        cur = hmul(cur, x)
+    raise ValueError("order exceeded cap")
+
+
+def close_group(gens, cap=100000):
+    """Exact closure under multiplication. Returns the element set."""
+    elems = {QONE}
+    frontier = [QONE]
+    while frontier:
+        nxt = []
+        for a in frontier:
+            for g in gens:
+                b = hmul(a, g)
+                if b not in elems:
+                    elems.add(b)
+                    nxt.append(b)
+                    if len(elems) > cap:
+                        raise ValueError("closure exceeded cap")
+        frontier = nxt
+    return elems
+
+
+# --------------------------------------------------------------------------
+# gates
+# --------------------------------------------------------------------------
+
+A5_PROFILE = {1: 1, 2: 15, 3: 20, 5: 24}
+
+
+def run_gates(gens, mut=None):
+    res = {}
+
+    # P1: unit norms
+    norms_ok = all(hnorm(g) == ONE for g in gens)
+    res["P1_generators_unit_norm"] = norms_ok
+
+    # P2: exact closure to 120
+    try:
+        G = close_group(gens)
+    except ValueError:
+        res["P2_closure_order_120"] = False
+        res["P3_identity_inverses_center"] = False
+        res["P4_central_quotient_is_A5"] = False
+        return res, None
+    order = len(G)
+    res["P2_closure_order_120"] = (order == 120)
+
+    # P3: identity, inverses, center exactly {+1, -1}
+    has_id = QONE in G
+    inv_ok = all(hconj(g) in G for g in G)  # unit quaternion inverse = conjugate
+    center = {g for g in G if all(hmul(g, h) == hmul(h, g) for h in G)}
+    minus_one = hneg(QONE)
+    center_ok = (center == {QONE, minus_one})
+    res["P3_identity_inverses_center"] = bool(has_id and inv_ok and center_ok)
+
+    # P4: quotient by center has A_5 order profile
+    if mut == "quotient_by_trivial":
+        cosets = [frozenset({g}) for g in G]
+    else:
+        cosets = []
+        seen = set()
+        for g in G:
+            if g in seen:
+                continue
+            pair = frozenset({g, hneg(g)})
+            cosets.append(pair)
+            seen |= pair
+    profile = {}
+    if len(cosets) == 60:
+        rep_of = {}
+        for c in cosets:
+            for e in c:
+                rep_of[e] = c
+        for c in cosets:
+            g = next(iter(c))
+            n = 1
+            cur = g
+            while rep_of[cur] != rep_of[QONE] or n == 0:
+                cur = hmul(cur, g)
+                n += 1
+                if n > 120:
+                    break
+            profile[n] = profile.get(n, 0) + 1
+    res["P4_central_quotient_is_A5"] = (len(cosets) == 60 and profile == A5_PROFILE)
+    return res, order
+
+
+# --------------------------------------------------------------------------
+# packet io
+# --------------------------------------------------------------------------
+
+def load_packet(path):
+    raw = open(path, "rb").read()
+    digest = hashlib.sha256(raw).hexdigest()
+    doc = json.loads(raw.decode("utf-8"))
+    gens = []
+    for row in doc["generators"]:
+        if len(row) != 4:
+            raise ValueError("generator is not a 4-tuple")
+        gens.append(tuple(parse_coeff(c) for c in row))
+    return doc, gens, digest
+
+
+MUTATIONS = {
+    "perturb_generator": "add 1 to the scalar numerator of generator 0",
+    "drop_golden_generator": "keep only the rational generator",
+    "duplicate_generator": "replace generator 1 by generator 0",
+    "quotient_by_trivial": "quotient by the trivial subgroup instead of the center",
+}
+
+
+def mutate(gens, name):
+    if name == "perturb_generator":
+        g = list(gens[0])
+        p, q = g[0]
+        g[0] = (p + 1, q)
+        return [tuple(g)] + list(gens[1:])
+    if name == "drop_golden_generator":
+        return [gens[0]]
+    if name == "duplicate_generator":
+        return [gens[0], gens[0]]
+    if name == "quotient_by_trivial":
+        return list(gens)
+    raise ValueError(name)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--packet", required=True)
+    ap.add_argument("--report")
+    ap.add_argument("--mutation-tests", action="store_true")
+    args = ap.parse_args()
+
+    doc, gens, digest = load_packet(args.packet)
+    res, order = run_gates(gens)
+
+    print(f"packet          : {args.packet}")
+    print(f"packet sha256   : {digest}")
+    print(f"generators      : {len(gens)}")
+    print(f"closure order   : {order}")
+    print("")
+    for k, v in res.items():
+        print(f"  {'PASS' if v else 'FAIL'}  {k}")
+    baseline_ok = all(res.values())
+    print("")
+    print("VERDICT:", "all gates PASS" if baseline_ok else "GATE FAILURE")
+
+    if args.mutation_tests:
+        print("\nmutation tests (each must redden at least one gate):")
+        if not baseline_ok:
+            print("  baseline is not green; aborting")
+            return 1
+        covered = set()
+        allred = True
+        for name, desc in MUTATIONS.items():
+            mg = mutate(gens, name)
+            mres, _ = run_gates(mg, mut=name if name == "quotient_by_trivial" else None)
+            red = [k for k, v in mres.items() if not v]
+            covered |= set(red)
+            ok = bool(red)
+            allred &= ok
+            print(f"  {'OK  ' if ok else 'MISS'} {name:24s} reddened: {','.join(red) if red else 'NOTHING'}  ({desc})")
+        uncovered = set(res) - covered
+        if uncovered:
+            print(f"  UNCOVERED GATES: {sorted(uncovered)}")
+        if not allred or uncovered:
+            print("\nMUTATION SUITE FAILED")
+            return 1
+        print("\nmutation suite: every gate reddened by at least one mutation")
+
+    if args.report:
+        report = {
+            "packet_sha256": digest,
+            "packet_format_version": doc.get("format_version"),
+            "generator_count": len(gens),
+            "closure_order": order,
+            "gates": res,
+            "environment": {
+                "python": platform.python_version(),
+                "platform": platform.platform(),
+                "exact_arithmetic": "fractions.Fraction over Q(phi), no floating point",
+            },
+        }
+        with open(args.report, "w") as fh:
+            json.dump(report, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        print(f"\nreport written: {args.report}")
+
+    return 0 if baseline_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openwave/xperiments/m8_mit/research/scripts/m8_5a_packet_audit.py
+++ b/openwave/xperiments/m8_mit/research/scripts/m8_5a_packet_audit.py
@@ -1,0 +1,515 @@
+"""M8.5-A PACKET AUDIT: the maintainer check that runs before the clean room opens.
+
+WHAT THIS IS.  The [M8.5-A reproduction protocol](../findings/m8_5a_reproduction_protocol.md)
+section 4 requires the packet entering the clean room to be audited by someone other than the
+context that will implement from it.  The clean-room procedure standard
+([`dev_docs/tasks/t4_task_details.md`](../../../../../dev_docs/tasks/t4_task_details.md))
+fixes two properties of that audit, and this file is written to satisfy both:
+
+  1  IT RUNS FROM THE PACKET ALONE.  The author shipped a verification script and a report
+     alongside the packet, in a separate archive that stays outside the room.  This file
+     reads NEITHER.  An audit that reads the supplier's report and concurs is a review of
+     the report; the two results are set side by side afterwards, as a cross-check, in
+     [`m8_5_task_details.md`](../tasks/m8_5_task_details.md).
+  2  IT IS MECHANICAL, NOT A JUDGMENT CALL.  The same maintainer assembles and audits the
+     packet, so every check below is a count or an exact equality that can go red, and
+     `--mutation-tests` shows each one doing so.
+
+WHAT THE PACKET IS.  Two generators of a finite subgroup of the unit quaternions, with every
+component given as an exact element of the field Q(phi), phi^2 = phi + 1.  No decimal
+rendering exists anywhere in the packet, which is what makes the hash pin a GROUP rather
+than a transcription of one (protocol section 4, canonicalization).
+
+WHAT THIS VERIFIES.  Eight checks, each mutation-tested:
+
+  A1  format: exactly the declared keys, the declared minimal polynomial and basis, every
+      component parsing as (a + b*phi)/2 with integer a and b and the denominator fixed at 2
+  A2  both generators have quaternion norm exactly 1 in Q(phi), not 1 to a tolerance
+  A3  the generated closure is finite, closed under multiplication, and has exactly 120
+      distinct elements
+  A4  the closure contains the identity and an inverse for every element
+  A5  the center is exactly {+1, -1}
+  A6  the element-order census over all 120 elements
+  A7  the central quotient has order 60 and the A5 element-order profile
+  A8  leakage: the packet carries no labels, dimensions, distances or character values, and
+      no key outside the declared set
+
+A6 IS THIS AUDIT'S ADDITION.  A5 and A7 together (center of order 2, quotient A5) are also
+satisfied by the direct product A5 x C2, which is NOT the binary icosahedral group.  What
+separates them is the order-4 population: 2I has 30 elements of order 4, A5 x C2 has none.
+A finite subgroup of the unit quaternions cannot be A5 x C2 for an independent reason (the
+only unit quaternion of order 2 is -1, while A5 x C2 has 31 involutions), so the census is
+not the only thing standing between the two.  It is, however, the mechanical version of that
+argument, and this audit prefers a count to an appeal to a theorem.
+
+WHAT THIS DOES NOT VERIFY.  That the supplied group is the one the M8 column needs.  This
+audit establishes what the packet IS; whether that is the right input is the protocol's
+question, answered by the pre-registration, not here.  It also does not certify the packet
+target-free by construction: A8 scans for the leakage vocabulary this protocol named, and a
+scan is a floor, not a proof.
+
+USAGE.
+    python3 m8_5a_packet_audit.py                     audit, write JSON, exit 0 on all-pass
+    python3 m8_5a_packet_audit.py --mutation-tests    additionally run the mutation suite
+    python3 m8_5a_packet_audit.py --packet PATH       audit a packet elsewhere
+
+Exit code is nonzero if any check fails, so a red audit cannot be mistaken for a green one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from fractions import Fraction
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_PACKET = HERE.parent / "data" / "m8_5a_packet.json"
+DEFAULT_OUT = HERE.parent / "data" / "m8_5a_packet_audit.json"
+
+# The expected group, declared here so the checks below compare against a stated reference
+# rather than against whatever the packet happens to produce.  Sources: the binary
+# icosahedral group 2I = SL(2,5), order 120, nine conjugacy classes; and A5, order 60.
+EXPECTED_ORDER = 120
+EXPECTED_ORDER_CENSUS = {1: 1, 2: 1, 3: 20, 4: 30, 5: 24, 6: 20, 10: 24}
+EXPECTED_QUOTIENT_ORDER = 60
+EXPECTED_QUOTIENT_CENSUS = {1: 1, 2: 15, 3: 20, 5: 24}
+
+DECLARED_KEYS = {
+    "coefficient_field",
+    "coefficient_form",
+    "format_version",
+    "generators",
+    "quaternion_basis",
+}
+DECLARED_MINPOLY = "phi^2 - phi - 1"
+DECLARED_BASIS = ["1", "i", "j", "k"]
+
+# Vocabulary that would carry a target into the room.  Protocol section 4 forbids the packet
+# carrying anything derived; these are the words the derived objects are made of.
+LEAKAGE_TOKENS = [
+    "irrep", "irreducible", "character", "chi", "dim", "dimension", "degree",
+    "distance", "adjacency", "mckay", "affine", "e8", "dynkin", "node",
+    "class", "conjugacy", "trivial", "sigma", "tau", "spin", "label",
+    "table", "level", "occurrence", "flat", "connection", "sym",
+]
+
+COMPONENT_RE = re.compile(r"^\((-?\d+) \+ (-?\d+)\*phi\)/2$")
+
+
+# ----------------------------------------------------------------------------------------
+# Exact arithmetic in Q(phi), phi^2 = phi + 1.  An element is the pair (p, q) meaning
+# p + q*phi with p and q rational.  Nothing here rounds, so every equality below is exact.
+# ----------------------------------------------------------------------------------------
+
+class Fp:
+    """An element of Q(phi), phi^2 = phi + 1."""
+
+    __slots__ = ("p", "q")
+
+    def __init__(self, p: Fraction, q: Fraction = Fraction(0)) -> None:
+        self.p = Fraction(p)
+        self.q = Fraction(q)
+
+    def __add__(self, other: "Fp") -> "Fp":
+        return Fp(self.p + other.p, self.q + other.q)
+
+    def __sub__(self, other: "Fp") -> "Fp":
+        return Fp(self.p - other.p, self.q - other.q)
+
+    def __neg__(self) -> "Fp":
+        return Fp(-self.p, -self.q)
+
+    def __mul__(self, other: "Fp") -> "Fp":
+        # (p1 + q1 phi)(p2 + q2 phi) = p1 p2 + (p1 q2 + p2 q1) phi + q1 q2 phi^2,
+        # and phi^2 = phi + 1.
+        p = self.p * other.p + self.q * other.q
+        q = self.p * other.q + other.p * self.q + self.q * other.q
+        return Fp(p, q)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Fp) and self.p == other.p and self.q == other.q
+
+    def __hash__(self) -> int:
+        return hash((self.p, self.q))
+
+    def key(self) -> tuple:
+        return (self.p.numerator, self.p.denominator, self.q.numerator, self.q.denominator)
+
+
+ZERO = Fp(Fraction(0))
+ONE = Fp(Fraction(1))
+
+
+class Quat:
+    """A quaternion with coefficients in Q(phi), in the basis (1, i, j, k)."""
+
+    __slots__ = ("c",)
+
+    def __init__(self, c: tuple) -> None:
+        self.c = tuple(c)
+
+    def __mul__(self, o: "Quat") -> "Quat":
+        a1, b1, c1, d1 = self.c
+        a2, b2, c2, d2 = o.c
+        return Quat((
+            a1 * a2 - b1 * b2 - c1 * c2 - d1 * d2,
+            a1 * b2 + b1 * a2 + c1 * d2 - d1 * c2,
+            a1 * c2 - b1 * d2 + c1 * a2 + d1 * b2,
+            a1 * d2 + b1 * c2 - c1 * b2 + d1 * a2,
+        ))
+
+    def __neg__(self) -> "Quat":
+        return Quat(tuple(-x for x in self.c))
+
+    def conj(self) -> "Quat":
+        a, b, c, d = self.c
+        return Quat((a, -b, -c, -d))
+
+    def norm(self) -> Fp:
+        a, b, c, d = self.c
+        return a * a + b * b + c * c + d * d
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Quat) and self.c == other.c
+
+    def __hash__(self) -> int:
+        return hash(self.key())
+
+    def key(self) -> tuple:
+        return tuple(x.key() for x in self.c)
+
+
+QUAT_ONE = Quat((ONE, ZERO, ZERO, ZERO))
+QUAT_NEG_ONE = -QUAT_ONE
+
+
+# ----------------------------------------------------------------------------------------
+# Packet parsing
+# ----------------------------------------------------------------------------------------
+
+def parse_component(text: str) -> Fp:
+    """Parse '(a + b*phi)/2' into an exact Q(phi) element.  Raises on any other shape."""
+    m = COMPONENT_RE.match(text)
+    if not m:
+        raise ValueError(f"component does not match (a + b*phi)/2 with integer a, b: {text!r}")
+    a, b = int(m.group(1)), int(m.group(2))
+    return Fp(Fraction(a, 2), Fraction(b, 2))
+
+
+def parse_generators(packet: dict) -> list:
+    return [Quat(tuple(parse_component(x) for x in g)) for g in packet["generators"]]
+
+
+# ----------------------------------------------------------------------------------------
+# Group construction, from the generators alone
+# ----------------------------------------------------------------------------------------
+
+def close(generators: list, cap: int = 5000) -> list:
+    """Breadth-first closure under multiplication.  The cap turns a non-finite or wrong
+    generating set into a loud failure rather than a hang."""
+    seen = {QUAT_ONE.key(): QUAT_ONE}
+    frontier = [QUAT_ONE]
+    while frontier:
+        nxt = []
+        for x in frontier:
+            for g in generators:
+                y = x * g
+                k = y.key()
+                if k not in seen:
+                    seen[k] = y
+                    nxt.append(y)
+                    if len(seen) > cap:
+                        raise RuntimeError(f"closure exceeded {cap} elements; not finite as expected")
+        frontier = nxt
+    return list(seen.values())
+
+
+def element_order(q: Quat, cap: int = 1000) -> int:
+    x, n = q, 1
+    while x != QUAT_ONE:
+        x = x * q
+        n += 1
+        if n > cap:
+            raise RuntimeError("element order exceeded cap")
+    return n
+
+
+def census(elements: list, order_of) -> dict:
+    out: dict = {}
+    for e in elements:
+        o = order_of(e)
+        out[o] = out.get(o, 0) + 1
+    return dict(sorted(out.items()))
+
+
+def center(elements: list) -> list:
+    return [z for z in elements if all(z * g == g * z for g in elements)]
+
+
+def quotient_by_center(elements: list) -> tuple:
+    """Cosets of {+1, -1}.  Returns (cosets, multiply, order_of) with the coset operations
+    defined on representatives, which is well defined because the subgroup is central."""
+    rep = {}
+    for e in elements:
+        k = e.key()
+        kn = (-e).key()
+        if k not in rep and kn not in rep:
+            rep[k] = e
+    cosets = list(rep.values())
+
+    def coset_key(q: Quat) -> tuple:
+        return min(q.key(), (-q).key())
+
+    index = {coset_key(c): c for c in cosets}
+
+    def order_of(c: Quat) -> int:
+        x, n = c, 1
+        while coset_key(x) != coset_key(QUAT_ONE):
+            x = x * c
+            n += 1
+            if n > 1000:
+                raise RuntimeError("coset order exceeded cap")
+        return n
+
+    return cosets, index, order_of
+
+
+# ----------------------------------------------------------------------------------------
+# The checks
+# ----------------------------------------------------------------------------------------
+
+def run_checks(raw: bytes, packet: dict) -> tuple:
+    """Returns (checks, detail).  Each check is (id, description, passed, observed)."""
+    checks = []
+    detail: dict = {}
+
+    def add(cid, desc, passed, observed):
+        checks.append({"id": cid, "check": desc, "pass": bool(passed), "observed": observed})
+
+    # A8 is computed first and appended last.  It is the only check that does not depend on
+    # the packet parsing, and leakage detection must not be silenced by a format failure: a
+    # stray key carrying a target reddens A1, and an audit that stopped there would report
+    # the wrong reason.  The mutation suite is what surfaced this.
+    text = raw.decode("utf-8", errors="replace").lower()
+    hits = sorted({t for t in LEAKAGE_TOKENS if re.search(rf"\b{re.escape(t)}", text)})
+    stray_keys = sorted(set(packet.keys()) - DECLARED_KEYS)
+    a8 = not hits and not stray_keys
+
+    def finish():
+        add("A8", "no leakage vocabulary and no key outside the declared set", a8,
+            {"token_hits": hits, "stray_keys": stray_keys})
+        return checks, detail
+
+    # A1 format
+    keys_ok = set(packet.keys()) == DECLARED_KEYS
+    minpoly = packet.get("coefficient_field", {}).get("minimal_polynomial")
+    gen_sym = packet.get("coefficient_field", {}).get("generator")
+    basis_ok = packet.get("quaternion_basis") == DECLARED_BASIS
+    try:
+        gens = parse_generators(packet)
+        parse_ok, parse_err = True, None
+    except ValueError as exc:
+        gens, parse_ok, parse_err = [], False, str(exc)
+    shape_ok = (
+        isinstance(packet.get("generators"), list)
+        and len(packet["generators"]) == 2
+        and all(isinstance(g, list) and len(g) == 4 for g in packet["generators"])
+    )
+    a1 = keys_ok and minpoly == DECLARED_MINPOLY and gen_sym == "phi" and basis_ok and shape_ok and parse_ok
+    add("A1", "declared keys, minimal polynomial, basis; every component is (a + b*phi)/2",
+        a1, {"keys_match": keys_ok, "minimal_polynomial": minpoly, "basis_match": basis_ok,
+             "shape_2x4": shape_ok, "components_parse": parse_ok, "parse_error": parse_err})
+    if not a1:
+        return finish()
+
+    # A2 exact unit norm
+    norms = [g.norm() for g in gens]
+    a2 = all(n == ONE for n in norms)
+    add("A2", "both generators have quaternion norm exactly 1 in Q(phi)", a2,
+        {"norms": [f"{n.p} + {n.q}*phi" for n in norms]})
+
+    # A3 closure
+    try:
+        elements = close(gens)
+        closure_err = None
+    except RuntimeError as exc:
+        elements, closure_err = [], str(exc)
+    order = len(elements)
+    keys = {e.key() for e in elements}
+    closed = bool(elements) and all((a * b).key() in keys for a in elements for b in elements)
+    a3 = order == EXPECTED_ORDER and closed
+    add("A3", f"closure is finite, multiplicatively closed, of order exactly {EXPECTED_ORDER}",
+        a3, {"order": order, "closed_under_multiplication": closed, "error": closure_err})
+    if not a3:
+        return finish()
+
+    # A4 identity and inverses
+    has_id = QUAT_ONE.key() in keys
+    inverses_ok = all(any((a * b).key() == QUAT_ONE.key() for b in elements) for a in elements)
+    add("A4", "identity present and every element has an inverse in the closure",
+        has_id and inverses_ok, {"identity_present": has_id, "all_invertible": inverses_ok})
+
+    # A5 center
+    z = center(elements)
+    z_keys = sorted(e.key() for e in z)
+    a5 = len(z) == 2 and z_keys == sorted([QUAT_ONE.key(), QUAT_NEG_ONE.key()])
+    add("A5", "center is exactly {+1, -1}", a5, {"center_order": len(z)})
+
+    # A6 element-order census
+    cen = census(elements, element_order)
+    a6 = cen == EXPECTED_ORDER_CENSUS
+    add("A6", "element-order census matches 2I and rules out A5 x C2 (30 elements of order 4)",
+        a6, {"census": cen, "expected": EXPECTED_ORDER_CENSUS,
+             "order_4_population": cen.get(4, 0)})
+
+    # A7 central quotient
+    cosets, _, coset_order = quotient_by_center(elements)
+    qcen = census(cosets, coset_order)
+    a7 = len(cosets) == EXPECTED_QUOTIENT_ORDER and qcen == EXPECTED_QUOTIENT_CENSUS
+    add("A7", f"central quotient has order {EXPECTED_QUOTIENT_ORDER} with the A5 order profile",
+        a7, {"quotient_order": len(cosets), "census": qcen,
+             "expected": EXPECTED_QUOTIENT_CENSUS})
+
+    detail["generator_orders"] = [element_order(g) for g in gens]
+    detail["element_order_census"] = cen
+    detail["quotient_order_census"] = qcen
+    detail["group_order"] = order
+    detail["center_order"] = len(z)
+    return finish()
+
+
+# ----------------------------------------------------------------------------------------
+# Canonicalization and hashing
+# ----------------------------------------------------------------------------------------
+
+def canonical_bytes(packet: dict) -> bytes:
+    """The canonical serialization: keys sorted, two-space indent, ASCII, LF, one trailing
+    newline.  Declared here so the same group always produces the same bytes."""
+    return json.dumps(packet, sort_keys=True, indent=2, ensure_ascii=True).encode("utf-8") + b"\n"
+
+
+# ----------------------------------------------------------------------------------------
+# Mutation suite: every check above is shown to go red under a deliberate defect
+# ----------------------------------------------------------------------------------------
+
+def mutations(packet: dict) -> list:
+    """Each entry is (name, mutated packet, the check ids expected to go red)."""
+    out = []
+
+    m = json.loads(json.dumps(packet))
+    m["generators"][0][0] = "(1 + 0*phi)/3"
+    out.append(("denominator_not_2", m, ["A1"]))
+
+    m = json.loads(json.dumps(packet))
+    m["coefficient_field"]["minimal_polynomial"] = "phi^2 - 2"
+    out.append(("wrong_minimal_polynomial", m, ["A1"]))
+
+    m = json.loads(json.dumps(packet))
+    m["generators"][0][1] = "(3 + 0*phi)/2"
+    out.append(("norm_not_unit", m, ["A2"]))
+
+    m = json.loads(json.dumps(packet))
+    # A unit quaternion, so A2 stays green by design: this mutation tests A3 alone.
+    m["generators"][1] = ["(0 + 0*phi)/2", "(2 + 0*phi)/2", "(0 + 0*phi)/2", "(0 + 0*phi)/2"]
+    out.append(("second_generator_replaced_by_i", m, ["A3"]))
+
+    m = json.loads(json.dumps(packet))
+    m["generators"] = [packet["generators"][0], packet["generators"][0]]
+    out.append(("generators_collapsed_to_one", m, ["A3"]))
+
+    m = json.loads(json.dumps(packet))
+    m["dimensions"] = [1, 2, 2, 3, 3, 4, 4, 5, 6]
+    out.append(("dimension_labels_added", m, ["A8"]))
+
+    m = json.loads(json.dumps(packet))
+    m["mckay_distance"] = 3
+    out.append(("mckay_distance_added", m, ["A8"]))
+
+    return out
+
+
+def run_mutation_suite(packet: dict) -> list:
+    results = []
+    for name, mutated, expected_red in mutations(packet):
+        raw = canonical_bytes(mutated)
+        try:
+            checks, _ = run_checks(raw, mutated)
+            reds = sorted(c["id"] for c in checks if not c["pass"])
+            error = None
+        except Exception as exc:  # a mutation that breaks the run counts as red, loudly
+            reds, error = ["EXCEPTION"], f"{type(exc).__name__}: {exc}"
+        # The expected checks must go red.  Later checks may not run at all once an earlier
+        # one aborts the sequence, which is why this is a subset test, not an equality test.
+        ok = all(cid in reds or "EXCEPTION" in reds for cid in expected_red)
+        results.append({"mutation": name, "expected_red": expected_red,
+                        "observed_red": reds, "detected": ok, "error": error})
+    return results
+
+
+# ----------------------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--packet", type=Path, default=DEFAULT_PACKET)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--mutation-tests", action="store_true")
+    args = ap.parse_args()
+
+    raw = args.packet.read_bytes()
+    packet = json.loads(raw)
+
+    incoming = hashlib.sha256(raw).hexdigest()
+    canon = canonical_bytes(packet)
+    authoritative = hashlib.sha256(canon).hexdigest()
+
+    checks, detail = run_checks(raw, packet)
+    all_pass = all(c["pass"] for c in checks)
+
+    mut = run_mutation_suite(packet) if args.mutation_tests else None
+    mut_ok = all(m["detected"] for m in mut) if mut else None
+
+    result = {
+        "what": "M8.5-A packet audit, run from the packet alone",
+        "packet_file": args.packet.name,
+        "incoming_sha256": incoming,
+        "canonical_form": "json.dumps(sort_keys=True, indent=2, ensure_ascii=True) + LF",
+        "authoritative_sha256": authoritative,
+        "canonicalization_changed_bytes": incoming != authoritative,
+        "checks": checks,
+        "detail": detail,
+        "all_checks_pass": all_pass,
+        "mutation_suite": mut,
+        "mutation_suite_all_detected": mut_ok,
+    }
+    args.out.write_text(json.dumps(result, indent=2) + "\n")
+
+    print(f"packet            {args.packet}")
+    print(f"incoming sha256   {incoming}")
+    print(f"authoritative     {authoritative}")
+    print(f"canonicalization  {'CHANGED the bytes' if incoming != authoritative else 'no-op (delivered bytes already canonical)'}")
+    print()
+    for c in checks:
+        print(f"  {'PASS' if c['pass'] else 'FAIL'}  {c['id']}  {c['check']}")
+        print(f"        {json.dumps(c['observed'])}")
+    print()
+    print(f"  generator orders          {detail.get('generator_orders')}")
+    print(f"  element-order census      {detail.get('element_order_census')}")
+    print(f"  central quotient census   {detail.get('quotient_order_census')}")
+    if mut is not None:
+        print()
+        for m in mut:
+            print(f"  {'DETECTED' if m['detected'] else 'MISSED  '}  {m['mutation']:34s} "
+                  f"expected red {m['expected_red']}, observed {m['observed_red']}")
+    print()
+    print(f"ALL CHECKS PASS: {all_pass}" + (f" | MUTATIONS ALL DETECTED: {mut_ok}" if mut is not None else ""))
+    print(f"written: {args.out}")
+
+    return 0 if all_pass and (mut_ok is not False) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openwave/xperiments/m8_mit/research/tasks/m8_5_task_details.md
+++ b/openwave/xperiments/m8_mit/research/tasks/m8_5_task_details.md
@@ -167,8 +167,57 @@ timestamp predates the run; contents subject to the block A leakage scan):
 | --- | --- |
 | the canonical packet | `../data/m8_5a_packet.json` |
 | the clean-room task file | `../data/m8_5a_cleanroom_task.md` |
+| the clean-room group-input file | `../data/m8_5a_cleanroom_group_input.md` |
 | the maintainer packet audit | `../scripts/m8_5a_packet_audit.py`, `../data/m8_5a_packet_audit.json` |
 | the author's verification evidence, as received | `../data/m8_5a_packet_author_evidence/` |
+
+**Audit result, 2026-07-31.** [`m8_5a_packet_audit.py`](../scripts/m8_5a_packet_audit.py) run
+from the packet alone: eight checks green, seven mutations each reddening their target, exit 0.
+Exact arithmetic throughout, no tolerance anywhere.
+
+| Quantity | Observed |
+| --- | --- |
+| incoming SHA-256, as delivered | `e3b0c945bbbb15b4549fa641234c9461062c2337b3d1e372af621b614d4883a9` |
+| canonical form | keys sorted, two-space indent, ASCII, LF, one trailing newline |
+| authoritative SHA-256 | identical to the incoming hash: the delivered bytes were already canonical, so canonicalization is a no-op here |
+| generator norms | exactly `1` in `Q(φ)`, both |
+| generator orders | 6 and 4 |
+| closure | finite, multiplicatively closed, order exactly 120 |
+| center | exactly `{+1, −1}` |
+| element-order census | 1, 1, 20, 30, 24, 20, 24 at orders 1, 2, 3, 4, 5, 6, 10 |
+| central quotient | order 60, profile 1, 15, 20, 24 at orders 1, 2, 3, 5 |
+| leakage scan | no label, dimension, distance or character vocabulary; no key outside the declared set |
+
+The element-order census is the audit's addition rather than a restatement of the author's
+gates. A center of order 2 over a quotient with the `A₅` profile is also satisfied by the
+direct product `A₅ × C₂`, which is not the binary icosahedral group; the order-4 population
+separates them, 30 against none. A finite subgroup of the unit quaternions cannot be
+`A₅ × C₂` for an independent reason, since `−1` is the only unit quaternion of order 2 while
+that product has 31 involutions, so the census is not the only thing standing between the two.
+It is the mechanical version of that argument, and this audit prefers a count to an appeal to a
+theorem.
+
+**Cross-check against the author's evidence, run only after the above was complete.** The
+author's report states the same packet hash, the same closure order, and its four gates true.
+The two runs agree, and they are not fully independent in method: both work exactly over
+`Q(φ)` through `fractions.Fraction`, which the packet format effectively forces. The checks
+differ, which is where the value is: the element-order census and the leakage scan are the
+maintainer side only, and the author's report carries an environment record the audit does not.
+
+**The room, as sealed before launch.** Four files, nothing else:
+
+| File | SHA-256 | Provenance |
+| --- | --- | --- |
+| `PROTOCOL.md` | `f7370de24ca26f78c4019bf30db30abe54810f83198f9bded39fd0c25e10bf96` | `diff`-identical to [the frozen protocol](../findings/m8_5a_reproduction_protocol.md) |
+| `m8_5a_packet.json` | `e3b0c945bbbb15b4549fa641234c9461062c2337b3d1e372af621b614d4883a9` | the author's packet, byte-identical |
+| `GROUP_INPUT.md` | `8b5fb2a61cdfe82cfe90f6c57e1e02f283229b1dd30470c331774dc3fb12f837` | maintainer-written wrapper; names the packet, states its hash, restates the packet's own coefficient-format field, quotes the packet verbatim |
+| `TASK.md` | `c662fd06c334809f0f4cdeda0903967536564dae6d597d0db308257aa34210c8` | maintainer-written, operational only |
+
+**The group order is withheld, which is stricter than the protocol requires.** Protocol § 4
+lists the order, 120, among the permitted construction inputs. `GROUP_INPUT.md` does not supply
+it, so G1 stays a check that can fail rather than a restatement of something handed over. The
+withholding is stated in that file, so the implementer knows it is deliberate and does not
+spend the run wondering whether the packet is incomplete.
 
 **Landing map for the § 9 commitment** (fixed before the run so the copy-out is mechanical;
 one commit, nothing unsealed until it lands):


### PR DESCRIPTION
The M8.5-A packet arrived on #386 (thread comment 5145139922) in two deliberately separate archives: the packet, and the author's own verification evidence marked to stay outside the room. This lands the packet, the audit, the clean-room task and group-input files, and the author's evidence as received, all before the room opens so the timestamp predates the run.

The audit runs from the packet alone and does not read the author's `verify_packet.py` or report, since an audit that reads the supplier's report and concurs is a review of the report. Eight checks, each mutation-tested so no green line is a line that cannot fail: format and exact `(a + b*phi)/2` parsing, unit norm exact in `Q(phi)`, closure finite and of order exactly 120, identity and inverses, center exactly `{+1, -1}`, element-order census, central quotient of order 60 with the `A5` profile, and a leakage scan. All eight green, seven mutations each reddening their target, exit 0.

The one check beyond the author's P-gates is the element-order census: 1, 1, 20, 30, 24, 20, 24 at orders 1, 2, 3, 4, 5, 6, 10. P3 and P4 as stated are also satisfied by `A5 x C2`, which is not the binary icosahedral group, and the order-4 population separates them, 30 against none. Unit quaternions rule that product out anyway, since `-1` is the only unit quaternion of order 2 while `A5 x C2` has 31 involutions, so the census is the mechanical version of an argument already available rather than a gap in the gates.

Set side by side afterwards, the author's report agrees on the packet hash, the closure order, and its four gates. The two runs are not fully independent in method, both working exactly over `Q(phi)` through `fractions.Fraction`, which the packet format effectively forces. The checks are what differ.

On canonicalization: the delivered bytes were already canonical under the declared form, so the incoming and authoritative hashes are identical. The step still ran and is still recorded, because the chain from delivery to room has to be complete whether or not it moved. Exact arithmetic removed the sharpest risk the protocol anticipated, which was a decimal rendering pinning a transcription rather than a group.

The room is sealed with four files, hashes recorded in `m8_5_task_details.md`: the protocol as a `diff`-identical copy, the packet byte-identical, a group-input wrapper naming the packet and stating its hash, and the task file.

@dmobius3 one deliberate choice to flag. Protocol section 4 permits supplying the group order, and `GROUP_INPUT.md` withholds it so that gate stays a check that can fail. Withholding is the stricter side, so it does not block the run; if you intended 120 to be handed over, say so and I will supply it and record the change as a deviation.

Also landed: the T4 deviations log for block A, including where the plan understated its own containment. The unavoidable user-level instruction file carries nothing answer-bearing and does name this repository, and the room is isolated by withheld web tools and by instruction rather than by a sandbox. Three guards are now explicit: the task file states the boundary as an obligation, the room session runs in default permission mode so an out-of-room tool call surfaces as an approval prompt, and the transcript is checked against the manifest at copy-out.
