### PR TITLE
Close the M8.5-A group-order question

### DIFF
--- a/dev_docs/CLEAN_ROOM_STANDARDS.md
+++ b/dev_docs/CLEAN_ROOM_STANDARDS.md
@@ -110,6 +110,15 @@ handing the full object makes it true by construction. Where the protocol permit
 a derivable quantity (M8.5-A: the group order), withholding it is the stricter choice, and
 the withholding is STATED in the packet so silence does not read as an incomplete delivery.
 
+**A tightening beyond the protocol is raised with the supplier, not just stated in the
+packet.** Both sides agreed to the protocol, so withholding something it permits is the
+maintainer's unilateral change until the supplier says otherwise: name it at delivery and
+offer to supply the quantity and log a deviation. The run is valid either way, since the
+stricter side cannot make a gate easier, and the point of asking is that an unraised
+tightening turns into an argument about the input condition after the result exists. At
+M8.5-A the author's answer was that the packet had been limited to the generators for the
+same reason, which made the condition shared rather than assumed.
+
 **Author-side evidence is not the audit.** An author may ship a verification script and
 report alongside the packet; they stay outside the room, and the maintainer audit runs from
 the packet alone. An audit that reads the supplier's report and concurs is a review of the

--- a/dev_docs/tasks/t4_task_details.md
+++ b/dev_docs/tasks/t4_task_details.md
@@ -265,6 +265,10 @@ kind of gap a standard exists to close. Three guards, added at block A:
 **2026-07-31, block A. The group order is withheld, tighter than protocol § 4 permits.** The
 protocol allows supplying 120 as a construction input. `GROUP_INPUT.md` withholds it so G1
 stays falsifiable, and says so in the file, so silence does not read as an incomplete packet.
+Raised with the author at delivery with an offer to supply it and log a deviation; the answer,
+2026-08-01, was that the packet was limited to the generators for the same reason, so the
+tightening was shared rather than unilateral and no deviation is recorded. The rule that came
+out of it is in the standard's packet section.
 
 **2026-07-31, block A. Canonicalization turned out to be a no-op.** § The packet anticipated
 irrational components arriving as decimals, where a hash would pin a transcription. The author

--- a/openwave/xperiments/m8_mit/research/tasks/m8_5_task_details.md
+++ b/openwave/xperiments/m8_mit/research/tasks/m8_5_task_details.md
@@ -285,6 +285,15 @@ environment catch, the raw-output path redaction, the scratchpad writes) are log
 [`m8_5a_commitment.md`](../findings/m8_5a_commitment.md) § 4-6. No protocol-level deviation:
 no mid-run relay, no packet amendment, no unsealing before the commitment.
 
+**2026-08-01. The withheld group order was intentional on both sides, so nothing is recorded
+as a deviation.** The block A note asked the author whether omitting it from the packet was
+meant, offering to supply 120 and log the change
+([#386](https://github.com/openwave-labs/openwave/pull/386) thread, answered on
+[#394](https://github.com/openwave-labs/openwave/pull/394#issuecomment-5152324680)). The
+author's answer: the packet was limited to the generators so that G1's order result stayed a
+derived check rather than a restatement of supplied metadata. The stricter input condition was
+the intended one, and the run met it.
+
 ## FINDINGS
 
 **M8.5-A adjudication, 2026-07-31: REPRODUCED.** The clean-room implementation


### PR DESCRIPTION
The author confirmed on #394 that omitting the group order from the packet was intentional: the packet was limited to the generators so G1's order result stayed a derived check. The withholding was shared rather than a unilateral maintainer tightening, so no deviation is recorded.

- m8_5_task_details.md: dated deviations-log entry
- t4_task_details.md: block A entry closed
- CLEAN_ROOM_STANDARDS.md: raise a tightening with the supplier at delivery