### PR TITLE
Close T5: tasks stay in roadmaps, issues become platform issues

### DIFF
--- a/dev_docs/platform_roadmap.md
+++ b/dev_docs/platform_roadmap.md
@@ -20,6 +20,7 @@
 | TaskID | Title | Description | Gated By |
 | --- | --- | --- | --- |
 | [T2](tasks/t2_task_details.md) | MODELS.md normalized score: a fair single number per column | 🔶 DEFERRED 2026-07-28, same day as the proposal (was M5.30): the score-board already separates covered from not-covered and orders the columns, so a scalar score waits for a critical mass of tested rows. The proposed formula scores silence as average and ranks ❌ below 🚧; the coverage-plus-score-on-attempted repair is unstable at small samples. Analysis and candidate cures in the task doc. | critical mass of tested rows (user call) + [T1](tasks/t1_task_details.md) final criteria set + user "go" |
+| [T6](tasks/t6_task_details.md) | SMT-certified discrete topological invariants (contributor offer) | 🔶 DEFERRED 2026-08-01, on arrival (was issue #298): a contributor's z3 encodings prove per-plaquette winding bounds, torus charge-sum theorems and constructibility in milliseconds when the encoding mirrors the boundary operator. Credible for certified discrete initial conditions and impossibility checks on small lattices, not for the PDE solvers. No consumer in the current program. | a task whose verdict turns on a machine-checked discrete invariant, or wants a certified seed + the contributor's availability |
 
 ## CONVENTIONS
 

--- a/dev_docs/tasks/t5_task_details.md
+++ b/dev_docs/tasks/t5_task_details.md
@@ -226,7 +226,7 @@ questions and offers of contribution belong in Discussions, and become rows if t
 ### Close-out: every open issue got a roadmap home
 
 The condition on closing the issues was that no open one is the only record of its work. Audited
-2026-08-01 across all twelve open issues; three needed a new row, and two are not tasks at all.
+2026-08-01 across all twelve open issues; four needed a new row, and one is not a task.
 
 | Issue | Roadmap home | Kind |
 | --- | --- | --- |
@@ -240,11 +240,12 @@ The condition on closing the issues was that no open one is the only record of i
 | [#247](https://github.com/openwave-labs/openwave/issues/247) particle field configurations | not a task: adopted as a standing requirement, the per-particle field-config section every briefing carries ([`ONBOARDING_MODELS.md`](../../ONBOARDING_MODELS.md) § 3.3), and the prescription recorded in the M7 roadmap | standard, not a row |
 | [#248](https://github.com/openwave-labs/openwave/issues/248) collect the M6 author's papers | satisfied by the 2026-07-20 M6 refresh harvest: 29 latest-version records in [`_CITATIONS.md`](../../openwave/xperiments/m6_ouroboros/theory/_CITATIONS.md), including the primary dynamics paper | done |
 | [#290](https://github.com/openwave-labs/openwave/issues/290) regularized vortex-loop | M5.19, closed COMPLETE 2026-07-10 with three adversarial audits | done |
-| [#298](https://github.com/openwave-labs/openwave/issues/298) SMT solvers for combinatorial species | not a task: an outside offer of a contribution, which is Discussions material until someone scopes it | offer, not a row |
+| [#298](https://github.com/openwave-labs/openwave/issues/298) SMT solvers for combinatorial species | **new**: [T6](t6_task_details.md), deferred on arrival. The thread was already answered and acknowledged; the row exists because that answer promised a follow-up if a consumer appeared, and a closed issue is not where a promise survives | new row, deferred |
 | [#324](https://github.com/openwave-labs/openwave/issues/324) stiffness ladder | **new**: [M5.21.13](../../openwave/xperiments/m5_liquid_crystal/research/tasks/m5_21_13_task_details.md), with a premise check on the δ direction | new row + archive |
 
 Each new row's task document carries the issue body verbatim, so closing the issue destroys no
-record. The two non-tasks are not closed by this task; what happens to them is the user's call.
+record. The one non-task ([#247](https://github.com/openwave-labs/openwave/issues/247)) closes on
+the standard it became.
 
 ### One thing the exercise proved on its own
 

--- a/dev_docs/tasks/t6_task_details.md
+++ b/dev_docs/tasks/t6_task_details.md
@@ -1,0 +1,72 @@
+# T6: SMT-certified discrete topological invariants (contributor offer)
+
+> Roadmap row: [`../platform_roadmap.md`](../platform_roadmap.md). Status: 🔶 **DEFERRED
+> 2026-08-01, on arrival**. Owner: unassigned. Filed from GitHub issue
+> [#298](https://github.com/openwave-labs/openwave/issues/298) (opened 2026-07-16 by
+> `chadbrewbaker`) when [T5](t5_task_details.md) settled that tasks live in roadmaps. The row
+> exists to keep a promise made in that thread, not because work is queued: the maintainer reply
+> said the fit would be analysed and followed up if a consumer landed, and a closed issue is not a
+> place a promise survives.
+
+## PLANNING
+
+### What was offered
+
+An outside contributor benchmarked SMT (z3) encodings against small lattice topology and offered
+to implement them properly, with tests, if the platform has a use. The measured results, from the
+thread:
+
+| Result | Time |
+| --- | --- |
+| Per-plaquette winding bound `\|w\| ≤ 1` proved UNSAT on a `Z_k` clock discretization | 18 ms |
+| Total vortex charge on a torus is zero, proved as UNSAT | 19 ms |
+| Vortex/antivortex pair constructed at prescribed plaquettes | 28 ms |
+| Charge-1 vortex built on an open grid, with the boundary carrying the charge | 16 ms |
+
+The finding that travels further than the timings is about encoding, not solving: giving each edge
+one difference variable, reused with opposite signs by its two adjacent plaquettes, makes
+`Σ w_p = 0` syntactic and collapses a 15-second timeout to 19 ms of propagation. Stated generally,
+the solver does not find topology; the encoding carries it, and an impossibility proof is cheap
+exactly when the variable sharing mirrors the boundary operator.
+
+A second arm used Burnside / cycle-index counting to predict symmetry reduction before the solver
+ran (100 raw states → 5 orbits under `C₄ × Z₅`; allSAT enumeration 98 ms → 24 ms, the predicted
+factor of 5), which makes the count and the solver a correctness check on each other.
+
+### Where it could slot, and where it could not
+
+The contributor's own framing is the honest one and is adopted here: SMT is credible for
+**certified discrete initial conditions** and **impossibility checks on small lattices** ("no
+configuration with this charge profile exists under these boundary conditions"), and is not a
+competitor to the platform's PDE solvers. Two plausible consumers, neither of them scheduled:
+
+| Candidate | Why it might fit |
+| --- | --- |
+| A certified seed for a defect run | Today's seeds are constructed and then measured; a certificate that a seed's charge profile is the only one admissible under its boundary conditions would be an input guarantee rather than an output check |
+| A machine-checked discrete invariant in a task that turns on one | Where a winding or charge-sum argument is load-bearing for a verdict, a mechanical proof on the discrete lattice is a second route to it, independent of the measuring script |
+
+### Why deferred
+
+No consumer exists in the current program: the live work is continuous-field PDE runs, and nothing
+queued turns on a discrete impossibility proof. Filing a task with no consumer would put a
+contributor's effort behind a use that has not been established, which the thread explicitly
+avoided ("no need to implement anything speculatively in the meantime").
+
+**Re-open trigger**: a task whose verdict turns on a machine-checked discrete invariant, or that
+wants a certified seed, plus the contributor's availability at that time. Whoever re-opens it
+starts by asking whether the offer still stands.
+
+### Blindspots
+
+| Risk | Guard |
+| --- | --- |
+| The row becomes a permanent parking space, and the offer quietly expires | the re-open trigger names a concrete condition rather than a date, and the thread stays linked so the offer's own terms are readable |
+| Small-lattice certificates get read as claims about the continuum | the scope line above is the contributor's own and stays attached: certified discrete initial conditions and impossibility checks, never a statement about the PDE limit |
+
+## DEVIATIONS LOG
+
+(none)
+
+## FINDINGS
+
+(pending: deferred on arrival, nothing run)


### PR DESCRIPTION
T5 evaluated moving live task tracking to GitHub Issues + Projects v2 and is declined. A roadmap edit is a tracked diff, which is what files several authors touch need; an issue body edits in place with a deletable history. The migration's own intake model keeps every state change a maintainer action, so it would have relocated friction rather than removed it.

Before the open issues close, all twelve were audited into roadmap homes:
- new rows: M4.1 (was #201), M4.2 (was #202), M5.21.13 (was #324), each with the issue body archived verbatim in its task document
- T6 (was #298), deferred on arrival: the thread was already answered, and the row keeps the follow-up promise that reply made
- MODELS.md, M4_engine_upgrade, CONTRIBUTING, README, the model briefings and the M7 roadmap no longer route open work or proposals through issues
- the replacement rule lives in platform_roadmap.md section CONVENTIONS

Checkers clean: check_models_md, check_roadmaps, check_docs.