### PR TITLE
Add displaced-verification failure mode; complete M5.21.15

### DIFF
--- a/AI_HYGIENE.md
+++ b/AI_HYGIENE.md
@@ -11,7 +11,7 @@
 | [1. The stance](#1-the-stance) | one paragraph: instruments vs authors |
 | [2. Do / Don't quick reference](#2-do--dont-quick-reference) | the rules at a glance |
 | [3. Division of labor](#3-division-of-labor) | what models do well vs what only humans can supply |
-| [4. Failure modes](#4-failure-modes) | the six ways AI quietly corrupts a research record |
+| [4. Failure modes](#4-failure-modes) | the seven ways AI quietly corrupts a research record |
 | [5. Safeguards already in force](#5-safeguards-already-in-force) | repo standards that operationalize this page |
 | [Details](#failure-mode-details) | anchored deep dives, one per failure mode, at the doc tail |
 
@@ -61,7 +61,7 @@ Two consequences worth making explicit:
 
 ## 4. Failure modes
 
-Six patterns account for most AI damage to research records. Lean table here; mechanics, symptoms, and countermeasures in the [anchored details](#failure-mode-details).
+Seven patterns account for most AI damage to research records. Lean table here; mechanics, symptoms, and countermeasures in the [anchored details](#failure-mode-details).
 
 | # | Failure mode | One line | Detail |
 | --- | --- | --- | --- |
@@ -71,6 +71,7 @@ Six patterns account for most AI damage to research records. Lean table here; me
 | 4 | Authority laundering | model text acquires the standing of the human who forwards it | [§ detail](#authority-laundering-detail) |
 | 5 | Relay drift | AI-to-AI chains lose information at every hop while gaining confidence | [§ detail](#relay-drift-detail) |
 | 6 | Publication slop | unverified model text leaking into venues, polluting the commons and the author's credibility | [§ detail](#publication-slop-detail) |
+| 7 | Displaced verification | the check landed beside the load-bearing step instead of on it, and everyone involved felt verified | [§ detail](#displaced-verification-detail) |
 
 ## 5. Safeguards already in force
 
@@ -140,6 +141,14 @@ These repo standards exist precisely to make AI-assisted research auditable. Use
 **Countermeasure.** OpenWave's bar for anything public, in rising order of strictness: internal docs may be AI-drafted freely (they are verified by use and by review); repository claims must be script-backed with honest icons; benchmark entries go through staged preview plus governance; anything aimed at the research community (papers, preprints, mailing lists, collaborator reports) must be **human-owned prose over verified results**, with AI assistance disclosed where the venue expects it, and formatted for auditability per [`dev_docs/METHOD_NOTE.md`](dev_docs/METHOD_NOTE.md). The test is simple: if the assistant vanished tomorrow, you could still defend every published sentence, because you verified each one while writing it.
 
 A special case is **positioning slop**: aggregate self-ranking against other research programs ("closer to a complete theory than anything else produced") is prose that no single artifact can back, and it reads as marketing even when the underlying work is sound. The house pattern is the [`MODELS.md`](MODELS.md) one: comparisons stay per-criterion, artifact-linked, and carry their conditions inline, or they stay unpublished. The platform's voice is the referee's, never a contestant's.
+
+### Displaced verification detail
+
+**Mechanism.** A composite claim decomposes into an ambient fact and an inferential step that carries that fact to the object at hand. The ambient fact is usually the cheap half and always the satisfying half: it is crisp, it computes, it returns a number, and checking it produces the felt sense of having checked the claim. The step that actually carries the claim, the "and therefore this holds for THIS map, THIS instance, THIS regime", is the expensive half and gets assumed. Automation sharpens the trap from both ends. A model states the composite fluently with the checkable part attached as its evidence, and a second party asked to confirm reaches for the same checkable part, so the claim collects independent confirmations that all land in the same place.
+
+**Symptom.** You can name precisely what was verified and it is not the claim. A confirmation arrives that restates your evidence rather than adding an independent one. Nobody has run the object itself through the gate the claim is about, usually because the composite read as settled once its arithmetic checked out. The tell is that the check which could have gone red was never the one performed.
+
+**Countermeasure.** Write the claim as premise, step, conclusion, and ask which of the three the evidence touches. Then run the check that can actually fail: put the real object through the real gate rather than confirming a fact about the neighbourhood it lives in. Worked instance, [M8.8 #408](https://github.com/openwave-labs/openwave/pull/408): `det(2 − z) = 3^60` on `Z[2I]` is true, was independently confirmed on both sides, and was offered as evidence that scaling by `2 − z` gives `H₁` order `3^60`. It does not. `∂₂` carries a 119-dimensional kernel that absorbs the factor, the homology is unchanged, and one run of the packet audit against the mutated packet showed the certificate green in seconds. Both parties verified the determinant and neither ran the mutant. **A true statement about an ambient module is not a statement about a map**, and only the second is what a claim about a map rests on.
 
 ---
 

--- a/openwave/xperiments/m5_liquid_crystal/research/findings/m5_21_15_note.md
+++ b/openwave/xperiments/m5_liquid_crystal/research/findings/m5_21_15_note.md
@@ -271,6 +271,12 @@ ladder](../data/m5_21_14_resolution.json) trend (its n 32 → 48 → 64 sequence
 the continuum); an n ≥ 48 ladder on this profile is the open verification step, not a
 contradiction.
 
+### 5.6 The panel
+
+![The M5.21.15 panel: the free envelopes (no interior minimum, all channels), the ω² coefficient at the free minimizer, the R-cut sign map, the fixed-J money curve (interior minimum at positive energy), the E(J) envelope with dE/dJ = ω\*, and the minimizing dressings](../plots/m5_21_15_panel.png)
+
+Regen: [`m5_21_15_d_panel.py`](../scripts/m5_21_15_d_panel.py) (seconds, from the saved JSONs).
+
 ## 6. Verdict (pre-registered both ways)
 
 The pre-registration asked: does a positive-energy nonzero-ω minimum EXIST in the probed

--- a/openwave/xperiments/m5_liquid_crystal/research/tasks/m5_21_convo.md
+++ b/openwave/xperiments/m5_liquid_crystal/research/tasks/m5_21_convo.md
@@ -432,3 +432,26 @@ The author replied to the M5.21.11 sanity-check send and TOOK THE EXCHANGE PUBLI
 | Reply posture | HELD (user call, this capture): no answer goes back until [M5.21.15](m5_21_15_task_details.md) runs; checkpoint policy, machine-checkable branches first |
 | The author's "(?)" | A genuine open question, not a claim: whether a positive-energy nonzero-ω minimum exists. The honest baseline from [M5.21.3](m5_21_3_task_details.md): on the UNDRESSED functional no finite stationary ω exists in the probed range (equal-depth control subtraction); what the dressed and constraint-carried functionals do is exactly M5.21.15's measurement |
 | Standing flags | unchanged and unraised (the Dirac ask, the help offer, the unification-plans question) |
+
+## 2026-08-11 ~14:00 EDT: SENT: the M5.21.15 answer (the concavity theorem + the measured fixed-J minimum)
+
+**Context**: 1:1 reply on the same thread (no cc), sent by the user after [M5.21.15](m5_21_15_task_details.md) closed (approved 13:47 EDT) and [PR #433](https://github.com/openwave-labs/openwave/pull/433) merged to main. Sent-record: routing + content summary per the two-tier rule; the full text stays in the mail thread.
+
+**What was sent** (the Fable-voice technical block + the user's own opening):
+
+| Piece | Content summary |
+| --- | --- |
+| The structural half | free minimization can never select nonzero ω: E exactly affine in ω² per configuration (verified 1.3e-11) ⇒ every free envelope concave in ω² ⇒ no interior minimum, any family/dressing/box; the author's "it stopped minimization process" affirmed and sharpened (iteration-capped upper bounds; increasing ω²-slopes = the convergence diagnostic); the measured interior MAXIMUM at g = 8 noted as the one permitted shape |
+| The constructive half | the fixed-J minimum measured: interior minimum at ω = 0.59, E_total = +115.9 > 0 (family units, g = 32, δ = 0.3, guard 0.02), matching ω\* = J/(2·kin) = 0.592; dE/dJ = ω\* to 0.4-2.4 percent; E(J) convex; the dressing raises ω\* at fixed J |
+| The V hook | the energy sign at the minimum flips with the dressing-guard width in [0.02, 0.05]: named as the concrete number the regularization potential must answer (the [Q25](../m5_question_tracker.md#q25-detail) tie to the author's "just a first guess") |
+| The caveat | the rotation-sector ω² coefficients also flip negative DRESSED (the M5.21.3 rotations-positive statement is undressed-only) |
+| Verification status | two independent audit rounds, no structural refutation; kin sector lattice-certified at n = 32; the E-well subgrid at h = 1.5 (n ≥ 48 ladder named as the open step) |
+| Link + attachment | the note on main (`findings/m5_21_15_note.md`) + the 6-panel figure attached |
+
+### Notes
+
+| Item | Content |
+| --- | --- |
+| Asks in the message | NONE new; the guard-choice question was not re-asked directly (ask economy): the V-sign bracket re-surfaces it implicitly |
+| Standing flags | unchanged and unraised (the Dirac ask, the help offer, the unification-plans question) |
+| Next | await the author's read; the corrected-3×3 ladder stays unstaged pending the guard answer; Backlog head = [M5.21.13](m5_21_13_task_details.md) (courtesy-gated), user pick |


### PR DESCRIPTION
Adds the 7th AI hygiene failure mode (displaced verification) to AI_HYGIENE.md, documenting the pattern where a check lands on an ambient fact rather than the actual load-bearing claim, leading to false confidence across independent reviewers.

Completes M5.21.15 findings with the panel figure (section 5.6), and logs the author communication sent to Duda after M5.21.15 closed, documenting the concavity theorem result and the fixed-J minimum measurement.

All work audited; PR #433 merged to main.