### PR TITLE
M8.8: a disagreement is assessable, not attributable to one route

### DIFF
--- a/openwave/xperiments/m8_mit/research/tasks/m8_8_task_details.md
+++ b/openwave/xperiments/m8_mit/research/tasks/m8_8_task_details.md
@@ -74,8 +74,17 @@ consumes `d3`, which requires the identity among relations or an equivalent reso
 the spectral-zeta definition (`log T^2 = zeta'_coexact(0) - 2 zeta'_scalar(0)`, the Ray-Singer
 combination on `S^3/2I`), not from any chain complex. Nothing in a construction packet was an
 input to M8.3, and the equality of the analytic and combinatorial routes is the Cheeger-Müller
-theorem rather than a shared construction, so a disagreement localizes an implementation error in
-one route instead of being unresolvable.
+theorem rather than a shared construction, so a disagreement is ASSESSABLE instead of
+unresolvable.
+
+Assessable is not the same as attributable, and the protocol's § 1 is the stricter reading. A
+mismatch is assessed against a structured diagnostic partition of four preregistered branches:
+an implementation error in one route, a convention-bridge mismatch, a failed hypothesis of the
+theorem, and a supplied-model or provenance error. Each branch carries its own gate, every branch
+its evidence does not exclude is reported, and no unique attribution is forced. The fourth is
+bounded rather than excluded, since the packet is author-supplied and the model gates establish
+that the complex behaves correctly without identifying which model it is; the maintainer-side
+packet audit and the maintainer-held provenance record sit beside them for that reason.
 
 Two protocol points settled before drafting, to keep them out of the freeze review:
 


### PR DESCRIPTION
The task record claimed a disagreement between the analytic and combinatorial routes localizes an implementation error in one of them. It does not. The disjointness argument holds, since M8.3 built no chain complex and the routes are joined by Cheeger-Muller rather than by shared machinery, but that buys assessability and not attribution: a mismatch is assessed against a four-branch structured diagnostic partition, each branch gated separately, with every branch its evidence does not exclude reported and no unique attribution forced. The supplied-model branch is bounded rather than excluded, because the packet is author-supplied and the model gates verify behaviour without identifying the model.

The protocol is referenced in prose rather than linked, since that file lands with #408 and the link would dangle here until it does.