### PR TITLE
Document room-operator permission runbook

### DIFF
--- a/dev_docs/PR_REVIEW_STANDARDS.md
+++ b/dev_docs/PR_REVIEW_STANDARDS.md
@@ -23,7 +23,7 @@ A documented negative is a merge-worthy contribution. An overstated positive is 
 | --- | --- |
 | [1. Intake](#1-intake) | the five things to establish before reading a line of code |
 | [2. Blast-radius map](#2-blast-radius-map) | which paths get which level of scrutiny |
-| [3. Gate A: safety and hygiene](#3-gate-a-safety-and-hygiene) | large files, encoding, copyright, secrets, dangling references |
+| [3. Gate A: safety and hygiene](#3-gate-a-safety-and-hygiene) | large files, encoding, copyright, secrets, dangling references, code intent |
 | [4. Gate B: scope containment](#4-gate-b-scope-containment) | model-folder discipline, shared files, root documents, the commitment sweep and its loud notification (§ 4.1) |
 | [5. Gate C: claim to artifact](#5-gate-c-claim-to-artifact) | recompute the headline number from the shipped data yourself |
 | [6. Gate D: the adversarial pass](#6-gate-d-the-adversarial-pass) | is the mechanism wired, is the signal above the noise, do the knobs manufacture the result |
@@ -76,6 +76,7 @@ Mechanical checks. Run them all; they take under a minute and they catch the thi
 | A6 | **Deleted files leave no dangling references, and no capability** | Every deletion is either unreferenced or every referencing import and link is repointed in the same PR. Then ask the second question: what did the deletion *remove*? A reference check is clean by construction when a file is self-contained, which is exactly the case for an xperiment configuration, a validation script, or a research note. Deleting one takes an entry off the menu and nothing complains | grep the deleted basenames across the PR branch, `.py` and `.md` both, then open each deleted file and ask what it did |
 | A7 | **New files follow the folder convention** | A new subfolder inside a model folder must match what the other columns use (`research/`, `theory/`, `data/`, `plots/`, `xparameters/`, `utils/`). A novel folder name is a convention fork. **The `utils/` rule holds at two levels.** At the model root: the launcher, the medium and the engines stay at the top, and supporting scripts (instrumentation, plotting, sampling, monitoring) go in `<model>/utils/`. Inside `xparameters/`: only launchable xperiment parameter modules, each defining `XPARAMETERS`, sit at the top level, and supporting scripts go in `xparameters/utils/`, because the launcher offers every top-level `.py` there as a selectable xperiment | `ls -d openwave/xperiments/*/*/` and compare, then `git check-ignore -v <new-folder>/<file>` on any folder name introduced by the PR |
 | A8 | **Repository language is English** | Code comments, docstrings, and documentation in English, so every author and cold reader can read every column | scan added comment lines for non-English text |
+| A9 | **Code intent review, BEFORE anything is executed** | Every added or modified executable line is read for what it does beyond the stated purpose. Red flags, each a stop-and-ask: network calls in research code (`requests`, `urllib`, `socket`, `curl` via `subprocess`) where the science needs none; file writes outside the model's own tree; `eval`/`exec`/`pickle.load` on data the PR also ships; encoded or compressed blobs decoded at runtime; environment or credential reads (`os.environ` beyond documented configuration); edits to `.github/` workflows, `pyproject.toml` hooks, or anything that runs at install or CI time with tokens (already T4 surfaces, named here because they execute). Obfuscation is itself a finding: research code has no reason to hide what it does | grep the diff for the tokens above, then read every hit in context. This check precedes Gate C by construction, see the execution rule there |
 
 ## 4. Gate B: scope containment
 
@@ -132,6 +133,8 @@ RENEGOTIATED NOW, BEFORE THE FREEZE, NOT AFTER.
 This is the gate [`REPRODUCE.md`](../REPRODUCE.md) and [`AI_HYGIENE.md`](../AI_HYGIENE.md) exist to enforce, and it is where most real problems surface.
 
 **The rule: do not read the numbers, recompute them.** If the PR ships the data, write your own short script, from the raw artifact, using your own definition of the metric, and compare. This is the [adversarial audit](../AI_HYGIENE.md#1-the-stance) applied to review.
+
+**The execution rule: running a contributed script is executing the PR, on your machine, before any merge.** This gate's recomputations and reruns therefore happen only after [A9](#3-gate-a-safety-and-hygiene) has read the code for intent. A payload in a plausible-looking research script fires at review time, not at merge time, and "it had not merged yet" protects nothing. Where A9 flagged something unresolved, recompute from the raw data with your own script and do not run the contributed one.
 
 | # | Check | Bar |
 | --- | --- | --- |

--- a/dev_docs/tasks/t4_task_details.md
+++ b/dev_docs/tasks/t4_task_details.md
@@ -154,6 +154,12 @@ The declined prompt is evidence, not just prevention: a room session that ever a
 outside path has stated something about its behavior under isolation, and the standard wants
 that recorded even when the answer was no.
 
+Remote approval (the operator answering prompts from a phone) is permitted: it relocates the
+operator's channel and grants the session nothing. The rules above apply unchanged on any
+device, and the two that erode on a small screen are the ones to hold consciously: every
+prompt is read in full before it is answered, and a question from the implementer is never
+answered from the phone, it is relayed and answered from the protocol text or not at all.
+
 ### Running it beside a live maintainer session
 
 The two sessions are independent processes and may run side by side. The information rule is

--- a/dev_docs/tasks/t4_task_details.md
+++ b/dev_docs/tasks/t4_task_details.md
@@ -136,6 +136,24 @@ record. An instruction delivered as chat text is invisible to the packet hash, a
 manifest, and composed by a context holding the targets, which is the one information channel
 § 4 forbids. The near-empty prompt is a firewall property, not a style preference.
 
+### The operator during the run
+
+The human at the room's keyboard is a firewall component, and the standard owes them a
+runbook, not just a launch flag. The permission rules (decided at block B, applied live):
+
+| Prompt or event | Operator action |
+| --- | --- |
+| at launch, before the opening prompt | verify the room's four file hashes against the sealed record; verify the session banner's working directory is the room; record the banner's model for the environment record |
+| permission prompt for a path inside the room, or for running the implementation there | approve |
+| permission prompt for any path outside the room, or any network call | decline, and log the prompt text in the deviations log |
+| no blanket grant | never pre-approve tool classes, never "don't ask again" on file access, never a bypass mode. Each prompt is read before it is answered; the reading is the guard |
+| the implementer asks a question | not answered from the operator's knowledge, however innocuous. Relayed to the maintainer session, answered from the protocol text or not at all, logged as a deviation |
+| the implementer finishes | its final message is relayed verbatim; nothing in the room is touched until block C copies it out |
+
+The declined prompt is evidence, not just prevention: a room session that ever asked for an
+outside path has stated something about its behavior under isolation, and the standard wants
+that recorded even when the answer was no.
+
 ### Running it beside a live maintainer session
 
 The two sessions are independent processes and may run side by side. The information rule is

--- a/dev_docs/tasks/t4_task_details.md
+++ b/dev_docs/tasks/t4_task_details.md
@@ -55,6 +55,7 @@ uses; the machinery does not make a run blind.
 | Setting | Decision |
 | --- | --- |
 | Location | any directory with no `CLAUDE.md` anywhere on its ancestor path, and outside every repository working tree. The concrete path is a local choice and stays out of the repository |
+| Python environment | must not have the platform installed or importable: an editable install makes the quarantined tree reachable through a bare `import` regardless of the room's location, and an environment named after the repository puts that name in the shell prompt. Verify from the room's shell before launch: the `import` fails, `pip show` returns nothing (DEVIATIONS LOG, block B) |
 | Launch | `claude --disallowedTools "WebSearch,WebFetch"`, in DEFAULT permission mode. Not a bypass mode: the approval prompt is what makes a tool call reaching outside the room visible to the operator, and it is the one containment guard that does not rely on the implementer's cooperation |
 | Write scope | the implementer writes only inside the room and never reaches the repository; a maintainer copies artifacts out and performs every commit |
 | Teardown | the room is deleted at the end of the run, block G below. Not before: a rerun under § 3 needs it, it is the only copy until block C has copied the artifacts out, and block F may need to check a detail against it |
@@ -250,6 +251,26 @@ The leakage check ran last and was skipped whenever an earlier format check abor
 sequence, so a stray key carrying a target reddened the audit for the wrong reason. Fixed by
 computing the leakage scan first and appending it unconditionally. Worth carrying into the
 standard: the mutation suite earned its place by failing something.
+
+**2026-07-31, block B. The Python environment is part of the room, and the plan never said
+so.** Caught live at launch: the shell arrived in the room with a conda environment active
+whose site-packages carry this platform as an installed package, making the quarantined tree
+importable from inside the room through a bare `import`, its path discoverable through
+`pip show`, and the repository named in the shell prompt itself. The ancestor-path rule
+covers what loads by instruction; the interpreter is a second, independent route into the
+quarantined tree, and checking one says nothing about the other. Requirement for the
+standard: before launch, the active environment must not have the platform installed or
+importable, verified mechanically from the room's shell (`import` fails, `pip show` returns
+nothing), and the interpreter, versions, and available numerics libraries are recorded for
+the environment record. This run switched to the conda base environment, verified clean:
+the platform not importable, numerics and exact-arithmetic libraries present.
+
+**2026-07-31, block A/B, adjacent catch. A notification is not a record, and an edit is not
+a notification.** The block A audit reply was landed by editing a merged PR's body, which
+notifies nobody, and a mention added by edit does not notify either. The question that needed
+an answer was then re-sent as a new comment on the delivery thread, which does notify. For
+the standard's communications note: the PR body is the durable record, a new comment is the
+notification, and anything requiring a human's answer goes in a new comment.
 
 ## FINDINGS
 


### PR DESCRIPTION
This pull request updates the PR review standards and T4 task documentation to strengthen code intent review and clarify containment and operator procedures. The most important changes include introducing a new mechanical check for code intent, tightening the execution sequence to ensure code is reviewed before execution, and adding detailed requirements and operator guidance for T4 room runs.

**PR Review Standards Improvements:**

- **Code Intent Review:**
  * Added a new check (A9) requiring explicit review of code intent before any code is executed, with specific red flags (e.g., network calls, file writes outside the model tree, use of `eval`/`exec`, etc.) and a prescribed review method.
  * Updated the Gate A summary to include "code intent" as a review item.

- **Execution Sequence Clarification:**
  * Added a rule in Gate C specifying that contributed scripts must not be executed until code intent review (A9) is completed, with instructions for handling unresolved findings.

**T4 Task Documentation Updates:**

- **Python Environment Isolation:**
  * Added a requirement that the Python environment in a T4 room must not have the platform installed or importable, with verification steps before launch. [[1]](diffhunk://#diff-fe04acad89c94bac01626ba9526d23d143dab0a9f2aaefc35b33fc66ab5e1ea5R58) [[2]](diffhunk://#diff-fe04acad89c94bac01626ba9526d23d143dab0a9f2aaefc35b33fc66ab5e1ea5R279-R298)

- **Operator Runbook and Permissions:**
  * Introduced a detailed operator runbook, outlining actions for permission prompts, session verification, and handling implementer questions during a T4 room run.

- **Process and Communication Notes:**
  * Documented lessons learned regarding environment verification and the importance of using comments (not PR body edits) for notifications requiring a human response.