### PR TITLE
Provenance-archive verifier, Gate C row C8, boxed commitment notice

### DIFF
--- a/dev_docs/PR_REVIEW_STANDARDS.md
+++ b/dev_docs/PR_REVIEW_STANDARDS.md
@@ -25,7 +25,7 @@ A documented negative is a merge-worthy contribution. An overstated positive is 
 | [2. Blast-radius map](#2-blast-radius-map) | which paths get which level of scrutiny |
 | [3. Gate A: safety and hygiene](#3-gate-a-safety-and-hygiene) | large files, encoding, copyright, secrets, dangling references, code intent |
 | [4. Gate B: scope containment](#4-gate-b-scope-containment) | model-folder discipline, shared files, root documents, the commitment sweep and its loud notification (§ 4.1) |
-| [5. Gate C: claim to artifact](#5-gate-c-claim-to-artifact) | recompute the headline number from the shipped data yourself |
+| [5. Gate C: claim to artifact](#5-gate-c-claim-to-artifact) | recompute the headline number from the shipped data yourself, and out-of-band deliveries from their manifest (C8) |
 | [6. Gate D: the adversarial pass](#6-gate-d-the-adversarial-pass) | is the mechanism wired, is the signal above the noise, do the knobs manufacture the result |
 | [7. Gate E: MODELS.md cell changes](#7-gate-e-modelsmd-cell-changes) | the evidence bar for moving a cell, and the linter a maintainer runs (§ 7.1) |
 | [8. Gate F: other authors' work](#8-gate-f-other-authors-work) | not damaging a column you do not own |
@@ -108,17 +108,36 @@ mentions mid-prose is a commitment the human accepts without reading. Scan every
 | Standing rules | new conventions that bind future reviews or future work | every future review inherits the cost, and maintaining the rule is itself maintainer workload |
 
 **The notification.** The moment the sweep finds anything, and again as the LAST block before
-the verdict, the reviewing agent prints an all-caps notice in the terminal:
+the verdict, the reviewing agent prints a boxed notice in the terminal:
+
+**The layout is fixed**, because the point of the notice is that it cannot be skimmed past. One
+box per commitment, boxes stacked, then a single table carrying one row per commitment in the
+same order, then the acceptance line. Reproduce it exactly:
 
 ```text
-⚠️⚠️⚠️ MAINTAINER COMMITMENT NOTICE ⚠️⚠️⚠️
-MERGING PR #<N> CREATES THE FOLLOWING RESPONSIBILITIES:
-1. <CLASS>: <WHAT IT BINDS> / WHO PAYS: <PARTY> / COMES DUE: <TRIGGER>
-2. ...
-ACCEPTANCE HAPPENS AT MERGE. ANY LINE NOT ACCEPTED IS
-RENEGOTIATED NOW, BEFORE THE FREEZE, NOT AFTER.
-⚠️⚠️⚠️ END COMMITMENT NOTICE ⚠️⚠️⚠️
+╔══════════════════════════════════════════════════════════════╗
+║  MAINTAINER COMMITMENT NOTICE                                ║
+║  CLASS: <class>                                              ║
+║  WHO PAYS: <party>                                           ║
+║  COMES DUE: <trigger>                                        ║
+╚══════════════════════════════════════════════════════════════╝
 ```
+
+Directly beneath the boxes, as a markdown table so the terminal renders it ruled:
+
+| What it actually is | Agent does | Maintainer does | Attention |
+| --- | --- | --- | --- |
+| <plain restatement> | <the machine half> | <the human-only half> | <sitting or decision count> |
+
+Then, as the closing line: **acceptance happens at merge, and any line not accepted is
+renegotiated now, before the freeze, not after.**
+
+| Layout rule | Why |
+| --- | --- |
+| The box is drawn, not an all-caps paragraph | a ruled block survives a scrollback in a way a wall of capitals does not, and this notice has to be findable after the fact |
+| Keep the box at a fixed narrow width, and continue a long value on its own line rather than widening it | a box wider than the terminal wraps, and a wrapped box reads as noise |
+| One box per commitment, never a numbered list inside one box | the boxes are what make the count visible at a glance, which is the number the decision turns on |
+| The four columns go directly beneath, as a table, never inside the box | the box carries what binds; the table carries what it costs. Merging them loses both |
 
 **The effort split.** Naming the class and the party is not enough to decide with. The party is
 almost always "maintainers", while the reviewing agent is itself doing most of the work the line
@@ -146,12 +165,12 @@ that is the half that binds both parties and has to survive in the durable recor
 | Fires at detection AND restates in full as the last block before the verdict | the merge decision must have the commitments as the freshest thing on screen, not something scrolled past an hour earlier |
 | Prints even when the verdict is approve | approval is exactly the moment acceptance happens; a clean review with a silent commitment is the failure mode this exists for |
 | One line per commitment: class, what it binds, who pays, when it comes due | a notice without the cost attached is a headline, not a notice |
-| In the terminal, the loud block is followed by the effort split, never replaced by it | the all-caps form has to stay short to stay readable, and the four columns are what the decision actually needs |
+| In the terminal, the boxed block is followed by the effort split, never replaced by it | the box has to stay short to stay readable, and the four columns are what the decision actually needs |
 | The effort split never leaves the terminal | it is a decision aid for the person deciding, not a term of the agreement. Posting it puts the maintainer's internal division of labor into a public thread, where it reads as part of what the contributor is signing up to and is not |
 | The notice states which obligations the merge itself triggers and which wait for a later deliberate act | a freeze that binds at a separate lock commit makes the merge nearly free, and when that is true it is the single most decision-relevant fact on the page |
 | Any obligation requiring execution of contributor-supplied code gets its own flagged line, with the mitigation named | it is a trust decision no agent can make on a maintainer's behalf, and [§ 5](#5-gate-c-claim-to-artifact)'s execution rule already puts it before the merge rather than after. Name the container |
 | A clean sweep reports as one quiet line, `commitment sweep: none` | the loud block stays meaningful only if it is rare; alarm fatigue is how loud notices die |
-| The posted review carries the same list in normal case, under its own heading | the thread is the durable record. ALL CAPS is for the terminal moment of decision, not for the permanent prose |
+| The posted review carries the same list in normal case, under its own heading | the thread is the durable record. The box is for the terminal moment of decision, not for the permanent prose |
 
 ## 5. Gate C: claim to artifact
 
@@ -170,6 +189,21 @@ This is the gate [`REPRODUCE.md`](../REPRODUCE.md) and [`AI_HYGIENE.md`](../AI_H
 | C5 | **Internal consistency** | The same quantity carries the same value in the abstract, the summary table, and the detail table. Cross-check them against each other before checking either against the data |
 | C6 | **The reproduction route is written down** | A reader with a clean clone can get from the claim to the command. Per [`REPRODUCE.md`](../REPRODUCE.md) that lives in the research note, once |
 | C7 | **Claim strength matches evidence strength** | "Within the explored parameter range, X" is a result. "Proof of X" from an empirical sweep is not. Words like *proof*, *confirmed*, *uniquely*, and *demonstrates* each need the artifact that earns them |
+| C8 | **An out-of-band delivery is recomputed, never read** | Where a clean-room protocol hands the derivation to the maintainer outside the repository, verify it with [`verify_provenance_archive.py`](utils/verify_provenance_archive.py) and treat any self-check shipped inside the archive as informational. Hash before rerunning anything: derivation scripts write their outputs beside themselves, so a rerun in the extracted tree can overwrite a manifest-listed file and fail the manifest with the audit itself as the cause |
+
+**On C8, the two checks a manifest cannot perform on itself.** Every listed file can hash correctly while the archive is still wrong, in two directions a per-file sweep does not look. *Closure*: a file present but unlisted rode along unhashed. *Orphan references*: a hash written anywhere in the archive that resolves to nothing the archive contains, which is what an artifact left over from a superseded run looks like from the outside. The script does both, and the second one is what caught a real case.
+
+**When running [`verify_provenance_archive.py`](utils/verify_provenance_archive.py) is required.** Same no-CI caveat as [7.1](#71-the-modelsmd-linter) and [7.2](#72-the-roadmap-linter): nothing invokes it but a reviewer, so it belongs to the procedure or it does not happen.
+
+| Trigger | Run it |
+| --- | --- |
+| A PR declares a provenance class whose obligation is a maintainer-side rerun of an author's derivation | on arrival of the delivery, before accepting the freeze |
+| Any artifact reaches the maintainer outside the repository: an archive, an encrypted blob, a link to bytes not in the PR | before reading anything inside it |
+| A published hash is restated, corrected, or moves for any reason | against the new value, in full. A hash that moved retires every check run against the old one |
+| Before rerunning anything from the archive, including the author's own recovery wrapper | first, always. A rerun can overwrite a listed file and fail the manifest with the audit as the cause |
+| The archive is rebuilt and redelivered | in full again. A partial recheck of "just the changed file" cannot see closure or an orphaned reference |
+
+The verdict is `--strict` when the delivery is being frozen, and default otherwise: an orphan reference is a warning while an archive is still moving, and a failure once it is meant to be final.
 
 ## 6. Gate D: the adversarial pass
 
@@ -498,6 +532,13 @@ python3 dev_docs/utils/check_models_md.py    # mandatory when MODELS.md is touch
 python3 dev_docs/utils/check_roadmaps.py     # mandatory when a roadmap is touched, see 7.2
 ```
 
+Out-of-band provenance delivery ([C8](#5-gate-c-claim-to-artifact)), before rerunning anything from it:
+
+```bash
+python3 dev_docs/utils/verify_provenance_archive.py --archive ARCHIVE.tar.gz \
+    --expect-sha <published sha256> --no-quantities
+```
+
 ### Recording the verdict: submit it as a review, not as a comment
 
 The [verdict](#12-verdict-and-how-to-write-it) has to be submitted as a **review**, which carries a state, and not as a conversation comment, which does not. GitHub makes this easy to get wrong: both render identically and both notify, but only a review sets `reviewDecision`, shows the status badge on the PR list, and satisfies or blocks the CODEOWNERS gate. A review body that says "changes requested" while the PR state says `REVIEW_REQUIRED` leaves the contributor without the signal they watch for.
@@ -558,6 +599,7 @@ One row per PR that taught us something. Newest at the bottom.
 | [#402](https://github.com/openwave-labs/openwave/pull/402) | First full run of § 10.3, and it held: one review carrying every finding, one in-thread answer to the one blocking item (the unnamed adjudicator, the #380 who-pays lesson caught BEFORE the freeze this time), maintainer edits and landing-time items applied on the branch, one merge. Separately verified: the Update branch button's unsigned merge commit does not trip the DCO check, since the probot app ignores merge commits, confirmed empirically on #399-#401, each of which merged carrying one. Updating a fork PR needs no signed local merge | § 10.3 worked example, § 13 |
 | [#408](https://github.com/openwave-labs/openwave/pull/408) | A gate the reviewer adds is itself a claim, and this one was wrong. The new integral check ran a fixed list of primes; scaling the contributed top boundary map by a prime outside that list passed every listed one while multiplying every value the run would report by that prime to a power. A finite list can only ever reject. The contributor spotted it first, in a protocol revision demoting the battery to a reject screen, which is what prompted the attack that reproduced it. An exact certificate replaced the accept side, and the mutation suite gained the case that reddens it | Gate D row D11 |
 | [#408](https://github.com/openwave-labs/openwave/pull/408) | The commitment notice fired correctly and still misinformed. Every line read `WHO PAYS: MAINTAINERS` against an obligation set that was almost entirely scripted reruns the reviewing agent would perform, so the maintainer read personal labor that was not there and hesitated over commitments that were nearly free. A notice built to prevent silent acceptance produced the opposite failure. The missing fact was also the cheapest one to state: the freeze bound at a later lock commit, so the merge itself committed almost nothing | § 4.1 effort split, three new § 4.1 rules |
+| [#408](https://github.com/openwave-labs/openwave/pull/408) | An archive delivered out of band passed all 21 of its manifest hashes and was still carrying a certificate pinned to a superseded object, concluding `NOT CERTIFIED`, unlabelled. Per-file hashes verify the files and not the story they tell, so the check that found it resolves every hash the archive *writes* against something the archive *contains*. Same run: that certificate recorded its own premises as satisfied because they were Python literals in the JSON write rather than the outcomes of the checks above them | Gate C row C8, [`verify_provenance_archive.py`](utils/verify_provenance_archive.py) |
 
 ---
 

--- a/dev_docs/utils/verify_provenance_archive.py
+++ b/dev_docs/utils/verify_provenance_archive.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Verify an out-of-band provenance archive against its own manifest.
+
+A clean-room reproduction protocol delivers its derivation to the maintainer
+outside the repository, because the derivation bytes must not enter the base the
+room opens from. What arrives is an archive plus an author-supplied manifest of
+hashes. The maintainer's job is to recompute all of it, and specifically NOT to
+run the self-check that ships inside the archive: a checker running inside the
+artifact it verifies is the one gate an audit cannot delegate, since it can
+report success by construction.
+
+This script is that recomputation. It never imports, executes, or trusts
+anything from the archive. It reads the manifest as data.
+
+What it checks:
+
+  1. the archive file's own hash, when one is given to check against;
+  2. every manifest-listed file, hash and byte count;
+  3. closure both ways, no unlisted file present and no listed file absent;
+  4. the ordered subset's concatenation, compared against the value declared in
+     the PACKET rather than the value restated in the manifest;
+  5. every cross-hash the packet declares about itself, resolved by content;
+  6. orphan hash references, any 64-hex value written anywhere in the archive
+     that corresponds to nothing the archive contains.
+
+Check 4 is the reason this is worth automating. The manifest supplies the recipe
+(which files, in what order) and the packet supplies the target. They are
+separate documents produced at separate times, so their agreement is evidence,
+while a manifest agreeing with itself is not.
+
+Check 6 catches the failure that a per-file hash sweep cannot see: an artifact
+left in the archive from a superseded run still pins the object it was computed
+against, and that pin resolves to nothing. Every listed file can hash correctly
+while one of them describes a different construction entirely.
+
+ORDER MATTERS. Run this BEFORE rerunning anything from the archive. Derivation
+scripts commonly write their outputs next to themselves, so a rerun in the
+extracted tree can overwrite a manifest-listed file and turn a clean archive
+into a failing one, with the audit as the cause.
+
+Manifest schema, kept loose on purpose so a future packet format still parses:
+a row of `| path | sha256 | bytes |` in backticks is a listed file, and a
+leading integer column marks membership in the ordered set, in that order.
+
+Usage:
+    python3 dev_docs/utils/verify_provenance_archive.py DIR
+    python3 dev_docs/utils/verify_provenance_archive.py --archive FILE.tar.gz
+    python3 dev_docs/utils/verify_provenance_archive.py --archive FILE.tar.gz \\
+        --expect-sha 0123abcd... --no-quantities --strict
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+HEX64 = re.compile(r"\b([0-9a-f]{64})\b")
+ROW = re.compile(
+    r"^\|\s*(?:(\d+)\s*\|\s*)?`([^`]+)`\s*\|\s*`([0-9a-f]{64})`\s*\|\s*(\d+)\s*\|\s*$"
+)
+TEXT_SUFFIXES = {".md", ".py", ".txt", ".json", ".csv", ".toml", ".cfg", ".yml", ".yaml"}
+
+# Decimal renderings with at least this many places count as a reproduced
+# quantity under --no-quantities. Version strings are excluded separately.
+DECIMAL_PLACES = 3
+VERSIONISH = re.compile(r"\d+\.\d+\.\d+")
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+class Result:
+    def __init__(self) -> None:
+        self.failures: list[str] = []
+        self.warnings: list[str] = []
+
+    def check(self, ok: bool, label: str, detail: str = "") -> bool:
+        mark = "✅" if ok else "❌"
+        print(f"  {mark} {label}" + (f"   {detail}" if detail else ""))
+        if not ok:
+            self.failures.append(label)
+        return ok
+
+    def warn(self, label: str, detail: str = "") -> None:
+        print(f"  ⚠️  {label}" + (f"   {detail}" if detail else ""))
+        self.warnings.append(label)
+
+
+def parse_manifest(text: str) -> tuple[list[tuple[str, str, int]], list[str]]:
+    """Return (listed files, ordered subset paths in order)."""
+    listed: list[tuple[str, str, int]] = []
+    ordered: list[tuple[int, str]] = []
+    for line in text.splitlines():
+        m = ROW.match(line)
+        if not m:
+            continue
+        index, path, digest, size = m.group(1), m.group(2), m.group(3), int(m.group(4))
+        listed.append((path, digest, size))
+        if index is not None:
+            ordered.append((int(index), path))
+    return listed, [p for _, p in sorted(ordered)]
+
+
+def find_packet(root: Path, listed: list[tuple[str, str, int]]) -> tuple[Path, dict] | None:
+    """The packet is whichever listed JSON declares a provenance id. Found by
+    schema rather than by filename, so a renamed packet still resolves."""
+    for path, _, _ in listed:
+        f = root / path
+        if f.suffix != ".json" or not f.is_file():
+            continue
+        try:
+            doc = json.loads(f.read_text())
+        except (ValueError, UnicodeDecodeError):
+            continue
+        if isinstance(doc, dict) and isinstance(doc.get("provenance_id"), dict):
+            return f, doc
+    return None
+
+
+def verify(root: Path, args: argparse.Namespace, r: Result) -> None:
+    manifest = root / "MANIFEST.md"
+    if not manifest.is_file():
+        r.check(False, "MANIFEST.md present at the archive root")
+        return
+
+    listed, ordered = parse_manifest(manifest.read_text())
+    print(f"\n== manifest ==\n  {len(listed)} file(s) listed, {len(ordered)} in the ordered set")
+
+    print("\n== 1. every listed file, recomputed ==")
+    digests: dict[str, str] = {}
+    bad = 0
+    for path, want_sha, want_len in listed:
+        f = root / path
+        if not f.is_file():
+            print(f"  ❌ missing: {path}")
+            bad += 1
+            continue
+        blob = f.read_bytes()
+        digests[path] = sha256(blob)
+        if digests[path] != want_sha or len(blob) != want_len:
+            print(f"  ❌ {path}")
+            print(f"       sha want {want_sha}")
+            print(f"       sha got  {digests[path]}")
+            print(f"       len want {want_len}  got {len(blob)}")
+            bad += 1
+    r.check(bad == 0, f"{len(listed) - bad} of {len(listed)} listed file(s) verify")
+
+    print("\n== 2. closure, the direction a manifest cannot check on itself ==")
+    on_disk = {str(p.relative_to(root)) for p in root.rglob("*") if p.is_file()}
+    names = {p for p, _, _ in listed} | {"MANIFEST.md"}
+    extra, absent = sorted(on_disk - names), sorted(names - on_disk)
+    r.check(not extra, "no unlisted file rode along", "" if not extra else ", ".join(extra))
+    r.check(not absent, "no listed file is absent", "" if not absent else ", ".join(absent))
+
+    print("\n== 3. the ordered set, against the packet's declared value ==")
+    if not ordered:
+        r.warn("the manifest declares no ordered set, so nothing pins the source content")
+        concat = None
+    else:
+        h = hashlib.sha256()
+        total = 0
+        for rel in ordered:
+            blob = (root / rel).read_bytes()
+            h.update(blob)
+            total += len(blob)
+        concat = h.hexdigest()
+        print(f"  concatenation of {len(ordered)} file(s), {total} bytes")
+        print(f"  {concat}")
+
+    found = find_packet(root, listed)
+    if found is None:
+        r.warn("no listed JSON declares a provenance id, so check 3 has no independent target")
+    else:
+        packet, doc = found
+        rel = str(packet.relative_to(root))
+        declared = doc["provenance_id"].get("source_content_sha256")
+        print(f"  packet: {rel}  id {doc['provenance_id'].get('id', '(none)')}")
+        if concat is not None and declared:
+            r.check(
+                concat == declared,
+                "the ordered set reproduces the packet's source_content_sha256",
+            )
+        elif not declared:
+            r.warn("the packet declares no source_content_sha256")
+
+        print("\n== 4. the packet's other declared cross-hashes, resolved by content ==")
+        by_digest = {v: k for k, v in digests.items()}
+        cross = {k: v for k, v in doc.items() if k.endswith("_sha256") and isinstance(v, str)}
+        if not cross:
+            print("  (none declared)")
+        for key, value in sorted(cross.items()):
+            owner = by_digest.get(value)
+            r.check(owner is not None, f"{key} resolves to a file in the archive", owner or value)
+
+    print("\n== 5. orphan hash references ==")
+    known = set(digests.values()) | ({concat} if concat else set())
+    if args.expect_sha:
+        known.add(args.expect_sha)
+    orphans: list[str] = []
+    for path, _, _ in listed:
+        f = root / path
+        if f.suffix.lower() not in TEXT_SUFFIXES:
+            continue
+        try:
+            content = f.read_text(errors="replace")
+        except OSError:
+            continue
+        for n, line in enumerate(content.splitlines(), 1):
+            for digest in HEX64.findall(line):
+                if digest not in known:
+                    orphans.append(f"{path}:{n}: {digest}")
+    if orphans:
+        for o in orphans[:20]:
+            print(f"     {o}")
+        if len(orphans) > 20:
+            print(f"     ... and {len(orphans) - 20} more")
+        msg = "hash reference(s) resolve to nothing in this archive"
+        if args.strict:
+            r.check(False, f"{len(orphans)} {msg}")
+        else:
+            r.warn(f"{len(orphans)} {msg}", "a superseded artifact may have been left behind")
+    else:
+        r.check(True, "every hash written in the archive resolves to something it contains")
+
+    if args.no_quantities:
+        print("\n== 6. no reproduced quantity ==")
+        hits: list[str] = []
+        for path, _, _ in listed:
+            f = root / path
+            if f.suffix.lower() not in TEXT_SUFFIXES:
+                continue
+            try:
+                content = f.read_text(errors="replace")
+            except OSError:
+                continue
+            for n, line in enumerate(content.splitlines(), 1):
+                stripped = VERSIONISH.sub("", line)
+                if re.search(rf"\d+\.\d{{{DECIMAL_PLACES},}}", stripped):
+                    hits.append(f"{path}:{n}: {line.strip()[:100]}")
+        for h in hits[:20]:
+            print(f"     {h}")
+        r.check(not hits, f"no decimal rendering of {DECIMAL_PLACES}+ places in any listed file")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("directory", nargs="?", help="extracted archive root, holding MANIFEST.md")
+    ap.add_argument(
+        "--archive", help="tar.gz to hash, screen and extract to a temporary directory"
+    )
+    ap.add_argument("--expect-sha", help="sha256 the --archive file must have")
+    ap.add_argument(
+        "--no-quantities",
+        action="store_true",
+        help="assert the archive contains no decimal rendering, for clean-room deliveries",
+    )
+    ap.add_argument("--strict", action="store_true", help="treat warnings as failures")
+    args = ap.parse_args()
+
+    if bool(args.directory) == bool(args.archive):
+        ap.error("give exactly one of DIRECTORY or --archive")
+
+    r = Result()
+    tmp: tempfile.TemporaryDirectory | None = None
+
+    if args.archive:
+        blob = Path(args.archive).read_bytes()
+        got = sha256(blob)
+        print(f"\n== 0. the archive file ==\n  {got}   {len(blob)} bytes")
+        if args.expect_sha:
+            r.check(got == args.expect_sha, "archive sha256 matches the expected value")
+        with tarfile.open(args.archive) as tar:
+            members = tar.getnames()
+            unsafe = [m for m in members if m.startswith("/") or ".." in Path(m).parts]
+            r.check(not unsafe, "no member escapes the extraction root", ", ".join(unsafe[:3]))
+            if unsafe:
+                return 1
+            tmp = tempfile.TemporaryDirectory(prefix="provenance-verify-")
+            tar.extractall(tmp.name, filter="data")
+        roots = [p for p in Path(tmp.name).iterdir() if p.is_dir()]
+        root = roots[0] if len(roots) == 1 else Path(tmp.name)
+    else:
+        root = Path(args.directory).resolve()
+
+    verify(root, args, r)
+
+    if tmp is not None:
+        tmp.cleanup()
+
+    failed = r.failures or (r.warnings and args.strict)
+    print()
+    if failed:
+        print(
+            f"❌ archive verification FAILED: {len(r.failures)} failure(s), "
+            f"{len(r.warnings)} warning(s)"
+        )
+        for f in r.failures:
+            print(f"    {f}")
+        return 1
+    if r.warnings:
+        print(f"⚠️  archive verified with {len(r.warnings)} warning(s)")
+        return 0
+    print("✅ archive verified: every hash recomputed, closure both ways, nothing orphaned")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Maintainer-side tooling from the #408 review: a verifier for a provenance archive delivered out of band, the Gate C row that makes running it part of the procedure, and a fixed layout for the § 4.1 commitment notice.

## The verifier

A clean-room reproduction protocol hands the derivation to the maintainer outside the repository, because those bytes must not enter the base the room opens from. What arrives is an archive and an author-supplied manifest of hashes, and the obligation is to recompute all of it rather than run the self-check that ships inside it. That was done by hand once. This makes it repeatable, and the packet format is already committed to being the schema for later packets.

| # | Check |
| --- | --- |
| 0 | archive hash, and no member escapes extraction |
| 1 | every listed file, hash and byte count |
| 2 | closure both ways |
| 3 | ordered set, against the packet's declared value |
| 4 | the packet's cross-hashes, resolved by content |
| 5 | orphan hash references |
| 6 | no decimal rendering (`--no-quantities`) |

Check 3 is the one worth automating. The manifest supplies the recipe, which files and in what order, and the packet supplies the target. They are separate documents, so their agreement is evidence, while a manifest agreeing with itself is not.

Check 5 is new, and it came from a real case. An archive can pass checks 1 and 2 and still carry an artifact left over from a superseded run, which still pins the object it was computed against. That pin resolves to nothing, and nothing else in the sweep looks for it.

The script never imports, executes, or trusts anything from the archive. Any self-check inside is informational, per D11.

## Verified

Run against the real #408 delivery: 21 of 21 files, closure both ways, ordered set reproduces the packet's `source_content_sha256`, and check 5 surfaces the one stale reference, matching the hand audit exactly.

Mutation-tested, since a checker that only accepts is the thing D10 and D11 exist to catch:

| Mutation | Caught by |
| --- | --- |
| flip one byte in a listed file | check 1 |
| add an unlisted file | check 2 |
| delete a listed file | checks 1 and 2 |
| tamper a frozen file, repair its row | check 3 |
| `--strict` on a warning | exit 1 |

The fourth is the design claim: tampering with the source *and* repairing the manifest to match still fails, because the target does not come from the manifest.

## Standards changes

| Where | What |
| --- | --- |
| Gate C, row C8 | out-of-band deliveries are recomputed, never read |
| Gate C, after the table | the two checks a manifest cannot do on itself |
| Gate C, trigger table | when running the verifier is required, and when `--strict` applies |
| § 13 appendix | the command, with the hash-before-rerun warning |
| § 14 lessons log | the #408 row this came from |
| § 4.1 | the commitment notice gets a fixed boxed layout |

The § 4.1 change is layout only, no change to what the notice contains: one drawn box per commitment, the four-column effort split directly beneath as a table, then the acceptance line. A ruled block stays findable in a scrollback where a wall of capitals does not, and one box per commitment makes the count visible at a glance, which is the number the decision turns on.

Checkers clean: `check_no_local`, `check_models_md`, `check_roadmaps`, `black --line-length 99`, and every internal anchor resolves.
