### PR TITLE
M8.5-A: the section 9 commitment

### DIFF
--- a/openwave/xperiments/m8_mit/research/data/m8_5a_raw_output.txt
+++ b/openwave/xperiments/m8_mit/research/data/m8_5a_raw_output.txt
@@ -1,0 +1,80 @@
+===== main run: python3 m8_5a_reproduction.py (exit 0) =====
+M8.5-A context-isolated independent-method reproduction
+schema_version: m8_5a-v1
+packet: m8_5a_packet.json sha256 e3b0c945bbbb15b4549fa641234c9461062c2337b3d1e372af621b614d4883a9
+env.hardware: arm64
+env.implementation: CPython
+env.interpreter: python 3.13.9
+env.libraries: standard library only (fractions, json, hashlib); no numpy
+env.os: Darwin 25.5.0
+env.seeds: none: the pipeline is deterministic and fully exact over Q(phi)
+
+group: order 120, 9 conjugacy classes, sizes [1, 1, 12, 12, 12, 12, 20, 20, 30]
+irreducible dimensions: [1, 2, 2, 3, 3, 4, 4, 5, 6]
+
+gates (every tolerance fixed at exactly 0; 811 multiplicities checked):
+  G1   PASS  constructed order 120 (required 120); closed under generators: True
+  G2   PASS  9 classes, sizes [1, 1, 12, 12, 12, 12, 20, 20, 30]: sum to 120, each divides 120, identity is a singleton, each class closed under conjugation
+  G3   PASS  character rows exactly orthonormal in <.,.>_G (tolerance 0, exact Q(phi) arithmetic); 9 irreducibles
+  G4   PASS  sum of squared dimensions [1, 2, 3, 4, 5, 6, 2, 4, 3] = 120 (group order 120)
+  G5   PASS  exactly one 2-dim irreducible has chi(g) = 2 cos theta(g) on every class under the packet embedding (that is Q); the constructed 'standard' rep has that character; the constructed 'galois' rep has the character of the unique other 2-dim irreducible (that is Q')
+  G6   PASS  McKay mark condition A.dims = 2.dims holds exactly
+  G7   PASS  graph distance defined for every irreducible; (dim, distance) signatures pairwise distinct: [(1, 0), (2, 1), (2, 7), (3, 2), (3, 6), (4, 3), (4, 6), (5, 4), (6, 5)]
+  G9   PASS  McKay tensor-multiplicity matrix is symmetric
+  G8   PASS  integer-nearness held for all 811 multiplicities computed (restriction, adjacency, first-occurrence), at tolerance exactly 0
+  G12  PASS  the consumed V_n character object satisfies chi_{V_n}(e) = n+1 for 0 <= n <= 24
+  G11  PASS  consumed tau_sigma character equals (chi_sigma(g)^2 + chi_sigma(g^2))/2 on every class for all three connection classes
+  G10  PASS  comparison harness: identity compares 'reproduced'; doc_typo transcription mutation compares 'partial disagreement' (['(dim=1,d=0) trivial: 0 vs 1'])
+
+scalar first-occurrence table (rows label-free, by (dim, McKay distance)):
+  dim  distance  trivial  standard  galois
+    1         0        0         2       6
+    2         1        1         1       5
+    3         2        2         0       4
+    4         3        3         1       3
+    5         4        4         2       2
+    6         5        5         3       1
+    3         6        6         4       0
+    4         6        6         4       2
+    2         7        7         5       3
+
+coexact module (section 6, ASSERTED rule; ran: True):
+  convention map: identity on levels: this implementation's level m maps to the source convention's coexact level m; both print eigenvalue m^2/R^2
+  m_first table:
+  dim  distance  trivial  standard  galois
+    1         0        2         2       6
+    2         1        3         3       5
+    3         2        2         2       4
+    4         3        3         3       3
+    5         4        4         2       2
+    6         5        5         3       3
+    3         6        6         4       2
+    4         6        6         4       2
+    2         7        7         5       3
+  rule adjudication (trivial column): all cells match
+  supporting checks: {'graph_bipartite': True, 'n_first_trivial_equals_mckay_distance': True}
+  verdict: structurally derived and reproduced
+  reason: general argument supplied (method_note_draft.md section C): n_first(rho, trivial) = McKay distance via the Clebsch-Gordan recursion, plus bipartite parity; coexact level-m content is V_m + V_{m-2} with m >= 2; computed table agrees cell-by-cell
+  standing: per PROTOCOL section 6, numerical agreement never upgrades the rule's standing; only the derivation can, and it is examined in the adversarial audit
+
+claim ceiling (section 2): context-isolated independent-method reproduction at most; adjudication against the pinned section 6.1 table is the maintainers' step and is NOT performed here.
+run status: completed; all gates PASS; awaiting section 7 adjudication
+result.json written: <clean-room-directory>/result.json
+
+===== mutation harness: python3 m8_5a_reproduction.py --mutation-tests =====
+== mutation harness ==
+G1_drop_element          target G1   -> reddened ['G1']                       OK   (one element removed from the closure result)
+G2_swap_elements         target G2   -> reddened ['G2']                       OK   (two elements swapped between conjugacy classes)
+G3_corrupt_char          target G3   -> reddened ['G3', 'G5']                 OK   (one character value shifted by +1)
+G4_drop_irrep            target G4   -> reddened ['G4']                       OK   (one irreducible removed from the extracted set)
+G5_swap_embeddings       target G5   -> reddened ['G5']                       OK   (standard and galois embeddings interchanged)
+G6_zero_entry            target G6   -> reddened ['G6', 'G7', 'G9']           OK   (one positive McKay adjacency entry zeroed)
+G7_disconnect            target G7   -> reddened ['G6', 'G7']                 OK   (one irreducible's adjacency row and column zeroed)
+G8_perturb_tower         target G8   -> reddened ['G8']                       OK   (a tower character value perturbed by +1/3)
+G9_asymmetric            target G9   -> reddened ['G6', 'G9']                 OK   (A[0][1] incremented, breaking symmetry)
+G10_sabotage_compare     target G10  -> reddened ['G10']                      OK   (comparison harness forced to report agreement)
+G11_chi_squared          target G11  -> reddened ['G11']                      OK   (Sym^2(sigma) replaced by chi_sigma^2 (Addendum 1))
+G12_n_weights            target G12  -> reddened ['G12']                      OK   (tower built with n rather than n+1 weights (Addendum 1))
+gates covered and reddened: ['G1', 'G10', 'G11', 'G12', 'G2', 'G3', 'G4', 'G5', 'G6', 'G7', 'G8', 'G9']
+MUTATION HARNESS: PASS (12 mutations, all 12 gates covered, clean run green)
+===== mutation harness exit: 0 =====

--- a/openwave/xperiments/m8_mit/research/data/m8_5a_result.json
+++ b/openwave/xperiments/m8_mit/research/data/m8_5a_result.json
@@ -1,0 +1,359 @@
+{
+  "claim_ceiling": "context-isolated independent-method reproduction (PROTOCOL section 2); no stronger label available",
+  "coexact_module": {
+    "convention_map": "identity on levels: this implementation's level m maps to the source convention's coexact level m; both print eigenvalue m^2/R^2",
+    "declared_before_unsealing": true,
+    "m_first_rows": [
+      {
+        "dim": 1,
+        "m_first": {
+          "galois": 6,
+          "standard": 2,
+          "trivial": 2
+        },
+        "mckay_distance": 0
+      },
+      {
+        "dim": 2,
+        "m_first": {
+          "galois": 5,
+          "standard": 3,
+          "trivial": 3
+        },
+        "mckay_distance": 1
+      },
+      {
+        "dim": 3,
+        "m_first": {
+          "galois": 4,
+          "standard": 2,
+          "trivial": 2
+        },
+        "mckay_distance": 2
+      },
+      {
+        "dim": 4,
+        "m_first": {
+          "galois": 3,
+          "standard": 3,
+          "trivial": 3
+        },
+        "mckay_distance": 3
+      },
+      {
+        "dim": 5,
+        "m_first": {
+          "galois": 2,
+          "standard": 2,
+          "trivial": 4
+        },
+        "mckay_distance": 4
+      },
+      {
+        "dim": 6,
+        "m_first": {
+          "galois": 3,
+          "standard": 3,
+          "trivial": 5
+        },
+        "mckay_distance": 5
+      },
+      {
+        "dim": 3,
+        "m_first": {
+          "galois": 2,
+          "standard": 4,
+          "trivial": 6
+        },
+        "mckay_distance": 6
+      },
+      {
+        "dim": 4,
+        "m_first": {
+          "galois": 2,
+          "standard": 4,
+          "trivial": 6
+        },
+        "mckay_distance": 6
+      },
+      {
+        "dim": 2,
+        "m_first": {
+          "galois": 3,
+          "standard": 5,
+          "trivial": 7
+        },
+        "mckay_distance": 7
+      }
+    ],
+    "own_convention": "coexact level m: Hodge-Laplacian eigenvalue m^2/R^2 on (V_m x V_{m-2}) + (V_{m-2} x V_m), m >= 2",
+    "ran": true,
+    "rule_adjudication": [
+      {
+        "computed": 2,
+        "dim": 1,
+        "match": true,
+        "mckay_distance": 0,
+        "predicted": 2
+      },
+      {
+        "computed": 3,
+        "dim": 2,
+        "match": true,
+        "mckay_distance": 1,
+        "predicted": 3
+      },
+      {
+        "computed": 2,
+        "dim": 3,
+        "match": true,
+        "mckay_distance": 2,
+        "predicted": 2
+      },
+      {
+        "computed": 3,
+        "dim": 4,
+        "match": true,
+        "mckay_distance": 3,
+        "predicted": 3
+      },
+      {
+        "computed": 4,
+        "dim": 5,
+        "match": true,
+        "mckay_distance": 4,
+        "predicted": 4
+      },
+      {
+        "computed": 5,
+        "dim": 6,
+        "match": true,
+        "mckay_distance": 5,
+        "predicted": 5
+      },
+      {
+        "computed": 6,
+        "dim": 3,
+        "match": true,
+        "mckay_distance": 6,
+        "predicted": 6
+      },
+      {
+        "computed": 6,
+        "dim": 4,
+        "match": true,
+        "mckay_distance": 6,
+        "predicted": 6
+      },
+      {
+        "computed": 7,
+        "dim": 2,
+        "match": true,
+        "mckay_distance": 7,
+        "predicted": 7
+      }
+    ],
+    "rule_scope": "the asserted rule references only the McKay distance d, so it is adjudicated against the trivial-connection column; all three columns are reported as data",
+    "standing_note": "per PROTOCOL section 6, numerical agreement never upgrades the rule's standing; only the derivation can, and it is examined in the adversarial audit",
+    "supporting_checks": {
+      "graph_bipartite": true,
+      "n_first_trivial_equals_mckay_distance": true
+    },
+    "verdict": "structurally derived and reproduced",
+    "verdict_reason": "general argument supplied (method_note_draft.md section C): n_first(rho, trivial) = McKay distance via the Clebsch-Gordan recursion, plus bipartite parity; coexact level-m content is V_m + V_{m-2} with m >= 2; computed table agrees cell-by-cell"
+  },
+  "consulted_files": [
+    "PROTOCOL.md",
+    "TASK.md",
+    "GROUP_INPUT.md",
+    "m8_5a_packet.json",
+    "see manifest.md for automatically loaded context"
+  ],
+  "environment": {
+    "hardware": "arm64",
+    "implementation": "CPython",
+    "interpreter": "python 3.13.9",
+    "libraries": "standard library only (fractions, json, hashlib); no numpy",
+    "os": "Darwin 25.5.0",
+    "seeds": "none: the pipeline is deterministic and fully exact over Q(phi)"
+  },
+  "gates": [
+    {
+      "detail": "constructed order 120 (required 120); closed under generators: True",
+      "gate": "G1",
+      "pass": true
+    },
+    {
+      "detail": "9 classes, sizes [1, 1, 12, 12, 12, 12, 20, 20, 30]: sum to 120, each divides 120, identity is a singleton, each class closed under conjugation",
+      "gate": "G2",
+      "pass": true
+    },
+    {
+      "detail": "character rows exactly orthonormal in <.,.>_G (tolerance 0, exact Q(phi) arithmetic); 9 irreducibles",
+      "gate": "G3",
+      "pass": true
+    },
+    {
+      "detail": "sum of squared dimensions [1, 2, 3, 4, 5, 6, 2, 4, 3] = 120 (group order 120)",
+      "gate": "G4",
+      "pass": true
+    },
+    {
+      "detail": "exactly one 2-dim irreducible has chi(g) = 2 cos theta(g) on every class under the packet embedding (that is Q); the constructed 'standard' rep has that character; the constructed 'galois' rep has the character of the unique other 2-dim irreducible (that is Q')",
+      "gate": "G5",
+      "pass": true
+    },
+    {
+      "detail": "McKay mark condition A.dims = 2.dims holds exactly",
+      "gate": "G6",
+      "pass": true
+    },
+    {
+      "detail": "graph distance defined for every irreducible; (dim, distance) signatures pairwise distinct: [(1, 0), (2, 1), (2, 7), (3, 2), (3, 6), (4, 3), (4, 6), (5, 4), (6, 5)]",
+      "gate": "G7",
+      "pass": true
+    },
+    {
+      "detail": "McKay tensor-multiplicity matrix is symmetric",
+      "gate": "G9",
+      "pass": true
+    },
+    {
+      "detail": "integer-nearness held for all 811 multiplicities computed (restriction, adjacency, first-occurrence), at tolerance exactly 0",
+      "gate": "G8",
+      "pass": true
+    },
+    {
+      "detail": "the consumed V_n character object satisfies chi_{V_n}(e) = n+1 for 0 <= n <= 24",
+      "gate": "G12",
+      "pass": true
+    },
+    {
+      "detail": "consumed tau_sigma character equals (chi_sigma(g)^2 + chi_sigma(g^2))/2 on every class for all three connection classes",
+      "gate": "G11",
+      "pass": true
+    },
+    {
+      "detail": "comparison harness: identity compares 'reproduced'; doc_typo transcription mutation compares 'partial disagreement' (['(dim=1,d=0) trivial: 0 vs 1'])",
+      "gate": "G10",
+      "pass": true
+    }
+  ],
+  "group": {
+    "class_sizes": [
+      1,
+      1,
+      12,
+      12,
+      12,
+      12,
+      20,
+      20,
+      30
+    ],
+    "irreducible_dimensions": [
+      1,
+      2,
+      2,
+      3,
+      3,
+      4,
+      4,
+      5,
+      6
+    ],
+    "num_classes": 9,
+    "order": 120
+  },
+  "packet_sha256": "e3b0c945bbbb15b4549fa641234c9461062c2337b3d1e372af621b614d4883a9",
+  "rows": [
+    {
+      "dim": 1,
+      "mckay_distance": 0,
+      "n_first": {
+        "galois": 6,
+        "standard": 2,
+        "trivial": 0
+      }
+    },
+    {
+      "dim": 2,
+      "mckay_distance": 1,
+      "n_first": {
+        "galois": 5,
+        "standard": 1,
+        "trivial": 1
+      }
+    },
+    {
+      "dim": 3,
+      "mckay_distance": 2,
+      "n_first": {
+        "galois": 4,
+        "standard": 0,
+        "trivial": 2
+      }
+    },
+    {
+      "dim": 4,
+      "mckay_distance": 3,
+      "n_first": {
+        "galois": 3,
+        "standard": 1,
+        "trivial": 3
+      }
+    },
+    {
+      "dim": 5,
+      "mckay_distance": 4,
+      "n_first": {
+        "galois": 2,
+        "standard": 2,
+        "trivial": 4
+      }
+    },
+    {
+      "dim": 6,
+      "mckay_distance": 5,
+      "n_first": {
+        "galois": 1,
+        "standard": 3,
+        "trivial": 5
+      }
+    },
+    {
+      "dim": 3,
+      "mckay_distance": 6,
+      "n_first": {
+        "galois": 0,
+        "standard": 4,
+        "trivial": 6
+      }
+    },
+    {
+      "dim": 4,
+      "mckay_distance": 6,
+      "n_first": {
+        "galois": 2,
+        "standard": 4,
+        "trivial": 6
+      }
+    },
+    {
+      "dim": 2,
+      "mckay_distance": 7,
+      "n_first": {
+        "galois": 3,
+        "standard": 5,
+        "trivial": 7
+      }
+    }
+  ],
+  "schema_version": "m8_5a-v1",
+  "tolerances": {
+    "G3_orthonormality": "0 (exact arithmetic in Q(phi))",
+    "G5_Q_identification": "0 (exact)",
+    "G8_integer_nearness": "0 (exact: value must BE a nonnegative rational integer)",
+    "occurrence_test": "> 1/2 applied to an exact integer after G8"
+  }
+}

--- a/openwave/xperiments/m8_mit/research/findings/m8_5a_commitment.md
+++ b/openwave/xperiments/m8_mit/research/findings/m8_5a_commitment.md
@@ -1,0 +1,100 @@
+# M8.5-A: the § 9 commitment
+
+> The commitment record required by
+> [`m8_5a_reproduction_protocol.md`](m8_5a_reproduction_protocol.md) § 9: the clean-room
+> run's environment record, consulted-files manifest, commitment hashes, schema version, and
+> the pre-declared § 6 outcome, committed BEFORE any quarantined object is unsealed for
+> comparison. Adjudication against the pinned § 6.1 table is deliberately absent here: it is
+> the § 7 step, in a second, separately dated commit that names this one. Task record:
+> [`../tasks/m8_5_task_details.md`](../tasks/m8_5_task_details.md); procedure:
+> [`dev_docs/tasks/t4_task_details.md`](../../../../../dev_docs/tasks/t4_task_details.md).
+
+## 1. Commitment hashes (SHA-256)
+
+Computed independently by the maintainer at copy-out and matching the implementer's own
+`environment.md` record exactly, except where a redaction is disclosed in § 5.
+
+| Artifact | Repo file | SHA-256 |
+| --- | --- | --- |
+| the implementation | [`../scripts/m8_5a_reproduction.py`](../scripts/m8_5a_reproduction.py) | `3433254983fb0d70ffbaafbdf8f669f2752521f9e273a22e0a0e1ec0ac130ee2` |
+| raw output, as produced in the room | (room file; superseded in-repo by the redacted copy below) | `feef1e56604d0424907e7b7bf1fc1e03d0dec02c631fe573ae887806a041b3ff` |
+| raw output, committed copy (one line redacted, § 5) | [`../data/m8_5a_raw_output.txt`](../data/m8_5a_raw_output.txt) | `b9a6323b0b9e22c35f6d4308ec973431e16df83671893b92c432a9ef486ca51f` |
+| the result | [`../data/m8_5a_result.json`](../data/m8_5a_result.json) | `47c74573cdacecea868d74e21c8531014296c881fd5034ae5af9c15a5284fd02` |
+| the method-note draft | [`m8_5a_method_note.md`](m8_5a_method_note.md) | `c8ac98a218c0449ff0dfa28eb280b879d9ce44c742c94cf13e7e635ea60ce6a8` |
+| the input packet (unchanged through the run) | [`../data/m8_5a_packet.json`](../data/m8_5a_packet.json) | `e3b0c945bbbb15b4549fa641234c9461062c2337b3d1e372af621b614d4883a9` |
+
+Schema version: `m8_5a-v1`.
+
+**The § 6 declaration, fixed here and unavailable after unsealing: the coexact module RAN.**
+Implementer-reported verdict: `structurally derived and reproduced`, with the derivation and
+its self-flagged weakest links in the method-note draft, for the adversarial audit to attack.
+Per the standing rule, the numerical match itself upgrades nothing.
+
+## 2. Environment record (implementer's, verbatim content)
+
+| Field | Value |
+| --- | --- |
+| Interpreter | CPython 3.13.9 (`python3`), conda base environment |
+| Libraries | Python standard library only: `fractions`, `json`, `hashlib`, `argparse`, `platform`, `sys`, `os`, `copy`. No numpy, no third-party packages |
+| OS / hardware | macOS, Darwin kernel 25.5.0, arm64 (Apple silicon) |
+| Seeds | none: the pipeline is deterministic and fully exact over `Q(φ)`; a double-run byte-identity check confirmed determinism |
+| Implementer | Claude Code session, model Fable 5, high effort, recorded from the launch banner by the operator |
+| Date of run | 2026-07-31 |
+
+## 3. Consulted-files manifest (implementer's, folded)
+
+Deliberately consulted, all inside the room: `PROTOCOL.md`, `TASK.md`, `GROUP_INPUT.md` (read
+in full), and `m8_5a_packet.json` (parsed, hash-verified against the `GROUP_INPUT.md` pin).
+The implementer reports: no other file inside or outside the room read, listed, or searched;
+no web access (disabled by design); the relative links inside `PROTOCOL.md` not followed.
+
+Loaded automatically without being asked for, disclosed by the implementer:
+
+| Item | Implementer's assessment |
+| --- | --- |
+| the user-global Claude instruction file | writing-style and workflow preferences; mentions the platform and correspondent names; no `2I` group data, characters, dimensions, distances, first occurrences, or M8 target values |
+| the harness system prompt | tool definitions, environment description, memory-directory path; no memory files loaded, none carrying M8 facts exist for a fresh directory |
+
+**Prior-knowledge disclosure (the § 2 ceiling), implementer's statement:** the implementer is
+an AI model with an opaque training corpus, so prior exposure to published `2I` data cannot be
+excluded; general facts about binary polyhedral groups and McKay graphs are part of general
+mathematical training; no reference table was looked up or reconstructed from memory, and
+every reported number is derived by the committed source from the packet generators, bound by
+the gates and mutation harness. The claim label is capped at context-isolated
+independent-method reproduction accordingly.
+
+## 4. The maintainer's transcript check (the manifest is corroborated, not attested)
+
+The session transcript was audited against the manifest before this commitment, per the T4
+block C rule. Method: every `tool_use` event in the transcript JSONL was extracted and its
+paths classified.
+
+| Checked | Found |
+| --- | --- |
+| tool calls, total | 19: 3 reads, 4 writes, 2 edits, 10 shell commands |
+| web tool calls | 0 |
+| file-tool paths outside the room | none |
+| shell commands touching paths outside the room | none reading; two writing, disclosed next row |
+| the one deviation from "writes only inside the room" | the double-run byte-identity check redirected its two run outputs into the session's own harness-provided scratchpad directory and diffed them there. Session-private temp space, written not read, containing only the run's own stdout. Recorded because the write-scope rule was stated absolutely |
+| permission prompts declined by the operator | none; every prompt was an inside-room read, write, or run |
+| questions from the implementer mid-run | none |
+
+## 5. Redaction disclosure
+
+Line 62 of the room's `raw_output.txt` printed the clean-room directory's absolute path (the
+implementation echoing where it wrote `result.json`). The T4 rule keeps that path out of the
+repository, so the committed copy replaces the path with `<clean-room-directory>`; nothing
+else differs. Both hashes are in § 1: the original hash stays the commitment (it is also
+recorded inside the implementer's own `environment.md`), and the transcript retains the
+original line for any later verification. Lesson for the T4 standard: instruct the
+implementation to print repo-safe relative paths, so the raw output commits byte-identical.
+
+## 6. Operator log (block B)
+
+| Event | Note |
+| --- | --- |
+| launch | new terminal, room hash-verified (4 files), conda base environment verified free of the platform (`import` fails, `pip show` empty) after a first shell arrived with an environment carrying it (T4 deviations log) |
+| opening prompt | the near-empty prompt, verbatim from the T4 record, nothing else typed |
+| stall, ~15 min | a pending permission prompt had not surfaced in the terminal; the token counter sat frozen until the prompt appeared. Lesson: check for a pending prompt before interrupting a "stalled" room |
+| prompts | all inside-room; each approved individually, no blanket grants used |
+| finish | final message relayed to the maintainer session verbatim; room untouched until this copy-out |

--- a/openwave/xperiments/m8_mit/research/findings/m8_5a_method_note.md
+++ b/openwave/xperiments/m8_mit/research/findings/m8_5a_method_note.md
@@ -1,0 +1,310 @@
+# M8.5-A method note (draft, pre-commitment)
+
+Deliverable of the context-isolated independent-method reproduction specified in
+`PROTOCOL.md` (frozen 2026-07-30). Implementation: `m8_5a_reproduction.py`. Claim ceiling
+(§ 2): context-isolated independent-method reproduction, nothing stronger. Adjudication
+against the pinned § 6.1 table is the maintainers' step and is not performed here.
+
+## A. Equations first
+
+### A.1 The group
+
+The packet supplies two unit quaternions `g_1, g_2` with components in `Q(phi)`,
+`phi^2 = phi + 1`. The group is the multiplicative closure
+
+```text
+G = <g_1, g_2>  under quaternion multiplication in the basis (1, i, j, k).
+```
+
+All arithmetic is exact: an element of `Q(phi)` is stored as `a + b*phi` with `a, b`
+exact rationals (`fractions.Fraction`); products reduce by `phi^2 = phi + 1`. Conjugacy
+classes are orbits under conjugation by the generators (which generate all inner
+automorphisms). Inverses use `q^{-1} = conj(q)` for unit quaternions.
+
+### A.2 Inner product and multiplicities
+
+```text
+<a, b>_G = (1/|G|) * sum_g a(g) * conj(b(g))     (multiplicities over C)
+```
+
+Every character computed in this run is exactly real in `Q(phi)` (traces of the complex
+matrices are asserted to have imaginary part exactly zero), so conjugation is the
+identity and dual conventions cannot flip any result. Integer-nearness (§ 5.4) is
+enforced at tolerance exactly 0: a multiplicity must BE a nonnegative rational integer
+(zero `phi`-part, denominator 1). The occurrence test `> 1/2` is applied to the exact
+integer only after that gate passes.
+
+### A.3 The scalar tower, exactly
+
+For `g` with `2 cos(alpha) = 2 Re(g) =: t` (an exact element of `Q(phi)`), the power
+sums `s_m = e^{i m alpha} + e^{-i m alpha}` satisfy
+
+```text
+s_0 = 2,   s_1 = t,   s_m = t*s_{m-1} - s_{m-2}
+```
+
+and the restricted `SU(2)` character is the sum of its `n+1` weights:
+
+```text
+chi_{V_n}(g) = sum_{k=0..n} e^{i(n-2k) alpha}
+             = s_n + s_{n-2} + ... + (s_1 or 1)      (exact in Q(phi))
+```
+
+### A.4 Irreducible characters by peeling (the character-extraction method)
+
+Process `n = 0, 1, 2, ...`: subtract from `chi_{V_n}|_G` all known irreducible content
+(each coefficient an integer-gated multiplicity). The remainder is a genuine character,
+a nonnegative integer combination of not-yet-found irreducibles. If its norm
+`<r, r>_G` is exactly 1, `r` IS a new irreducible character. Norm >= 2 remainders are
+pooled and re-reduced whenever a new irreducible lands. Extraction completes when
+
+```text
+sum_rho (dim rho)^2 = |G|
+```
+
+and fails loud if the tower bound `n <= 24` is exhausted first. Correctness needs no
+assumption about the group: restrictions of `V_n` span the class functions or the run
+fails loud; a norm-1 nonnegative-integer combination of irreducibles is one irreducible.
+
+### A.5 Connections, coefficients, and the frozen embedding
+
+`Q` is identified, never declared (§ 5.3): it is the unique 2-dimensional irreducible
+whose character equals `2 cos(theta(g)) = 2 Re(g)` on every class under the packet's
+embedding (gate G5). `Q'` is the unique other 2-dimensional irreducible. The explicit
+matrices used for the three declared flat-connection classes are:
+
+| sigma | Explicit matrices |
+| --- | --- |
+| `trivial` | the 1x1 identity on every class |
+| `standard` (`Q`) | `su2_matrix(q)`: the packet embedding `q = w+xi+yj+zk -> [[w+xi, y+zi], [-y+zi, w-xi]]` |
+| `galois` (`Q'`) | `su2_matrix(galois(q))`: componentwise `phi -> 1-phi`, a quaternion-algebra automorphism, hence a genuine 2-dim representation of the same abstract group; G5 verifies its character is the other 2-dim irreducible |
+
+The coefficient representation is the contract input `tau_sigma = Sym^2(sigma)`,
+constructed EXPLICITLY (TASK requirement 2, preferred route): the induced matrix of
+`sigma(g)` on the monomial basis `{e_i e_j : i <= j}` is built entry by entry and
+`chi_{tau_sigma}(g)` is its trace. The character identity
+`(chi^2(g) + chi(g^2))/2` is NOT used in construction; it is checked afterwards by G11
+on the same constructed object, with `g^2` evaluated by raw quaternion multiplication.
+The two routes genuinely differ, so G11 is a cross-check here, not a restatement.
+
+### A.6 The reproduced quantity
+
+```text
+n_first(rho, sigma) = min{ n >= 0 : <chi_{V_n}|_G * chi_{tau_sigma}, chi_rho>_G > 0 }
+```
+
+searched for `n <= 24`, NOT-FOUND failing loud. Row identity is label-free: each
+irreducible is reported by `(dim, McKay distance)`, where `A_{rho,tau} =
+<chi_rho * chi_Q, chi_tau>_G` is derived in-implementation, integer-gated, and the
+distance is BFS graph distance from the trivial node over the support `A > 0`.
+
+## B. Equation-to-code map
+
+Line numbers refer to `m8_5a_reproduction.py` at commitment (SHA-256 in
+`environment.md`). No repository permalinks exist in this clean room; file plus line
+is the stable reference.
+
+| Equation / object | Code |
+| --- | --- |
+| `Q(phi)` exact arithmetic, Galois map `phi -> 1-phi` | `QPhi`, `m8_5a_reproduction.py:65` |
+| Quaternion product, conjugate, norm | `qmul`/`qconj`/`qnorm2`, `m8_5a_reproduction.py:152` |
+| Packet parsing plus SHA-256 pin check | `parse_component`/`load_packet`, `m8_5a_reproduction.py:183` |
+| A.1 closure `G = <g_1, g_2>` | `generate_group`, `m8_5a_reproduction.py:220`; `check_closure`, `:243` |
+| Conjugacy classes as generator-conjugation orbits | `conjugacy_classes`, `m8_5a_reproduction.py:252` |
+| A.5 frozen embedding `q -> SU(2)` | `su2_matrix`, `m8_5a_reproduction.py:310` |
+| A.5 explicit `Sym^2` matrix on monomial basis | `sym2_matrix`, `m8_5a_reproduction.py:329` |
+| A.5 sigma matrices and consumed `tau_sigma` characters | `build_sigma_reps`, `m8_5a_reproduction.py:354`; `build_tau_chars`, `:367` |
+| A.3 exact tower via `s_m` recursion over weights | `build_tower`, `m8_5a_reproduction.py:394` |
+| A.2 inner product; integer-nearness at tolerance 0 | `make_ip`, `m8_5a_reproduction.py:434`; `multiplicity`, `:449` |
+| A.4 peeling extraction | `extract_irreducibles`, `m8_5a_reproduction.py:464` |
+| McKay matrix, BFS distance, bipartite witness | `build_mckay`, `m8_5a_reproduction.py:540`; `bfs_distances`, `:568`; `bipartition_ok`, `:585` |
+| A.6 first occurrences (scalar) | `scalar_first_occurrences`, `m8_5a_reproduction.py:606` |
+| C. coexact module | `coexact_first_occurrences`, `m8_5a_reproduction.py:630`; `coexact_rule_prediction`, `:656` |
+| § 7 comparison harness plus doc_typo mutation | `compare_tables`, `m8_5a_reproduction.py:669`; `perturb_rows`, `:697` |
+| Pipeline and all gate evaluations G1..G12 | `run_pipeline`, `m8_5a_reproduction.py:714` |
+| § 8 mutation harness (12 mutations, coverage enforced) | `MUTATIONS`, `m8_5a_reproduction.py:986`; `run_mutation_tests`, `:1002` |
+
+## C. The coexact module: own harmonic analysis and the general argument
+
+### C.1 The coexact tower on S^3 (derived, not imported)
+
+Peter-Weyl on `S^3 = SU(2)` under left x right translation:
+
+```text
+L^2(S^3) = sum_n  V_n (x) V_n
+```
+
+Trivializing `Omega^1` by the left-invariant coframe gives
+`Omega^1 = L^2 (x) su(2)*`, with right translation acting on `su(2)*` as `V_2` and left
+translation acting on functions only, so as a left x right representation
+
+```text
+Omega^1 = sum_n V_n (x) (V_n (x) V_2) = sum_n V_n (x) (V_{n-2} + V_n + V_{n+2}).
+```
+
+Repeating with the right-invariant coframe forces the symmetric-in-labels form: the
+blocks of `Omega^1` are exactly `V_a (x) V_b` with `|a-b| in {0, 2}`, each once.
+Exact forms are `d` of nonconstant functions: the `(n, n)` blocks, `n >= 1` (and
+`(0,0)` is absent from `Omega^1`). `S^3` has no harmonic 1-forms. What remains is
+coexact:
+
+```text
+coexact Omega^1 = sum_{m >= 2}  ( V_m (x) V_{m-2}  +  V_{m-2} (x) V_m ).
+```
+
+On a 3-manifold, coexact eigenforms are curl eigenmodes and `Delta = (*d)^2`. On the
+Maurer-Cartan block (`(0,2)`, level `m = 2`) the curl eigenvalue is `±2/R`, giving
+`Delta = 4/R^2`, which is the known Killing-form eigenvalue on `S^3` and fixes the
+normalization; the ladder of blocks gives `curl = ±m/R` on the level-`m` pair, so
+
+```text
+Delta = m^2 / R^2   on   (V_m (x) V_{m-2}) + (V_{m-2} (x) V_m),   m >= 2,
+```
+
+with multiplicity `2(m^2 - 1)`, consistent with the level-2 count of 6. The deck group
+acts by LEFT multiplication, so only left factors matter for the quotient; the right
+factors contribute nonzero multiplicities, which cannot change a first occurrence
+(same waiver as § 5.2). Level `m` therefore contributes `V_m|_G + V_{m-2}|_G`, and the
+§ 5.4 pattern gives
+
+```text
+m_first(rho, sigma) = min{ m >= 2 :
+    <chi_{V_m} chi_{tau_sigma}, chi_rho> > 0  or  <chi_{V_{m-2}} chi_{tau_sigma}, chi_rho> > 0 }
+```
+
+searched for `m <= 24`. Convention map: this implementation's level `m` is the source
+convention's coexact level `m`; both print eigenvalue `m^2/R^2`. The map is the
+identity and is stated explicitly per § 6.
+
+### C.2 The general argument for the entry rule
+
+The asserted rule references only the McKay distance `d`, so it is adjudicated against
+the trivial-connection column; the other two columns are reported as data.
+
+**Lemma 1 (first occurrence equals distance).** Let `v_n(rho) = <chi_{V_n}|_G, chi_rho>`.
+Clebsch-Gordan on `SU(2)` gives `chi_{V_n} = chi_{V_{n-1}} chi_Q - chi_{V_{n-2}}`
+exactly, hence on multiplicity vectors
+
+```text
+v_n = A v_{n-1} - v_{n-2},   v_0 = e_trivial,   v_1 = e_Q.
+```
+
+By induction `v_n` is supported on distance <= n (applying `A` extends support by one
+step; subtraction cannot extend it). At `n = d(rho)`:
+`v_d(rho) = (A v_{d-1})(rho) - v_{d-2}(rho)`; the second term vanishes (distance
+`d > d-2`), and the first is positive because some geodesic neighbor `tau` of `rho` at
+distance `d-1` has `v_{d-1}(tau) > 0` by induction and `A_{rho,tau} > 0`. Hence
+`n_first(rho, trivial) = d(rho)` for every irreducible. (Computational witness:
+`n_first_trivial_equals_mckay_distance = True` in the module block.)
+
+**Lemma 2 (parity).** The support graph is bipartite (witness: `graph_bipartite =
+True`; the BFS parity classes 2-color every edge). By the same recursion,
+`v_n(rho) = 0` whenever `n != d(rho) (mod 2)`.
+
+**Rule.** `m_first(rho, trivial) = min{ m >= 2 : v_m(rho) > 0 or v_{m-2}(rho) > 0 }`:
+
+| `d(rho)` | Argument | Result |
+| --- | --- | --- |
+| `d >= 2` | `v_d(rho) > 0` (Lemma 1) and no `m < d` can reach distance `d` (support bound) | `m_first = d` |
+| `d = 0` | at `m = 2`, `v_0(rho) = v_0(trivial) = 1 > 0` | `m_first = 2` |
+| `d = 1` | `m = 2` needs `v_2(rho)` or `v_0(rho)`; both vanish (`v_0` by distance, `v_2` by Lemma 2 parity); at `m = 3`, `v_1(rho) > 0` | `m_first = 3` |
+
+This establishes the rule for the full representation family from the operator and
+representation structure (the coexact tower's left content plus the restriction
+recursion). It is not a pattern fit to the computed range: the computed `m <= 24` table
+is the check of the argument, not its source. Both lemma witnesses are computed and
+recorded in the module block; the derivation itself is what the § 9 adversarial audit
+examines. Verdict claimed: **structurally derived and reproduced** (trivial-column
+cells all match; the general argument above). Per the § 6 standing rule, the numerical
+match contributes nothing to standing; only the derivation is on offer, and its
+weakest link is stated in § H.
+
+## D. Results beside their gates
+
+Full verbatim output in `raw_output.txt`; machine-readable form in `result.json`.
+
+| Result | Gate that binds it | Outcome |
+| --- | --- | --- |
+| Group order 120, closed | G1 | ✅ PASS |
+| 9 classes, sizes [1, 1, 12, 12, 12, 12, 20, 20, 30] | G2 | ✅ PASS |
+| 9 irreducibles, exactly orthonormal | G3 (tolerance 0) | ✅ PASS |
+| Dimensions [1, 2, 2, 3, 3, 4, 4, 5, 6], squares sum to 120 | G4 | ✅ PASS |
+| `Q` identified by `chi = 2 cos theta`; `Q'` the unique other 2-dim | G5 | ✅ PASS |
+| McKay matrix: mark condition `A.dims = 2.dims` | G6 | ✅ PASS |
+| Distances defined; 9 signatures pairwise distinct | G7 | ✅ PASS |
+| All 811 multiplicities exactly nonnegative integers | G8 (tolerance 0) | ✅ PASS |
+| `A` symmetric | G9 | ✅ PASS |
+| Comparison harness reddens under doc_typo transcription mutation | G10 | ✅ PASS |
+| Consumed `tau_sigma` satisfies the Sym^2 character identity classwise | G11 (Addendum 1) | ✅ PASS |
+| Consumed tower satisfies `chi_{V_n}(e) = n+1`, `0 <= n <= 24` | G12 (Addendum 1) | ✅ PASS |
+| Mutation harness: 12 mutations, every gate covered and reddened, clean run green | § 8 requirement | ✅ PASS (exit 0) |
+
+Scalar first-occurrence table (label-free rows, `(dim, McKay distance)`):
+
+| dim | distance | trivial | standard | galois |
+| --- | --- | --- | --- | --- |
+| 1 | 0 | 0 | 2 | 6 |
+| 2 | 1 | 1 | 1 | 5 |
+| 3 | 2 | 2 | 0 | 4 |
+| 4 | 3 | 3 | 1 | 3 |
+| 5 | 4 | 4 | 2 | 2 |
+| 6 | 5 | 5 | 3 | 1 |
+| 3 | 6 | 6 | 4 | 0 |
+| 4 | 6 | 6 | 4 | 2 |
+| 2 | 7 | 7 | 5 | 3 |
+
+Coexact module: all trivial-column cells match the asserted rule; full `m_first` table
+for all three columns is in `result.json` and `raw_output.txt`. Verdict:
+structurally derived and reproduced (§ C.2), scope stated there.
+
+## E. Method-overlap disclosure (§ 3, required)
+
+| Ingredient | Overlap with object 1 (McKay recursion, literal group-theory inputs) | Overlap with object 2 (explicit quaternions, brute-force classes, Burnside) |
+| --- | --- | --- |
+| Explicit quaternion arithmetic and brute-force conjugacy classes | none | overlaps: same generic route |
+| Character extraction by exact peeling of tower restrictions | none: no group-theory literals imported; characters derived, not assumed | differs: object 2 used Burnside class-sum diagonalization; this run never forms class-sum matrices |
+| Clebsch-Gordan recursion used in Lemma 1 (coexact argument only) | the recursion is the same `SU(2)` identity the McKay recursion rests on; here it is a proof device, and the computed tables never use it (the tower is built from weight sums) | none |
+| Exact `Q(phi)` arithmetic end to end | differs (object 1 numeric/literal) | differs (object 2 numpy float, seed 11) |
+
+No call, import, copy, read, or execution of either object; no shared derived fixtures.
+No third fundamentally different method is claimed; context isolation and
+implementation independence are.
+
+## F. Tolerances (§ 8 commitment, fixed before any comparison)
+
+Every tolerance is fixed in the source (`TOLERANCES`, `m8_5a_reproduction.py:44`) at
+exactly 0: the entire pipeline is exact over `Q(phi)`; no floating point exists
+anywhere in it. Integer-nearness means "is exactly a nonnegative rational integer".
+The § 8 stability-under-increased-precision requirement is discharged by exactness:
+there is no working precision to increase and no conditioning to degrade; determinism
+was additionally confirmed by a byte-identical double run. Tolerances cannot be
+widened after unsealing because there are none to widen; any change would be a dated
+rerun per § 8.
+
+## G. Inspection artifacts (4)
+
+| # | Artifact | What to inspect |
+| --- | --- | --- |
+| 1 | `raw_output.txt` | verbatim stdout: gate lines, both tables, mutation-harness lines |
+| 2 | `result.json` | fixed § 5 schema, machine-readable |
+| 3 | G5/G11 gate lines in `raw_output.txt` | the identified-not-declared `Q` and the consumed-object Sym^2 check |
+| 4 | mutation-harness block in `raw_output.txt` | every gate reddened by a deliberate defect; coverage enforced; exit 0 |
+
+## H. Claims NOT verified (§ 9, explicit)
+
+| Claim | Status |
+| --- | --- |
+| The contract choice `tau_sigma = Sym^2(sigma)` | not verified; its consequences are checked (G11), the choice itself is the lock's § 2 contract input |
+| Fitness of any simulation backend | out of scope; that is M8.5-B |
+| The M8.3 Reidemeister-torsion closed forms | out of scope (§ 0) |
+| The coexact entry rule's truth beyond this derivation | the § 6 verdict claimed is "structurally derived and reproduced", so the rule is not listed as unverified on that ground; the derivation's weakest links are stated below and stand or fall with the adversarial audit |
+| Weakest links of § C: the identification of the coexact blocks as `V_m (x) V_{m-2} + V_{m-2} (x) V_m` and the curl normalization `Delta = m^2/R^2` rest on this note's own harmonic analysis (cross-checked against the Killing level `m = 2` count and eigenvalue, and the multiplicity formula `2(m^2-1)`); the rule's scope was read as the trivial-connection column because the rule references only `d` | flagged for the audit |
+| That the packet generators are the maintainers' intended input | not verifiable from inside the clean room; G1/G2 bind order and structure, the packet audit (§ 4) binds intent |
+| Agreement with the pinned § 6.1 table | not checked here by design; that is the § 7 adjudication, quarantine intact |
+
+## Adversarial-audit note
+
+This draft precedes the recorded adversarial audit required by § 9 before the
+deliverable crosses to the author. Items explicitly queued for that audit: the § C.2
+derivation (both lemmas and the scope reading), the realness assertion route, and the
+peeling algorithm's completion argument.

--- a/openwave/xperiments/m8_mit/research/scripts/m8_5a_reproduction.py
+++ b/openwave/xperiments/m8_mit/research/scripts/m8_5a_reproduction.py
@@ -1,0 +1,1156 @@
+#!/usr/bin/env python3
+"""M8.5-A context-isolated independent-method reproduction (scalar first-occurrence table).
+
+Implements PROTOCOL.md (frozen 2026-07-30) against the group input in m8_5a_packet.json.
+
+Conventions (stated per PROTOCOL.md section 5.4):
+  - Inner product <a,b>_G = (1/|G|) sum_g a(g) * conj(b(g)); multiplicities over C.
+  - All characters computed here are exactly real elements of Q(phi); conjugation is
+    therefore the identity and cannot flip any result. Realness is asserted, not assumed.
+  - ALL arithmetic is exact over Q(phi) (phi^2 = phi + 1) using fractions.Fraction.
+    No floating point enters the pipeline. Every tolerance is therefore fixed at
+    exactly zero (see TOLERANCES below); the section 8 stability-under-increased-
+    precision requirement is discharged by exactness itself.
+  - The occurrence test "multiplicity > 1/2" (section 5.4) is applied literally,
+    after the integer-nearness gate (G8) passes for that multiplicity.
+
+Exit codes: 0 = success; 2 = gate/structural failure (fail loud);
+            3 = mutation-harness failure (uncovered gate or unreddened mutation).
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import sys
+from fractions import Fraction
+
+# --------------------------------------------------------------------------
+# Frozen run parameters
+# --------------------------------------------------------------------------
+
+SCHEMA_VERSION = "m8_5a-v1"
+PACKET_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "m8_5a_packet.json")
+PACKET_SHA256 = "e3b0c945bbbb15b4549fa641234c9461062c2337b3d1e372af621b614d4883a9"
+EXPECTED_GROUP_ORDER = 120       # permitted construction input (PROTOCOL.md section 4);
+                                 # checked by G1, never used to build anything.
+N_MAX = 24                       # scalar search bound (section 5.5)
+M_MAX = 24                       # coexact search bound (section 6)
+PEEL_N_MAX = 24                  # bound for character-extraction peeling; fail loud beyond
+
+# Every tolerance in this run, fixed in source before any comparison (TASK req. 3):
+# all comparisons are exact equalities in Q(phi); the tolerance is exactly 0.
+TOLERANCES = {
+    "G3_orthonormality": "0 (exact arithmetic in Q(phi))",
+    "G5_Q_identification": "0 (exact)",
+    "G8_integer_nearness": "0 (exact: value must BE a nonnegative rational integer)",
+    "occurrence_test": "> 1/2 applied to an exact integer after G8",
+}
+
+
+class GateFailure(Exception):
+    """A gate failed; carries the gate name. Fail loud (PROTOCOL section 5.5, TASK req. 4)."""
+
+    def __init__(self, gate, detail):
+        self.gate = gate
+        self.detail = detail
+        super().__init__("%s: %s" % (gate, detail))
+
+
+# --------------------------------------------------------------------------
+# Exact arithmetic in Q(phi), phi^2 = phi + 1
+# --------------------------------------------------------------------------
+
+class QPhi(object):
+    """Element a + b*phi of Q(phi), a and b exact rationals. Immutable, hashable."""
+
+    __slots__ = ("a", "b")
+
+    def __init__(self, a, b=0):
+        object.__setattr__(self, "a", Fraction(a))
+        object.__setattr__(self, "b", Fraction(b))
+
+    def __setattr__(self, *args):
+        raise AttributeError("QPhi is immutable")
+
+    def __add__(self, o):
+        o = _coerce(o)
+        return QPhi(self.a + o.a, self.b + o.b)
+
+    def __sub__(self, o):
+        o = _coerce(o)
+        return QPhi(self.a - o.a, self.b - o.b)
+
+    def __neg__(self):
+        return QPhi(-self.a, -self.b)
+
+    def __mul__(self, o):
+        o = _coerce(o)
+        # (a1 + b1 phi)(a2 + b2 phi) = a1a2 + b1b2  +  (a1b2 + a2b1 + b1b2) phi
+        return QPhi(self.a * o.a + self.b * o.b,
+                    self.a * o.b + o.a * self.b + self.b * o.b)
+
+    __radd__ = __add__
+    __rmul__ = __mul__
+
+    def __rsub__(self, o):
+        return _coerce(o) - self
+
+    def __eq__(self, o):
+        o = _coerce(o)
+        return self.a == o.a and self.b == o.b
+
+    def __ne__(self, o):
+        return not self.__eq__(o)
+
+    def __hash__(self):
+        return hash((self.a, self.b))
+
+    def galois(self):
+        """Field automorphism phi -> 1 - phi:  a + b*phi -> (a+b) - b*phi."""
+        return QPhi(self.a + self.b, -self.b)
+
+    def is_zero(self):
+        return self.a == 0 and self.b == 0
+
+    def is_rational(self):
+        return self.b == 0
+
+    def is_nonneg_integer(self):
+        """Exact integer-nearness (tolerance 0): a nonnegative rational integer."""
+        return self.b == 0 and self.a.denominator == 1 and self.a >= 0
+
+    def as_int(self):
+        if not (self.b == 0 and self.a.denominator == 1):
+            raise ValueError("not an exact rational integer: %s" % self)
+        return int(self.a)
+
+    def sort_key(self):
+        return (self.a, self.b)
+
+    def __repr__(self):
+        if self.b == 0:
+            return str(self.a)
+        return "(%s + %s*phi)" % (self.a, self.b)
+
+
+def _coerce(x):
+    if isinstance(x, QPhi):
+        return x
+    return QPhi(x)
+
+
+ZERO = QPhi(0)
+ONE = QPhi(1)
+
+
+# --------------------------------------------------------------------------
+# Quaternions over Q(phi): tuples (w, x, y, z) of QPhi, basis (1, i, j, k)
+# --------------------------------------------------------------------------
+
+def qmul(p, q):
+    w1, x1, y1, z1 = p
+    w2, x2, y2, z2 = q
+    return (w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+            w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+            w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+            w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2)
+
+
+def qconj(q):
+    w, x, y, z = q
+    return (w, -x, -y, -z)
+
+
+def qnorm2(q):
+    w, x, y, z = q
+    return w * w + x * x + y * y + z * z
+
+
+QUAT_ONE = (ONE, ZERO, ZERO, ZERO)
+
+
+def quat_galois(q):
+    """Componentwise Galois conjugation: a group isomorphism onto the conjugate embedding."""
+    return tuple(c.galois() for c in q)
+
+
+# --------------------------------------------------------------------------
+# Packet parsing
+# --------------------------------------------------------------------------
+
+def parse_component(s):
+    """Parse '(a + b*phi)/2' with integer a, b into QPhi (a + b*phi)/2."""
+    s = s.strip()
+    if not (s.startswith("(") and s.endswith(")/2")):
+        raise ValueError("bad component format: %r" % s)
+    inner = s[1:-3]
+    left, right = inner.split("+")
+    a = int(left.strip())
+    rb = right.strip()
+    if not rb.endswith("*phi"):
+        raise ValueError("bad component format: %r" % s)
+    b = int(rb[:-4].strip())
+    return QPhi(Fraction(a, 2), Fraction(b, 2))
+
+
+def load_packet():
+    with open(PACKET_FILE, "rb") as f:
+        raw = f.read()
+    digest = hashlib.sha256(raw).hexdigest()
+    if digest != PACKET_SHA256:
+        raise GateFailure("packet", "SHA-256 mismatch: %s" % digest)
+    packet = json.loads(raw.decode("utf-8"))
+    if packet.get("format_version") != "m8_5a-packet-v1":
+        raise GateFailure("packet", "unexpected format_version")
+    gens = []
+    for g in packet["generators"]:
+        quat = tuple(parse_component(c) for c in g)
+        if qnorm2(quat) != ONE:
+            raise GateFailure("packet", "generator is not a unit quaternion: %s" % (quat,))
+        gens.append(quat)
+    return gens
+
+
+# --------------------------------------------------------------------------
+# Group construction: closure, conjugacy classes, power map
+# --------------------------------------------------------------------------
+
+def generate_group(gens, mutation=None):
+    """Breadth-first closure of the generator set under quaternion multiplication."""
+    elements = [QUAT_ONE]
+    seen = {QUAT_ONE}
+    frontier = [QUAT_ONE]
+    while frontier:
+        nxt = []
+        for q in frontier:
+            for g in gens:
+                p = qmul(q, g)
+                if p not in seen:
+                    seen.add(p)
+                    elements.append(p)
+                    nxt.append(p)
+        frontier = nxt
+        if len(elements) > 10000:
+            raise GateFailure("G1", "closure exceeded 10000 elements; not a small finite group")
+    if mutation == "G1_drop_element":
+        elements = elements[:-1]
+        seen = set(elements)
+    return elements, seen
+
+
+def check_closure(elements, seen, gens):
+    """True iff the element set is closed under right multiplication by every generator."""
+    for q in elements:
+        for g in gens:
+            if qmul(q, g) not in seen:
+                return False
+    return True
+
+
+def conjugacy_classes(elements, seen, gens, mutation=None):
+    """Partition into conjugacy classes: orbits under conjugation by the generators."""
+    inv_gens = [qconj(g) for g in gens]  # unit quaternions: inverse = conjugate
+    class_of = {}
+    classes = []
+    for e in elements:
+        if e in class_of:
+            continue
+        orbit = [e]
+        oseen = {e}
+        stack = [e]
+        while stack:
+            x = stack.pop()
+            for g, gi in zip(gens, inv_gens):
+                y = qmul(qmul(g, x), gi)
+                if y not in oseen:
+                    oseen.add(y)
+                    orbit.append(y)
+                    stack.append(y)
+        idx = len(classes)
+        classes.append(orbit)
+        for x in orbit:
+            class_of[x] = idx
+    # Deterministic class order: by (size, trace sort key); trace = 2*Re is a class invariant.
+    order = sorted(range(len(classes)),
+                   key=lambda i: (len(classes[i]),
+                                  (classes[i][0][0] + classes[i][0][0]).sort_key()))
+    classes = [classes[i] for i in order]
+    class_of = {}
+    for i, cl in enumerate(classes):
+        for x in cl:
+            class_of[x] = i
+    if mutation == "G2_swap_elements":
+        # Swap one element between the two largest classes: breaks conjugation-closure.
+        a, b = len(classes) - 1, len(classes) - 2
+        classes[a][0], classes[b][0] = classes[b][0], classes[a][0]
+        class_of[classes[a][0]] = a
+        class_of[classes[b][0]] = b
+    return classes, class_of
+
+
+# --------------------------------------------------------------------------
+# Complex numbers over Q(phi) and explicit matrix representations
+# --------------------------------------------------------------------------
+# A complex value is a pair (re, im) of QPhi. Matrices are tuples of row-tuples.
+
+CZERO = (ZERO, ZERO)
+CONE = (ONE, ZERO)
+
+
+def cadd(u, v):
+    return (u[0] + v[0], u[1] + v[1])
+
+
+def cmul(u, v):
+    return (u[0] * v[0] - u[1] * v[1], u[0] * v[1] + u[1] * v[0])
+
+
+def su2_matrix(q):
+    """Packet's frozen embedding: quaternion w + xi + yj + zk as the SU(2) matrix
+    [[w + x i,  y + z i], [-y + z i,  w - x i]]  (trace = 2w = 2 Re q)."""
+    w, x, y, z = q
+    return (((w, x), (y, z)),
+            ((-y, z), (w, -x)))
+
+
+def mat_trace_real(M):
+    """Trace of a complex matrix, asserted exactly real; returns the QPhi real part."""
+    re, im = ZERO, ZERO
+    for i in range(len(M)):
+        re = re + M[i][i][0]
+        im = im + M[i][i][1]
+    if not im.is_zero():
+        raise GateFailure("realness", "matrix trace has nonzero imaginary part: %s" % im)
+    return re
+
+
+def sym2_matrix(M):
+    """Explicit symmetric square: the induced matrix on the monomial basis
+    {e_i e_j : i <= j}. This is the constructed-object route of TASK requirement 2:
+    the coefficient character is the TRACE of this matrix, not the character identity."""
+    d = len(M)
+    basis = [(i, j) for i in range(d) for j in range(i, d)]
+    S = []
+    for (k, l) in basis:
+        row = []
+        for (i, j) in basis:
+            if i == j:
+                if k == l:
+                    c = cmul(M[k][i], M[k][i])
+                else:
+                    c = cmul((QPhi(2), ZERO), cmul(M[k][i], M[l][i]))
+            else:
+                if k == l:
+                    c = cmul(M[k][i], M[k][j])
+                else:
+                    c = cadd(cmul(M[k][i], M[l][j]), cmul(M[l][i], M[k][j]))
+            row.append(c)
+        S.append(tuple(row))
+    return tuple(S)
+
+
+def build_sigma_reps(class_reps):
+    """Explicit matrices, per conjugacy-class representative, for the three declared
+    flat-connection classes. 'standard' is the packet's frozen embedding itself;
+    'galois' is the Galois-conjugated embedding (componentwise phi -> 1 - phi, a
+    quaternion-algebra automorphism, hence a genuine 2-dim representation of the
+    same abstract group). 'trivial' is the 1-dimensional identity representation."""
+    reps = {}
+    reps["trivial"] = [((CONE,),) for _ in class_reps]
+    reps["standard"] = [su2_matrix(g) for g in class_reps]
+    reps["galois"] = [su2_matrix(quat_galois(g)) for g in class_reps]
+    return reps
+
+
+def build_tau_chars(sigma_reps, mutation=None):
+    """Coefficient representation tau_sigma = Sym^2(sigma), constructed explicitly.
+    Returns {name: tuple of QPhi class-function values} - THE object consumed by the
+    first-occurrence calculation and by gate G11 alike (Addendum 1 discipline)."""
+    tau = {}
+    for name, mats in sigma_reps.items():
+        vals = []
+        for M in mats:
+            if mutation == "G11_chi_squared":
+                t = mat_trace_real(M)
+                vals.append(t * t)          # the Addendum-1 mutation: chi^2, not Sym^2
+            else:
+                vals.append(mat_trace_real(sym2_matrix(M)))
+        tau[name] = tuple(vals)
+    return tau
+
+
+def build_sigma_chars(sigma_reps):
+    """chi_sigma from the same constructed matrices (used by G5 and G11)."""
+    return {name: tuple(mat_trace_real(M) for M in mats)
+            for name, mats in sigma_reps.items()}
+
+
+# --------------------------------------------------------------------------
+# The scalar tower V_n restricted to the group: exact characters
+# --------------------------------------------------------------------------
+
+def build_tower(class_reps, n_max, mutation=None):
+    """chi_{V_n} on each class, built from the weight sum: the SU(2) element with
+    eigenvalues exp(+-i alpha) (2 cos alpha = 2 Re q =: t) gives
+    chi_{V_n} = sum of the n+1 weights exp(i(n-2k) alpha), k = 0..n, evaluated
+    exactly via the power sums s_m = exp(im alpha) + exp(-im alpha):
+    s_0 = 2, s_1 = t, s_m = t s_{m-1} - s_{m-2}.
+    The G12 mutation builds each level with n weights instead of n+1."""
+    tower = []
+    per_class_s = []
+    for g in class_reps:
+        t = g[0] + g[0]                      # 2 Re q, exact in Q(phi)
+        s = [QPhi(2), t]
+        for m in range(2, n_max + 1):
+            s.append(t * s[m - 1] - s[m - 2])
+        per_class_s.append(s)
+    for n in range(0, n_max + 1):
+        count = n if mutation == "G12_n_weights" else n + 1
+        vals = []
+        for s in per_class_s:
+            top = count - 1
+            total = ZERO
+            m = top
+            while m > 0:
+                total = total + s[m]
+                m -= 2
+            if m == 0 and top >= 0:
+                total = total + ONE
+            vals.append(total)
+        tower.append(tuple(vals))
+    if mutation == "G8_perturb_tower":
+        v = list(tower[2])
+        v[0] = v[0] + QPhi(Fraction(1, 3))   # non-integer perturbation
+        tower[2] = tuple(v)
+    return tower
+
+
+# --------------------------------------------------------------------------
+# Class-function inner product and integer-nearness (G8)
+# --------------------------------------------------------------------------
+
+def make_ip(class_sizes, group_order):
+    inv = Fraction(1, group_order)
+    def ip(f, g):
+        """<f,g>_G = (1/|G|) sum_c |C_c| f(c) conj(g(c)); all values here are exactly
+        real (asserted at construction), so conjugation is the identity."""
+        acc = ZERO
+        for size, fv, gv in zip(class_sizes, f, g):
+            acc = acc + QPhi(size) * fv * gv
+        return QPhi(inv) * acc
+    return ip
+
+
+_G8_COUNT = [0]   # multiplicities checked in the current pipeline run (reporting only)
+
+
+def multiplicity(ip, f, g, context, g8_log):
+    """Every character inner product used as a multiplicity passes through here:
+    the section 5.4 integer-nearness rule at tolerance exactly 0."""
+    v = ip(f, g)
+    _G8_COUNT[0] += 1
+    if not v.is_nonneg_integer():
+        g8_log.append((context, repr(v)))
+        raise GateFailure("G8", "non-integer multiplicity in %s: %s" % (context, v))
+    return v.as_int()
+
+
+# --------------------------------------------------------------------------
+# Irreducible characters by exact peeling of the restricted tower
+# --------------------------------------------------------------------------
+
+def extract_irreducibles(tower, ip, id_class, group_order, g8_log):
+    """Peel irreducible characters out of the exact restrictions chi_{V_n}|_G.
+
+    Invariant: after subtracting all known irreducible content from a restriction,
+    the remainder is a genuine character (a nonnegative integer combination of
+    not-yet-found irreducibles). A remainder of norm 1 IS a new irreducible
+    character, exactly. Norm >= 2 remainders are pooled and re-reduced whenever a
+    new irreducible lands. Completes when the sum of squared dimensions equals the
+    group order; fails loud if the tower bound is exhausted first."""
+    known = []
+    pool = []
+
+    def reduce_fn(f, ctx):
+        r = list(f)
+        for chi in known:
+            m = multiplicity(ip, f, chi, "restriction multiplicity (%s)" % ctx, g8_log)
+            if m:
+                r = [rv - QPhi(m) * cv for rv, cv in zip(r, chi)]
+        return tuple(r)
+
+    def norm2(r, ctx):
+        v = ip(r, r)
+        if not v.is_nonneg_integer():
+            g8_log.append((ctx, repr(v)))
+            raise GateFailure("G8", "non-integer remainder norm in %s: %s" % (ctx, v))
+        return v.as_int()
+
+    def dims_done():
+        s = 0
+        for chi in known:
+            d = chi[id_class]
+            if not d.is_nonneg_integer():
+                raise GateFailure("character-extraction", "non-integer dimension %s" % d)
+            s += d.as_int() ** 2
+        return s == group_order
+
+    def drain_pool():
+        progress = True
+        while progress:
+            progress = False
+            for i in range(len(pool) - 1, -1, -1):
+                r = reduce_fn(pool[i], "pool re-reduction")
+                n2 = norm2(r, "pool remainder norm")
+                if n2 == 0:
+                    pool.pop(i)
+                    progress = True
+                elif n2 == 1:
+                    pool.pop(i)
+                    known.append(r)
+                    progress = True
+
+    for n in range(len(tower)):
+        if dims_done():
+            break
+        r = reduce_fn(tower[n], "V_%d restriction" % n)
+        n2 = norm2(r, "V_%d remainder norm" % n)
+        if n2 == 1:
+            known.append(r)
+            drain_pool()
+        elif n2 > 1:
+            pool.append(r)
+            drain_pool()
+
+    if not dims_done():
+        raise GateFailure("character-extraction",
+                          "peeling did not complete within the tower bound "
+                          "(sum of squared dims != group order); structural failure")
+    if pool:
+        raise GateFailure("character-extraction", "unresolved remainder pool nonempty")
+    return known
+
+
+# --------------------------------------------------------------------------
+# McKay matrix, graph distances
+# --------------------------------------------------------------------------
+
+def build_mckay(irreps, chi_q, ip, g8_log, mutation=None):
+    """A_{rho,tau} = <chi_rho * chi_Q, chi_tau>, derived in-implementation
+    (PROTOCOL section 5.7); entries pass the integer-nearness rule before rounding."""
+    k = len(irreps)
+    A = []
+    for r in range(k):
+        prod = tuple(a * b for a, b in zip(irreps[r], chi_q))
+        row = []
+        for t in range(k):
+            row.append(multiplicity(ip, prod, irreps[t],
+                                    "McKay adjacency A[%d][%d]" % (r, t), g8_log))
+        A.append(row)
+    if mutation == "G9_asymmetric":
+        A[0][1] += 1
+    if mutation == "G6_zero_entry":
+        for r in range(k):
+            for t in range(k):
+                if A[r][t] > 0:
+                    A[r][t] = 0
+                    return A
+    if mutation == "G7_disconnect":
+        last = k - 1
+        for t in range(k):
+            A[last][t] = 0
+            A[t][last] = 0
+    return A
+
+
+def bfs_distances(A, start):
+    """Graph distance from `start` over the support A > 0. None = unreachable."""
+    k = len(A)
+    dist = [None] * k
+    dist[start] = 0
+    frontier = [start]
+    while frontier:
+        nxt = []
+        for u in frontier:
+            for v in range(k):
+                if A[u][v] > 0 and dist[v] is None:
+                    dist[v] = dist[u] + 1
+                    nxt.append(v)
+        frontier = nxt
+    return dist
+
+
+def bipartition_ok(A, dist):
+    """True iff every edge of the support graph joins opposite BFS parities.
+    Computational witness for the parity lemma used by the coexact derivation."""
+    k = len(A)
+    for u in range(k):
+        for v in range(k):
+            if A[u][v] > 0 and dist[u] is not None and dist[v] is not None:
+                if (dist[u] + dist[v]) % 2 == 0:
+                    return False
+    return True
+
+
+# --------------------------------------------------------------------------
+# First occurrences: scalar tower (section 5.4) and coexact tower (section 6)
+# --------------------------------------------------------------------------
+
+def occurrence_multiplicity(ip, tower_n, tau_chi, rho_chi, ctx, g8_log):
+    prod = tuple(a * b for a, b in zip(tower_n, tau_chi))
+    return multiplicity(ip, prod, rho_chi, ctx, g8_log)
+
+
+def scalar_first_occurrences(tower, tau_chars, irreps, ip, g8_log):
+    """n_first(rho, sigma) = min{ n >= 0 : <chi_{V_n} chi_{tau_sigma}, chi_rho> > 0 },
+    n <= N_MAX, occurrence tested as multiplicity > 1/2 AFTER the G8 integer gate.
+    Also returns the full multiplicity table (reused by the coexact module, which
+    is defined over the same tower restrictions)."""
+    mult_table = {}
+    n_first = {}
+    not_found = []
+    for r, rho in enumerate(irreps):
+        for name, tau in tau_chars.items():
+            first = None
+            for n in range(0, N_MAX + 1):
+                m = occurrence_multiplicity(
+                    ip, tower[n], tau, rho,
+                    "first-occurrence <V_%d x tau_%s, rho_%d>" % (n, name, r), g8_log)
+                mult_table[(r, name, n)] = m
+                if first is None and Fraction(m) > Fraction(1, 2):
+                    first = n
+            if first is None:
+                not_found.append((r, name))
+            n_first[(r, name)] = first
+    return n_first, mult_table, not_found
+
+
+def coexact_first_occurrences(mult_table, irreps, tau_names):
+    """Coexact module (section 6). Own harmonic analysis (method note section C):
+    on S^3 = SU(2), Peter-Weyl gives Omega^1 = sum_n V_n (x) (V_n (x) V_2) in the
+    left-invariant coframe; exact forms carry the (V_n, V_n) blocks, so the coexact
+    eigenspace at level m (Hodge eigenvalue m^2/R^2, m >= 2) is
+    (V_m (x) V_{m-2}) + (V_{m-2} (x) V_m). The deck group acts on the LEFT factor,
+    so level m contributes V_m|_G + V_{m-2}|_G (right-factor dimensions are nonzero
+    multiplicities, which cannot change a first occurrence). Under the section 5.4
+    pattern: occurrence at level m iff either bracket multiplicity is positive.
+    m_first(rho, sigma) = min{ m >= 2 : mult(m) > 0 or mult(m-2) > 0 }, m <= M_MAX."""
+    m_first = {}
+    not_found = []
+    for r in range(len(irreps)):
+        for name in tau_names:
+            first = None
+            for m in range(2, M_MAX + 1):
+                if (mult_table[(r, name, m)] > 0
+                        or mult_table[(r, name, m - 2)] > 0):
+                    first = m
+                    break
+            if first is None:
+                not_found.append((r, name))
+            m_first[(r, name)] = first
+    return m_first, not_found
+
+
+def coexact_rule_prediction(d):
+    """The ASSERTED entry rule (section 6): level d for d >= 2, 2 for d = 0, 3 for d = 1."""
+    if d == 0:
+        return 2
+    if d == 1:
+        return 3
+    return d
+
+
+# --------------------------------------------------------------------------
+# Section 7 comparison harness (used at adjudication time; self-tested by G10)
+# --------------------------------------------------------------------------
+
+def compare_tables(rows_a, rows_b, sabotage=False):
+    """Label-free comparison of two scalar tables by (dim, mckay_distance) signature.
+    Returns (category, details). Exact integer equality, no tolerances."""
+    if sabotage:
+        return ("reproduced", [])          # G10 mutation target: a harness that cannot fail
+    sig_a = [(r["dim"], r["mckay_distance"]) for r in rows_a]
+    sig_b = [(r["dim"], r["mckay_distance"]) for r in rows_b]
+    if len(set(sig_a)) != len(sig_a) or len(set(sig_b)) != len(sig_b):
+        return ("structural failure", ["signatures not pairwise distinct"])
+    if len(rows_a) != len(rows_b):
+        return ("structural failure", ["row counts differ: %d vs %d"
+                                       % (len(rows_a), len(rows_b))])
+    if set(sig_a) != set(sig_b):
+        return ("structural failure", ["signature sets differ"])
+    by_sig = {(r["dim"], r["mckay_distance"]): r for r in rows_b}
+    mismatches = []
+    for r in rows_a:
+        other = by_sig[(r["dim"], r["mckay_distance"])]
+        for col in ("trivial", "standard", "galois"):
+            va, vb = r["n_first"][col], other["n_first"][col]
+            if va != vb:
+                mismatches.append("(dim=%d,d=%d) %s: %s vs %s"
+                                  % (r["dim"], r["mckay_distance"], col, va, vb))
+    if mismatches:
+        return ("partial disagreement", mismatches)
+    return ("reproduced", [])
+
+
+def perturb_rows(rows):
+    """The doc_typo transcription mutation: one transcribed cell perturbed by +1."""
+    import copy
+    out = copy.deepcopy(rows)
+    out[0]["n_first"]["trivial"] += 1
+    return out
+
+
+# --------------------------------------------------------------------------
+# Pipeline: construct everything, evaluate every gate on the consumed objects
+# --------------------------------------------------------------------------
+
+CONSULTED_FILES = ["PROTOCOL.md", "TASK.md", "GROUP_INPUT.md", "m8_5a_packet.json"]
+GATE_NAMES = ["G1", "G2", "G3", "G4", "G5", "G6",
+              "G7", "G8", "G9", "G10", "G11", "G12"]
+
+
+def run_pipeline(mutation=None):
+    gates = []
+    g8_log = []
+
+    def gate(name, ok, detail):
+        gates.append({"gate": name, "pass": bool(ok), "detail": detail})
+
+    def enforce():
+        for g in gates:
+            if not g["pass"]:
+                e = GateFailure(g["gate"], g["detail"])
+                e.gates = gates
+                raise e
+
+    try:
+        # -- group ---------------------------------------------------------
+        gens = load_packet()
+        elements, seen = generate_group(gens, mutation)
+        closed = check_closure(elements, seen, gens)
+        order = len(elements)
+        gate("G1", order == EXPECTED_GROUP_ORDER and closed,
+             "constructed order %d (required %d); closed under generators: %s"
+             % (order, EXPECTED_GROUP_ORDER, closed))
+        enforce()
+
+        classes, class_of = conjugacy_classes(elements, seen, gens, mutation)
+        sizes = [len(c) for c in classes]
+        g2_ok = (sum(sizes) == order
+                 and all(order % s == 0 for s in sizes)
+                 and len(classes[class_of[QUAT_ONE]]) == 1)
+        if g2_ok:
+            for i, cl in enumerate(classes):
+                for x in cl:
+                    for g in gens:
+                        if class_of.get(qmul(qmul(g, x), qconj(g))) != i:
+                            g2_ok = False
+        gate("G2", g2_ok,
+             "%d classes, sizes %s: sum to %d, each divides %d, identity is a "
+             "singleton, each class closed under conjugation" % (len(classes), sizes,
+                                                                 sum(sizes), order))
+        enforce()
+
+        class_reps = [c[0] for c in classes]
+        id_class = class_of[QUAT_ONE]
+        ip = make_ip(sizes, order)
+
+        # -- constructed objects consumed downstream ------------------------
+        tower = build_tower(class_reps, max(N_MAX, PEEL_N_MAX), mutation)
+        sigma_reps = build_sigma_reps(class_reps)
+        if mutation == "G5_swap_embeddings":
+            sigma_reps["standard"], sigma_reps["galois"] = (
+                sigma_reps["galois"], sigma_reps["standard"])
+        sigma_chars = build_sigma_chars(sigma_reps)
+        tau_chars = build_tau_chars(sigma_reps, mutation)
+
+        irreps = extract_irreducibles(tower, ip, id_class, order, g8_log)
+        if mutation == "G3_corrupt_char":
+            c = (id_class + 1) % len(classes)
+            v = list(irreps[1])
+            v[c] = v[c] + ONE
+            irreps[1] = tuple(v)
+        if mutation == "G4_drop_irrep":
+            irreps.pop()
+
+        dims = []
+        for chi in irreps:
+            d = chi[id_class]
+            if not d.is_nonneg_integer() or d.as_int() == 0:
+                raise GateFailure("character-extraction", "bad dimension %s" % d)
+            dims.append(d.as_int())
+
+        # -- character-table gates ------------------------------------------
+        ortho_ok = True
+        for i in range(len(irreps)):
+            for j in range(i, len(irreps)):
+                want = ONE if i == j else ZERO
+                if ip(irreps[i], irreps[j]) != want:
+                    ortho_ok = False
+        gate("G3", ortho_ok,
+             "character rows exactly orthonormal in <.,.>_G (tolerance 0, exact "
+             "Q(phi) arithmetic); %d irreducibles" % len(irreps))
+
+        gate("G4", sum(d * d for d in dims) == order,
+             "sum of squared dimensions %s = %d (group order %d)"
+             % (dims, sum(d * d for d in dims), order))
+
+        expected_q = tuple(g[0] + g[0] for g in class_reps)  # 2 cos theta = 2 Re q, raw
+        two_dims = [i for i, d in enumerate(dims) if d == 2]
+        q_matches = [i for i in two_dims if irreps[i] == expected_q]
+        g5_ok = (sigma_chars["standard"] == expected_q
+                 and len(q_matches) == 1
+                 and len(two_dims) == 2)
+        q_idx = q_matches[0] if q_matches else None
+        qp_idx = None
+        if g5_ok:
+            qp_idx = [i for i in two_dims if i != q_idx][0]
+            g5_ok = sigma_chars["galois"] == irreps[qp_idx]
+        gate("G5", g5_ok,
+             "exactly one 2-dim irreducible has chi(g) = 2 cos theta(g) on every class "
+             "under the packet embedding (that is Q); the constructed 'standard' rep "
+             "has that character; the constructed 'galois' rep has the character of "
+             "the unique other 2-dim irreducible (that is Q')")
+        enforce()
+
+        # -- McKay graph ------------------------------------------------------
+        A = build_mckay(irreps, irreps[q_idx], ip, g8_log, mutation)
+        triv_candidates = [i for i, chi in enumerate(irreps)
+                           if all(v == ONE for v in chi)]
+        if len(triv_candidates) != 1:
+            raise GateFailure("character-extraction", "trivial character not unique")
+        triv_idx = triv_candidates[0]
+        dist = bfs_distances(A, triv_idx)
+
+        g6_ok = all(sum(A[r][t] * dims[t] for t in range(len(dims))) == 2 * dims[r]
+                    for r in range(len(dims)))
+        gate("G6", g6_ok, "McKay mark condition A.dims = 2.dims holds exactly")
+
+        sigs = [(dims[i], dist[i]) for i in range(len(dims))]
+        g7_ok = all(d is not None for d in dist) and len(set(sigs)) == len(sigs)
+        gate("G7", g7_ok,
+             "graph distance defined for every irreducible; (dim, distance) "
+             "signatures pairwise distinct: %s" % sorted(
+                 s for s in sigs if s[1] is not None))
+
+        g9_ok = all(A[r][t] == A[t][r]
+                    for r in range(len(dims)) for t in range(len(dims)))
+        gate("G9", g9_ok, "McKay tensor-multiplicity matrix is symmetric")
+        enforce()
+
+        bipartite = bipartition_ok(A, dist)
+
+        # -- first occurrences (scalar) --------------------------------------
+        n_first, mult_table, nf = scalar_first_occurrences(
+            tower, tau_chars, irreps, ip, g8_log)
+        if nf:
+            gate("NOT-FOUND", False,
+                 "no occurrence within n <= %d for %s" % (N_MAX, nf))
+            enforce()
+
+        gate("G8", not g8_log,
+             "integer-nearness held for all %d multiplicities computed "
+             "(restriction, adjacency, first-occurrence), at tolerance exactly 0"
+             % _G8_COUNT[0])
+
+        g12_ok = all(tower[n][id_class] == QPhi(n + 1) for n in range(N_MAX + 1))
+        gate("G12", g12_ok,
+             "the consumed V_n character object satisfies chi_{V_n}(e) = n+1 "
+             "for 0 <= n <= %d" % N_MAX)
+
+        half = QPhi(Fraction(1, 2))
+        g11_ok = True
+        g11_detail = []
+        for name in ("trivial", "standard", "galois"):
+            for c, rep in enumerate(class_reps):
+                c2 = class_of[qmul(rep, rep)]     # raw group multiplication
+                lhs = tau_chars[name][c]          # the consumed coefficient character
+                rhs = (sigma_chars[name][c] * sigma_chars[name][c]
+                       + sigma_chars[name][c2]) * half
+                if lhs != rhs:
+                    g11_ok = False
+                    g11_detail.append("%s class %d: %s vs %s" % (name, c, lhs, rhs))
+        gate("G11", g11_ok,
+             "consumed tau_sigma character equals (chi_sigma(g)^2 + chi_sigma(g^2))/2 "
+             "on every class for all three connection classes"
+             + ("" if g11_ok else "; mismatches: %s" % g11_detail[:4]))
+
+        # -- output rows ------------------------------------------------------
+        row_order = sorted(range(len(irreps)), key=lambda i: (dist[i], dims[i]))
+        rows = []
+        for i in row_order:
+            rows.append({
+                "dim": dims[i],
+                "mckay_distance": dist[i],
+                "n_first": {name: n_first[(i, name)]
+                            for name in ("trivial", "standard", "galois")},
+            })
+
+        sab = (mutation == "G10_sabotage_compare")
+        cat_same, _ = compare_tables(rows, rows, sabotage=sab)
+        cat_mut, mut_detail = compare_tables(rows, perturb_rows(rows), sabotage=sab)
+        gate("G10", cat_same == "reproduced" and cat_mut == "partial disagreement",
+             "comparison harness: identity compares 'reproduced'; doc_typo "
+             "transcription mutation compares '%s' (%s)" % (cat_mut, mut_detail[:1]))
+        enforce()
+
+        # -- coexact module (section 6; pre-declared to RUN) -------------------
+        m_first, nf2 = coexact_first_occurrences(
+            mult_table, irreps, ("trivial", "standard", "galois"))
+        witness_nd = all(n_first[(i, "trivial")] == dist[i]
+                         for i in range(len(irreps)))
+        rule_cells = []
+        rule_all_match = True
+        for i in row_order:
+            pred = coexact_rule_prediction(dist[i])
+            comp = m_first[(i, "trivial")]
+            match = (pred == comp)
+            rule_all_match = rule_all_match and match
+            rule_cells.append({"dim": dims[i], "mckay_distance": dist[i],
+                               "predicted": pred, "computed": comp, "match": match})
+        if nf2:
+            verdict = "not resolved"
+            verdict_reason = ("NOT-FOUND cells within m <= %d: %s" % (M_MAX, nf2))
+        elif not rule_all_match:
+            verdict = "contradicted"
+            verdict_reason = ("at least one trivial-column cell disagrees under "
+                              "exact arithmetic and the stated convention map")
+        elif bipartite and witness_nd:
+            verdict = "structurally derived and reproduced"
+            verdict_reason = (
+                "general argument supplied (method_note_draft.md section C): "
+                "n_first(rho, trivial) = McKay distance via the Clebsch-Gordan "
+                "recursion, plus bipartite parity; coexact level-m content is "
+                "V_m + V_{m-2} with m >= 2; computed table agrees cell-by-cell")
+        else:
+            verdict = "numerically consistent, not derived"
+            verdict_reason = ("computed first occurrences agree across the declared "
+                              "range, but a supporting witness of the general "
+                              "argument failed (bipartite=%s, n_first=distance=%s)"
+                              % (bipartite, witness_nd))
+
+        module = {
+            "ran": True,
+            "declared_before_unsealing": True,
+            "own_convention": ("coexact level m: Hodge-Laplacian eigenvalue m^2/R^2 on "
+                               "(V_m x V_{m-2}) + (V_{m-2} x V_m), m >= 2"),
+            "convention_map": ("identity on levels: this implementation's level m maps "
+                               "to the source convention's coexact level m; both print "
+                               "eigenvalue m^2/R^2"),
+            "rule_scope": ("the asserted rule references only the McKay distance d, so "
+                           "it is adjudicated against the trivial-connection column; "
+                           "all three columns are reported as data"),
+            "m_first_rows": [{
+                "dim": dims[i],
+                "mckay_distance": dist[i],
+                "m_first": {name: m_first[(i, name)]
+                            for name in ("trivial", "standard", "galois")},
+            } for i in row_order],
+            "rule_adjudication": rule_cells,
+            "supporting_checks": {
+                "graph_bipartite": bipartite,
+                "n_first_trivial_equals_mckay_distance": witness_nd,
+            },
+            "verdict": verdict,
+            "verdict_reason": verdict_reason,
+            "standing_note": ("per PROTOCOL section 6, numerical agreement never "
+                              "upgrades the rule's standing; only the derivation can, "
+                              "and it is examined in the adversarial audit"),
+        }
+
+        return {
+            "gates": gates,
+            "rows": rows,
+            "module": module,
+            "order": order,
+            "num_classes": len(classes),
+            "class_sizes": sizes,
+            "dims": dims,
+            "distances": dist,
+            "q_index": q_idx,
+            "qprime_index": qp_idx,
+            "g8_checked": _G8_COUNT[0],
+        }
+    except GateFailure as e:
+        if not hasattr(e, "gates"):
+            e.gates = gates
+        raise
+
+
+# --------------------------------------------------------------------------
+# Mutation harness (PROTOCOL section 8): every PASS line must be shown to fail
+# --------------------------------------------------------------------------
+
+MUTATIONS = [
+    ("G1_drop_element", "G1", "one element removed from the closure result"),
+    ("G2_swap_elements", "G2", "two elements swapped between conjugacy classes"),
+    ("G3_corrupt_char", "G3", "one character value shifted by +1"),
+    ("G4_drop_irrep", "G4", "one irreducible removed from the extracted set"),
+    ("G5_swap_embeddings", "G5", "standard and galois embeddings interchanged"),
+    ("G6_zero_entry", "G6", "one positive McKay adjacency entry zeroed"),
+    ("G7_disconnect", "G7", "one irreducible's adjacency row and column zeroed"),
+    ("G8_perturb_tower", "G8", "a tower character value perturbed by +1/3"),
+    ("G9_asymmetric", "G9", "A[0][1] incremented, breaking symmetry"),
+    ("G10_sabotage_compare", "G10", "comparison harness forced to report agreement"),
+    ("G11_chi_squared", "G11", "Sym^2(sigma) replaced by chi_sigma^2 (Addendum 1)"),
+    ("G12_n_weights", "G12", "tower built with n rather than n+1 weights (Addendum 1)"),
+]
+
+
+def run_mutation_tests():
+    """For each mutation: rerun the full pipeline and demand the TARGET gate goes red.
+    Exits nonzero if any mutation fails to redden its target or any gate is uncovered."""
+    print("== mutation harness ==")
+    failures = 0
+    covered = set()
+    for name, target, desc in MUTATIONS:
+        _G8_COUNT[0] = 0
+        try:
+            run_pipeline(mutation=name)
+            reddened = set()
+        except GateFailure as e:
+            reddened = {g["gate"] for g in e.gates if not g["pass"]}
+            reddened.add(e.gate)
+        ok = target in reddened
+        if ok:
+            covered.add(target)
+        else:
+            failures += 1
+        print("%-24s target %-4s -> reddened %-28s %s   (%s)"
+              % (name, target, sorted(reddened) or "NOTHING",
+                 "OK" if ok else "MUTATION NOT DETECTED", desc))
+    uncovered = [g for g in GATE_NAMES if g not in covered]
+    _G8_COUNT[0] = 0
+    try:
+        run_pipeline(mutation=None)
+        clean_ok = True
+    except GateFailure as e:
+        clean_ok = False
+        print("clean pipeline FAILED under no mutation: %s" % e)
+    print("gates covered and reddened: %s" % sorted(covered))
+    if uncovered:
+        print("UNCOVERED GATES: %s" % uncovered)
+    if failures or uncovered or not clean_ok:
+        print("MUTATION HARNESS: FAIL (%d unreddened, %d uncovered, clean=%s)"
+              % (failures, len(uncovered), clean_ok))
+        return 3
+    print("MUTATION HARNESS: PASS (%d mutations, all %d gates covered, "
+          "clean run green)" % (len(MUTATIONS), len(GATE_NAMES)))
+    return 0
+
+
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
+
+def environment_record():
+    return {
+        "interpreter": "python %s" % platform.python_version(),
+        "implementation": platform.python_implementation(),
+        "libraries": "standard library only (fractions, json, hashlib); no numpy",
+        "os": "%s %s" % (platform.system(), platform.release()),
+        "hardware": platform.machine(),
+        "seeds": "none: the pipeline is deterministic and fully exact over Q(phi)",
+    }
+
+
+def print_report(res):
+    print("M8.5-A context-isolated independent-method reproduction")
+    print("schema_version: %s" % SCHEMA_VERSION)
+    print("packet: %s sha256 %s" % (os.path.basename(PACKET_FILE), PACKET_SHA256))
+    env = environment_record()
+    for k in sorted(env):
+        print("env.%s: %s" % (k, env[k]))
+    print("")
+    print("group: order %d, %d conjugacy classes, sizes %s"
+          % (res["order"], res["num_classes"], res["class_sizes"]))
+    print("irreducible dimensions: %s" % sorted(res["dims"]))
+    print("")
+    print("gates (every tolerance fixed at exactly 0; %d multiplicities checked):"
+          % res["g8_checked"])
+    for g in res["gates"]:
+        print("  %-4s %s  %s" % (g["gate"], "PASS" if g["pass"] else "FAIL",
+                                 g["detail"]))
+    print("")
+    print("scalar first-occurrence table (rows label-free, by (dim, McKay distance)):")
+    print("  dim  distance  trivial  standard  galois")
+    for r in res["rows"]:
+        print("  %3d  %8d  %7d  %8d  %6d"
+              % (r["dim"], r["mckay_distance"], r["n_first"]["trivial"],
+                 r["n_first"]["standard"], r["n_first"]["galois"]))
+    print("")
+    mod = res["module"]
+    print("coexact module (section 6, ASSERTED rule; ran: %s):" % mod["ran"])
+    print("  convention map: %s" % mod["convention_map"])
+    print("  m_first table:")
+    print("  dim  distance  trivial  standard  galois")
+    for r in mod["m_first_rows"]:
+        print("  %3d  %8d  %7d  %8d  %6d"
+              % (r["dim"], r["mckay_distance"], r["m_first"]["trivial"],
+                 r["m_first"]["standard"], r["m_first"]["galois"]))
+    print("  rule adjudication (trivial column): %s"
+          % ("all cells match" if all(c["match"] for c in mod["rule_adjudication"])
+             else [c for c in mod["rule_adjudication"] if not c["match"]]))
+    print("  supporting checks: %s" % mod["supporting_checks"])
+    print("  verdict: %s" % mod["verdict"])
+    print("  reason: %s" % mod["verdict_reason"])
+    print("  standing: %s" % mod["standing_note"])
+    print("")
+    print("claim ceiling (section 2): context-isolated independent-method "
+          "reproduction at most; adjudication against the pinned section 6.1 "
+          "table is the maintainers' step and is NOT performed here.")
+    print("run status: completed; all gates PASS; awaiting section 7 adjudication")
+
+
+def write_result_json(res, path):
+    out = {
+        "schema_version": SCHEMA_VERSION,
+        "rows": res["rows"],
+        "environment": environment_record(),
+        "gates": res["gates"],
+        "tolerances": TOLERANCES,
+        "consulted_files": CONSULTED_FILES + [
+            "see manifest.md for automatically loaded context"],
+        "coexact_module": res["module"],
+        "group": {"order": res["order"], "num_classes": res["num_classes"],
+                  "class_sizes": res["class_sizes"],
+                  "irreducible_dimensions": sorted(res["dims"])},
+        "claim_ceiling": ("context-isolated independent-method reproduction "
+                          "(PROTOCOL section 2); no stronger label available"),
+        "packet_sha256": PACKET_SHA256,
+    }
+    with open(path, "w") as f:
+        json.dump(out, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--mutation-tests", action="store_true",
+                    help="run the section 8 mutation harness and exit")
+    ap.add_argument("--json-out", default=os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "result.json"))
+    args = ap.parse_args(argv)
+
+    if args.mutation_tests:
+        return run_mutation_tests()
+
+    _G8_COUNT[0] = 0
+    try:
+        res = run_pipeline(mutation=None)
+    except GateFailure as e:
+        print("STRUCTURAL FAILURE (fail loud): gate %s: %s" % (e.gate, e.detail))
+        for g in getattr(e, "gates", []):
+            print("  %-4s %s  %s" % (g["gate"], "PASS" if g["pass"] else "FAIL",
+                                     g["detail"]))
+        return 2
+    print_report(res)
+    write_result_json(res, args.json_out)
+    print("result.json written: %s" % args.json_out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The section 9 commitment for the M8.5-A clean-room run: implementation, raw output, result, method-note draft, and the commitment record, all landed BEFORE any quarantined object is unsealed for comparison. Adjudication against the pinned section 6.1 table is deliberately absent from this PR; it follows as its own separately merged PR naming this one, per protocol section 7.

The run: a fresh Claude Code session in an isolated directory holding only the audited four-file packet, web tools disabled, manual permission mode throughout, no blanket grants. The implementation derives everything from the two packet generators in exact Q(phi) arithmetic (fractions.Fraction, no floats), so every tolerance is fixed at exactly zero. Twelve gates pass; the mutation harness exits zero with every gate covered and reddened; a double-run byte-identity check confirmed determinism.

The section 6 declaration, fixed here and unavailable after unsealing: the coexact module RAN, implementer verdict structurally derived and reproduced, with the derivation's self-flagged weakest links in the method-note draft for the adversarial audit to attack. Per the standing rule, the numerical match itself upgrades nothing.

The commitment record (findings/m8_5a_commitment.md) carries the environment record, the consulted-files manifest with the implementer's prior-knowledge disclosure, the maintainer's transcript check corroborating that manifest (19 tool calls, zero web calls, no path outside the room touched by any file tool, one disclosed write of the run's own stdout to session temp space), one disclosed redaction (a raw-output line printing the room's absolute path; both hashes recorded, the original stays the commitment), and the operator log including the environment catch and the stalled-prompt lesson now in the T4 deviations log.
