### PR TITLE
M8.8 audit: three defects from the #408 exchange

### DIFF
--- a/openwave/xperiments/m8_mit/research/scripts/m8_8_packet_audit.py
+++ b/openwave/xperiments/m8_mit/research/scripts/m8_8_packet_audit.py
@@ -133,8 +133,14 @@ MAX_INT64_PRIME = 3_037_000_499
 # likely to need a second opinion
 BOUND_PRIME = 2_147_483_647
 # entries in the A11 elimination stay tiny on a real packet; a runaway means the greedy
-# pivot order met something pathological, and the honest answer there is "inconclusive"
-A11_GROWTH_CAP = 1 << 40
+# pivot order met something pathological, and the honest answer there is "inconclusive".
+# The cap must ALSO keep the row update itself exact in int64: one step subtracts a
+# product of two entries, so entries at the cap reach cap^2 + cap before the cap check
+# runs, and the earlier 2^40 cap let products wrap silently (demonstrated: a matrix with
+# entries at 2^39 certified SATURATED because -2^78 wraps to exactly 0 mod 2^64).
+# The exact maximum satisfying cap^2 + cap < 2^63 is 3_037_000_499, which is the
+# constant already defined above.
+A11_GROWTH_CAP = MAX_INT64_PRIME
 LEAKAGE_VOCABULARY = (
     "torsion",
     "character",
@@ -427,6 +433,10 @@ def saturation_certificate(matrix: np.ndarray) -> tuple[bool | None, dict[str, A
     fails closed.
     """
     a = np.array(matrix, dtype=np.int64)
+    # the cap check below runs AFTER each update, which is sound only if the entries
+    # going INTO the update already respect the cap; an over-cap input must refuse here
+    if a.size and int(np.abs(a).max()) > A11_GROWTH_CAP:
+        return None, {"pivots": 0, "outcome": "inconclusive: entry growth"}
     rows, cols = a.shape
     live_rows = list(range(rows))
     live_cols = list(range(cols))
@@ -942,8 +952,14 @@ def run_checks(
         acyclicity,
     )
 
-    prose = json.dumps(packet.get("basing", {})) + json.dumps(packet.get("top_closure", {}))
-    scanned = raw.replace(prose.strip("{}"), "")
+    # `basing` and `top_closure` are declared prose and exempt from the vocabulary scan;
+    # scan a serialization that omits them rather than substring-replacing them out of
+    # `raw`, which never matched (compact dump vs indented raw) and silently scanned the
+    # prose too. The decimal-literal check below stays on the full raw on purpose.
+    scanned = json.dumps(
+        {k: v for k, v in packet.items() if k not in ("basing", "top_closure")},
+        sort_keys=True,
+    )
     hits = [word for word in LEAKAGE_VOCABULARY if word in scanned.lower()]
     leakage_ok = not hits and not re.search(r"\d\.\d", raw) and set(packet) <= DECLARED_KEYS
     record(
@@ -1032,11 +1048,13 @@ def _scale_top_boundary(packet: dict[str, Any]) -> None:
 
 
 def _relabel_relator(packet: dict[str, Any]) -> None:
-    """Mislabel the FIRST relator, which is the one currently agreeing with its matrix.
+    """Mislabel the first relator: `s^3` becomes `s^4` in the declared basis order.
 
-    Mutating the second relator's label would not do: swapping `(st)` for `(ts)` there is
-    the correction, not a defect, and A10 goes green under it.  That asymmetry is itself the
-    causal demonstration that A10 reads the matrices rather than the prose.
+    An earlier version of this docstring claimed that swapping `(st)` for `(ts)` on the
+    second relator would leave A10 green.  That was true against the packet the mutation
+    was written for, whose second matrix row was the `(ts)` jacobian, and it is false
+    against the shipped packet, where the same swap reddens A10 (measured).  Either
+    relabel now demonstrates the same thing: A10 reads the matrices, not the prose.
     """
     packet["basing"]["basis_order"] = packet["basing"]["basis_order"].replace("s^3", "s^4")
 


### PR DESCRIPTION
Three defects in `m8_8_packet_audit.py`, reported by the author on #408 with measured demonstrations, each reproduced here before fixing.

| Defect | Fix |
| --- | --- |
| A11 false SATURATED on int64 wrap | cap reuses `MAX_INT64_PRIME`, plus input guard |
| A9 prose exemption was a no-op | scan omits the exempt keys |
| stale `_relabel_relator` docstring | rationale corrected, both packets recorded |

**A11.** The elimination's row update multiplies two entries each allowed up to the old `2^40` cap, so products reach `2^80` and wrap int64 before the cap check runs. Demonstrated: `[[1, 2^39], [2^39, 0]]`, true elementary divisors `(1, 2^78)`, certified as cleared with unit pivots, because `-2^78` wraps to exactly 0 mod `2^64`. The safe cap must satisfy `cap^2 + cap < 2^63`, whose exact maximum 3,037,000,499 is the `MAX_INT64_PRIME` constant already defined in the file. The input guard exists because the post-update check cannot protect the first update: an over-cap matrix now refuses as inconclusive up front.

**A9.** The compact `json.dumps` needle can never occur in the indented raw, so the `replace` removed nothing and the declared prose was scanned too. It failed in the safe direction only, but a legitimate schema-prose word would have reddened a clean packet. The scan now runs over a serialization that omits the two declared-prose keys, verified both directions: "torsion" planted in `basing` passes, "torsion" planted in a data field still reddens.

**Docstring.** It claimed the second-relator `(st)` to `(ts)` swap leaves A10 green. True for the packet the mutation was written for, false for the shipped packet, where the swap reddens A10, measured through `run_checks`. The mutation itself was always functional; only the recorded rationale was stale.

Regression: full gates on the shipped packet pass before and after (A1 through A11, 10 of 10 mutations detected), consistent with the author's instrumentation showing peak entry 1 in the shipped elimination: the A11 hole was latent on real input, live only on adversarial input.

Checkers clean: `black --line-length 99`, `check_no_local`.
