### PR TITLE
M8.5-B adj04 adjudication

### DIFF
--- a/openwave/xperiments/m8_mit/research/findings/m8_5b_preregistration.md
+++ b/openwave/xperiments/m8_mit/research/findings/m8_5b_preregistration.md
@@ -1687,3 +1687,51 @@ just resolved for Packet II. Whoever writes that revision should give Packet I
 an explicit version slot in the `m8_5b-packet-I-<n>` form. It is recorded here
 rather than corrected here because altering Packet I's shape outside a format
 revision is the in-place amendment § 12 exists to prevent.
+
+### Addendum 12.2 - fresh Phase B adjudication case commitment
+
+*Drafted 2026-08-16 by the Phase B Sealer Unit. Adopted 2026-08-16 by the
+commissioner following Redline review. This addendum is an operative commitment
+under § 12.*
+
+A fresh Phase B adjudication case has been sealed under the § 4.1 packet
+contract as supplemented by Addendum 12.1. It supersedes nothing: the retired
+case `M85B-ADJ-01` remains burned per § 12.1.7, and the § 6.1 and § 11.7 hashes
+recording it are unaltered historical commitments.
+
+**Opaque case identifier.** `M85B-ADJ-04`. The label is opaque and encodes
+nothing about the case.
+
+**Packet hashes, over canonical bytes (§ 11.7: keys sorted, two-space indent,
+ASCII, LF, single trailing newline).**
+
+Packet I (case-input), SHA-256
+`52eabe3fc1d045bde8efad888e23f6302123fafa4e0ef151b31382f4cd1307c2`.
+
+Packet II (answer), SHA-256
+`f000b895668f85c06da46f4ea80eaaa9eaa34b923516e5a264120724766d5fdd`.
+
+Listed separately; neither may be inferred from the other. These are the
+operative adjudication-case commitments wherever § 4.1 refers to them, in place
+of the § 6.1 and § 11.7 entries that record the retired case.
+
+**Status of the packets.** Both are sealed and unopened. Packet I opens at
+§ 4.1 step 2 and Packet II at § 4.1 step 4. Neither has been published, and
+Packet II's bytes remain outside the repository until the adjudication is
+recorded (§ 4.1).
+
+**Admissibility, as recorded at commissioning.** The case is non-`2I` and is
+distinct from every member of the § 6.1 pilot tuning set; it informed no pilot
+choice. Its cited source supports the § 4.1 and Addendum 12.1 requirements
+without adapter discretion.
+
+**Build conditions.** The packets were built in a clean two-stage session by a
+unit with no access to the adjudication or qualification machinery, satisfying
+the Q6 separation-of-duties control. Every supplied build-time gate (S0-S6,
+L1-L3, V1-V8, and the SYN- sealing reservation) was run unmodified and cleared
+before sealing, and the supplied self-batteries were run and read at Stage 0,
+before the case was disclosed. No validation gate was written, patched,
+supplemented or replaced at any point after the case was disclosed.
+
+**Not settled here.** This addendum records a commitment only. It orders no
+§ 4.1 execution, authorizes no route run, and states no adjudication result.

--- a/openwave/xperiments/m8_mit/research/findings/m8_5b_preregistration.md
+++ b/openwave/xperiments/m8_mit/research/findings/m8_5b_preregistration.md
@@ -1735,3 +1735,50 @@ supplemented or replaced at any point after the case was disclosed.
 
 **Not settled here.** This addendum records a commitment only. It orders no
 § 4.1 execution, authorizes no route run, and states no adjudication result.
+
+### Addendum 12.3 - route (a) central-equivalence repair
+
+*Drafted 2026-08-16 by the adjudication side. Adopted 2026-08-16 by the
+commissioner following review. This addendum is an operative record under
+§ 12.*
+
+**What happened.** During blind execution of `M85B-ADJ-04`, before any Packet
+II access and before any route-output commitment, route (a) exposed an
+incompatibility between two conventions inside the frozen machinery: the
+effective-group closure identifies action pairs modulo the diagonal central
+kernel, `(u, v) ~ (-u, -v)`, choosing one representative per effective
+element, while the stencil layer's multiplication-table lookup required
+sign-exact equality of representatives. For an inhomogeneous cyclic case,
+products of representatives can land on the central partner of a listed
+representative, so the underlying group element exists but the lookup
+refuses, and route (a) stopped before producing an output. Execution stopped
+with it. No adjudication occurred, and the case's sealed commitments stand
+unaltered under Addendum 12.2.
+
+**The defect is latent, not case-induced.** The tuning-set member `L(7;1,2)`
+fails by the identical mechanism when driven through the same path, so the
+incompatibility predates the fresh case. It survived qualification because
+every case that previously reached the stencil path was sign-exact closed by
+accident of selection: the rehearsal case is homogeneous, and the pilot's
+binary polyhedral groups contain the central element natively.
+
+**What may change.** The production route may be repaired ONLY to make
+multiplication-table lookup respect the same diagonal central equivalence
+already used by the closure. No spectral formula, packet gate, comparator,
+indexing map, threshold, or answer-bearing logic may change.
+
+**What this obligates.** Requalification must add the missing diversity
+before any new case is selected: the homogeneous and binary-polyhedral
+regressions must still pass; `L(7;1,2)` must traverse the actual route-(a)
+stencil path; representative products landing on a central partner must
+resolve correctly; a deliberate mutation removing the central equivalence
+must make that check fail; a genuinely absent product must still be refused,
+so lookup does not become nearest-match; the orbit cloud's cardinality must
+remain the effective group order, proving no coincident sign-doubled points
+enter the stencils; and route (b), the Gamma = 1 validation, and the prior
+route-(a) controls must remain green. The repair and its requalification are
+subject to maintainer review before a fresh adjudication case is selected.
+
+**Disposition of `M85B-ADJ-04`.** Retired as the pre-reveal bug-discovery
+case. Its Packet II remains sealed and is not opened by this addendum or by
+the repair. Its commitments in Addendum 12.2 remain valid historical record.

--- a/openwave/xperiments/m8_mit/research/m8_5b/production/equivariant_stencils.py
+++ b/openwave/xperiments/m8_mit/research/m8_5b/production/equivariant_stencils.py
@@ -61,8 +61,17 @@ RBF_FD_WEIGHT_COVARIANCE = {
 
 
 def group_multiplication_table(pairs, tol=1e-9):
+    # Addendum 12.3: lookup matches modulo the diagonal central kernel,
+    # (u, v) ~ (-u, -v), the SAME equivalence the effective-group closure
+    # uses to choose its representatives.  A product of two representatives
+    # can land on the central partner of a listed representative; that is
+    # the same effective element, and refusing it made route (a) unable to
+    # run any inhomogeneous cyclic case.  A product matching NO listed
+    # element in either sign is still refused: the table is closure
+    # verification, not nearest-match.
     def same(a, b):
-        return abs(a[0] - b[0]).max() < tol and abs(a[1] - b[1]).max() < tol
+        return ((abs(a[0] - b[0]).max() < tol and abs(a[1] - b[1]).max() < tol) or
+                (abs(a[0] + b[0]).max() < tol and abs(a[1] + b[1]).max() < tol))
 
     def idx_of(p):
         for i, q in enumerate(pairs):

--- a/openwave/xperiments/m8_mit/research/m8_5b/qualification/MANIFEST.json
+++ b/openwave/xperiments/m8_mit/research/m8_5b/qualification/MANIFEST.json
@@ -4,7 +4,7 @@
     "qualification/MANIFEST.json",
     "qualification/PHASE_A_FREEZE.md"
   ],
-  "file_count": 36,
+  "file_count": 37,
   "files": {
     "confinement_probe.py": "6e05a7b3b07d87c11c736efac89b7bdc3dd93b0693d597356d4c82e8b597e559",
     "eval3b/gate_gamma1.py": "4bf69fe504bc244a657b6870c7bbe3876b821e07c2e8e26a2d751a46cceea32d",
@@ -25,7 +25,7 @@
     "pilot/route_a_twosided.py": "33a76e6018223b62d94bd196ca19ea8e36e53cf9139323f87e13037a82a342a0",
     "production/cl_descent.py": "1ecf742b0d64c09ee494fdd7a249866c2493cabb64cf090306b8706827832df1",
     "production/equivariant_oneform.py": "ff8b8a890523519b444567074766bec30825df9383faa04ba18beb15039673be",
-    "production/equivariant_stencils.py": "e99099baea55746956dd05a910cf2e939e85172f8e608eba017dd77ce2d0c1b9",
+    "production/equivariant_stencils.py": "c30cac01bed2da53980450035e3b823fa2ec3c17bae3d0487a000ec727a31520",
     "production/route_a_oneform_repn.py": "b98b79243d3dd64821a16b4e565fbebc7b1d553a29c960aa5afe0791d7532dd3",
     "production/route_a_producer.py": "a42f9c5ff2361192d94487273f130f14e0305da3831309079e2555043da40f95",
     "production/route_a_repn.py": "240575067f1ec92f0196d337f67ba9c99a2f82aa397e5fc189f5e7f7255043cb",
@@ -40,7 +40,8 @@
     "qualify_integration.py": "fb1de8e1ded52d7ecfb2c1a9b1d692a052a6729fc5809a6e7499c7403f60026c",
     "rehearsal_deletion_check.py": "882e14b059dc0df7beaeb3c985fa62191276fe33beff5b27920d627bec0c6031",
     "rehearsal_q4.py": "2e0493486430be765c50a1d8def7c4c1d5b56f79158da0f86489f6ded0ae2960",
-    "run_qualification.py": "29e0d13035ea6470c43bb769a4f6ffb047ed45e953e96126133722d5d5f940f9",
+    "route_a_closure_battery.py": "5ea14db85783a9313ba4a18fac86091d49988391bd70d4d24ae681b3fec7f1d9",
+    "run_qualification.py": "e7b18d81f9e111236461ae2c44380373f8473f66b914cda8159cd95126b46c74",
     "verify_packet_structural.py": "6af71e482b6ca2698d8dcaac29d25585b4a331cbd7479ff7be056db2551935b2"
   },
   "note": "SHA-256 of every shipped file except three. MANIFEST.json cannot contain its own hash. PHASE_A_FREEZE.md contains this manifest's hash, so hashing it here would be circular: the chain runs freeze -> manifest -> every other file, and the freeze record's own anchor is the commit that carries it. .gitignore is repository hygiene, not qualification evidence and not an input to any battery; repository policy marks it export-ignore, so it is absent from source archives, and pinning it made a correct exported tree fail this gate."

--- a/openwave/xperiments/m8_mit/research/m8_5b/qualification/PHASE_A_FREEZE.md
+++ b/openwave/xperiments/m8_mit/research/m8_5b/qualification/PHASE_A_FREEZE.md
@@ -9,7 +9,7 @@
     Scope        the scalar and one-form adjudication machinery for rungs 3a
                  and 3b, as published in this directory
     Manifest     `qualification/MANIFEST.json`
-                 SHA-256 2648611948b93b46fe70b3017b7953287ff1445a73cf553ffccf6cd54b410b87
+                 SHA-256 9e6dcd7b5d177040cf25f1eda0bb4614f4002cd85f25660ca9ec75dc9734d934
     Reproduce    python3 run_qualification.py
 
 ## What is frozen
@@ -35,7 +35,9 @@ shaped by an answer it had not seen.
 The qualification is reproducible, from a clean clone and from an exported
 source archive alike, by the single command above, which establishes, in
 order: no first-party module imported by the controlling process resolves
-outside this tree; the confinement those batteries run under, observed in a
+outside this tree; the route (a) group-closure battery added by Addendum
+12.3, whose mutation arm proves the central-equivalence repair is
+load-bearing; the confinement those batteries run under, observed in a
 child and a grandchild launched through the same helper they use and probed
 under a deliberately poisoned parent environment; the environment; the
 manifest; the Packet I and Packet II gate batteries; the structural battery
@@ -45,8 +47,11 @@ and the integrated battery.
 
 ## What the freeze does NOT claim
 
-**No rung has run on a real adjudication case.** Every case exercised here is
-synthetic or a frozen tuning case, so nothing in this directory is adjudication
-evidence, no external reference value has been compared to any route output, and
-no certification language from § 1 of the preregistration is engaged. The
-M8.5-A gate condition and every § 0 claim ceiling stand unchanged.
+**No qualification run in this tree is adjudication evidence.** `M85B-ADJ-04`
+invoked route (a) before this repair and stopped structurally before producing
+an output; it is retired under Addendum 12.3 and its Packet II remains sealed.
+Every case exercised by this qualification command is synthetic or a frozen
+tuning case, no external reference value has been compared to any route
+output, and no certification language from § 1 of the preregistration is
+engaged. The M8.5-A gate condition and every § 0 claim ceiling stand
+unchanged.

--- a/openwave/xperiments/m8_mit/research/m8_5b/route_a_closure_battery.py
+++ b/openwave/xperiments/m8_mit/research/m8_5b/route_a_closure_battery.py
@@ -1,0 +1,157 @@
+"""Route (a) group-closure battery (Addendum 12.3 requalification).
+
+The coverage this battery adds is exactly what the M85B-ADJ-04 STOP proved
+missing: route (a)'s stencil path exercised on an effective group that is
+NOT sign-exact closed. Every check prints PASS or FAIL and the process
+exits nonzero on any FAIL. The mutation arm rebuilds the PRE-repair
+sign-exact lookup locally and requires it to fail, so the repair is
+load-bearing, and the truncation arm requires refusal, so lookup did not
+become nearest-match.
+"""
+import sys
+
+for _p in ("production", "pilot", "gates"):
+    sys.path.insert(0, _p)
+
+import numpy as np                                          # noqa: E402
+from route_a_twosided import ONE, close_pairs, cloud, act_matrix, qmul  # noqa: E402
+from equivariant_stencils import group_multiplication_table  # noqa: E402
+import route_a_producer as route_a                          # noqa: E402
+import route_b_producer as route_b                          # noqa: E402
+import step3_runner                                          # noqa: E402
+
+fails = 0
+def ck(label, ok, detail=""):
+    global fails
+    print(f"  {'PASS' if ok else 'FAIL'}  {label}" + (f"   {detail}" if detail else ""))
+    if not ok:
+        fails += 1
+
+mk = lambda t: np.array([np.cos(t), np.sin(t), 0.0, 0.0])
+def lens_gens(q, s1, s2):
+    return [(mk(np.pi * (s1 + s2) / q), mk(np.pi * (s1 - s2) / q))]
+
+print("route (a) group-closure battery")
+
+# 1. homogeneous regression
+p31 = close_pairs(lens_gens(3, 1, 1))
+try:
+    group_multiplication_table(p31)
+    ck("homogeneous L(3,1): table closes (regression)", len(p31) == 3)
+except ValueError as e:
+    ck("homogeneous L(3,1): table closes (regression)", False, str(e))
+
+# 2. binary polyhedral regression: 2T, which contains -1 natively
+h = 0.5
+tet = [(np.array([h, h, h, h]), ONE.copy()), (np.array([0.0, 1.0, 0.0, 0.0]), ONE.copy())]
+p2t = close_pairs(tet)
+try:
+    group_multiplication_table(p2t)
+    ck("binary polyhedral 2T: table closes (regression)", len(p2t) == 24,
+       f"order {len(p2t)}")
+except ValueError as e:
+    ck("binary polyhedral 2T: table closes (regression)", False, str(e))
+
+# 3+4. the previously failing regime, with ground truth from the ACTION,
+# which is sign-free: T[i][j] must index the element whose SO(4) matrix
+# equals the matrix product. This is correctness, not mere non-crashing.
+p712 = close_pairs(lens_gens(7, 1, 2))
+T = group_multiplication_table(p712)
+mats = [act_matrix(u, v) for u, v in p712]
+good = all(np.abs(mats[i] @ mats[j] - mats[T[i][j]]).max() < 1e-8
+           for i in range(len(p712)) for j in range(len(p712)))
+wraps = sum(1 for i in range(len(p712)) for j in range(len(p712))
+            if not (np.abs(qmul(p712[i][0], p712[j][0]) - p712[T[i][j]][0]).max() < 1e-9))
+ck("inhomogeneous L(7;1,2): every table entry matches the SO(4) ground truth", good)
+ck("central-partner products actually occur and resolve", wraps > 0,
+   f"{wraps} of {len(p712)**2} products land on the central partner")
+
+# 5. mutation: the PRE-repair sign-exact lookup must FAIL here
+def sign_exact_table(pairs, tol=1e-9):
+    def same(a, b):
+        return abs(a[0] - b[0]).max() < tol and abs(a[1] - b[1]).max() < tol
+    def idx_of(p):
+        for i, q in enumerate(pairs):
+            if same(p, q):
+                return i
+        raise ValueError("product left the supplied element list")
+    return [[idx_of((qmul(pairs[i][0], pairs[j][0]), qmul(pairs[i][1], pairs[j][1])))
+             for j in range(len(pairs))] for i in range(len(pairs))]
+try:
+    sign_exact_table(p712)
+    ck("mutation: removing central equivalence makes L(7;1,2) fail", False,
+       "sign-exact lookup unexpectedly succeeded")
+except ValueError:
+    ck("mutation: removing central equivalence makes L(7;1,2) fail", True)
+
+# 6. genuinely absent product still refused
+try:
+    group_multiplication_table(p712[:-1])
+    ck("truncated element list is refused (lookup is not nearest-match)", False)
+except ValueError:
+    ck("truncated element list is refused (lookup is not nearest-match)", True)
+
+# 7. cloud cardinality: effective order exactly, no coincident points
+rng = np.random.default_rng(20260816)
+S = rng.normal(size=(12, 4)); S /= np.linalg.norm(S, axis=1, keepdims=True)
+X, oid, gid, M = cloud(S, p712)
+from scipy.spatial.distance import pdist
+ck("cloud cardinality is seeds x effective order, with no coincident points",
+   len(X) == 12 * len(p712) and pdist(X).min() > 1e-6,
+   f"{len(X)} nodes, min separation {pdist(X).min():.2e}")
+
+# 8. route (a) END TO END on the previously failing regime, frozen stencil
+# configuration at a reduced ladder rung, validated route-locally by the
+# frozen step-3 runner (which includes the full-band census)
+art_a = route_a.produce(p712, "requal-a-L712", "m8_5b-v1-requal", "SYN-L712-REQUAL",
+                        seeds=60, adjudication=False)
+probs = step3_runner._validate_one(art_a, p712, "route a")
+ck("route (a) traverses the stencil path end to end on L(7;1,2)",
+   not probs, "; ".join(probs[:2]))
+
+# 9a. route (b) is UNCHANGED by this repair, proven at RUNTIME: a fresh
+# subprocess executes the same produce() path 9b tests, then asks whether
+# the repaired module ever entered sys.modules. Import-time closure alone
+# would not establish this, since a lazy import inside produce() would
+# evade it; running the path first makes the sentence true of what was
+# actually executed.
+import subprocess as _sp
+_probe_code = (
+    "import sys\n"
+    "sys.path[:0] = ['production', 'pilot', 'gates']\n"
+    "import numpy as np\n"
+    "import route_b_producer\n"
+    "mk = lambda t: np.array([np.cos(t), np.sin(t), 0.0, 0.0])\n"
+    "gens = [(mk(np.pi * 3 / 7), mk(-np.pi / 7))]\n"
+    "route_b_producer.produce(gens, 'requal-b-9a', 'm8_5b-v1-requal',\n"
+    "                         'SYN-L712-REQUAL', adjudication=False)\n"
+    "print('equivariant_stencils' in sys.modules)\n"
+)
+probe = _sp.run([sys.executable, "-c", _probe_code],
+                capture_output=True, text=True, cwd=".")
+ck("repaired module never enters route (b)'s runtime through produce() "
+   "(runtime dependency closure)",
+   probe.stdout.strip().endswith("False"),
+   probe.stdout.strip()[-24:] or probe.stderr[:80])
+
+# 9b. and its scalar records equal an INDEPENDENT character-sum
+# recomputation performed here with this battery's own arithmetic, so the
+# baseline is mathematics, not a rerun of the same code.
+art_b = route_b.produce(lens_gens(7, 1, 2), "requal-b-L712", "m8_5b-v1-requal",
+                        "SYN-L712-REQUAL", adjudication=False)
+p712b = close_pairs(lens_gens(7, 1, 2))
+def chi(quat, n):
+    ang = np.arctan2(np.linalg.norm(quat[1:]), quat[0])
+    if abs(np.sin(ang)) < 1e-12:
+        return (n + 1) * (np.cos(ang) ** n if n else 1.0)
+    return np.sin((n + 1) * ang) / np.sin(ang)
+sc = [r for r in art_b["records"] if r["sector_id"] == "scalar"
+      and r["quotient_multiplicity"] is not None]
+ok_b = all(abs(r["quotient_multiplicity"]
+               - sum(chi(u, r["harmonic_level"]) * chi(v, r["harmonic_level"])
+                     for u, v in p712b) / len(p712b)) < 1e-9 for r in sc)
+ck("route (b) scalar records equal the independent character-sum baseline",
+   ok_b and len(sc) > 0, f"{len(sc)} scalar cells recomputed independently")
+
+print(f"\n{('BATTERY PASS' if fails == 0 else 'BATTERY FAIL')}: {fails} failures")
+sys.exit(1 if fails else 0)

--- a/openwave/xperiments/m8_mit/research/m8_5b/run_qualification.py
+++ b/openwave/xperiments/m8_mit/research/m8_5b/run_qualification.py
@@ -19,9 +19,9 @@ verdict.  Nonzero exit on anything short of a full pass.
     6  integrated   the Q1/Q2/Q3/Q5 battery
     7  records      the fresh run reproduces the shipped qualification records
 
-WHAT THIS DOES NOT SHOW.  Every case exercised here is synthetic or a frozen
-tuning case.  No rung has run on a real adjudication case, so nothing produced
-by this command is adjudication evidence.
+WHAT THIS DOES NOT SHOW.  No qualification run in this tree is adjudication
+evidence; every case exercised by this command is synthetic or a frozen
+tuning case.
 """
 
 import hashlib
@@ -194,6 +194,14 @@ record("gate_gamma1.py exits 0 (recovers the rung-2 tower)", rc == 0)
 rc, out = run("eval3b/mutations.py")
 record("eval3b mutation battery exits 0", rc == 0)
 
+# --- 4c route (a) group-closure battery (Addendum 12.3) ----------------------
+step("4c", "route (a) group-closure battery: central equivalence, both regimes")
+rc, out = run("route_a_closure_battery.py")
+record("route (a) closure battery exits 0", rc == 0)
+record("closure battery demonstrates the repair is load-bearing",
+       "mutation: removing central equivalence makes L(7;1,2) fail" in out
+       and "BATTERY PASS" in out)
+
 # --- 5 rehearsal -------------------------------------------------------------
 step(5, "Q4 integration rehearsal, including the deletion limb")
 rc, out = run("rehearsal_q4.py")
@@ -233,8 +241,8 @@ print(f"\n{'=' * 70}")
 if ok:
     print(f"PHASE A QUALIFICATION: PASS - structural 8/8; integrated "
           f"{n_items}/{n_items}; Q4 GREEN; deletion GREEN")
-    print("No rung has run on a real adjudication case; this is qualification,")
-    print("not adjudication evidence.")
+    print("No qualification run in this tree is adjudication evidence; every case")
+    print("exercised by this command is synthetic or a frozen tuning case.")
 else:
     print("PHASE A QUALIFICATION: FAIL")
     for name, passed, detail in results:

--- a/openwave/xperiments/m8_mit/research/m8_5b_adjudication/M85B-ADJ-04/STOP_RECORD.md
+++ b/openwave/xperiments/m8_mit/research/m8_5b_adjudication/M85B-ADJ-04/STOP_RECORD.md
@@ -1,0 +1,32 @@
+# M85B-ADJ-04: STOP / PRE-REVEAL ROUTE-A STRUCTURAL FAILURE
+
+    Case        M85B-ADJ-04, committed under Addendum 12.2
+    Outcome     retired as a pre-reveal bug-discovery case under
+                Addendum 12.3. No adjudication occurred
+    Packet II   sealed and unread throughout; its commitment stands
+
+## What happened
+
+Packet I was opened at § 4.1 step 2 and its bytes verified against the
+adopted commitment. During step 3, route (a) refused before producing an
+output: its multiplication-table lookup required sign-exact equality of
+action-pair representatives, while the effective-group closure had chosen
+representatives modulo the diagonal central kernel `(u, v) ~ (-u, -v)`, so
+products landing on a central partner were reported as absent. Route (b)
+was not run, no route output was committed, and no external reference value
+was consulted or compared. The external test is therefore not scored: no
+prediction ever met the reference.
+
+The defect is latent, not case-induced: the § 6.1 tuning case `L(7;1,2)`
+fails by the identical mechanism on the same path. It survived
+qualification because every case that previously reached route (a)'s
+stencil path was sign-exact closed by accident of selection. Addendum 12.3
+records the repair authorization and the requalification obligations;
+`route_a_closure_battery.py` in the qualified tree now covers the missing
+regime, with a mutation arm demonstrating the pre-repair lookup fails.
+
+## Files here
+
+`run_step3.py` is the step-3 driver exactly as executed at the STOP. It
+produced no artifacts. This directory deliberately contains no route
+output and no packet bytes.

--- a/openwave/xperiments/m8_mit/research/m8_5b_adjudication/M85B-ADJ-04/run_step3.py
+++ b/openwave/xperiments/m8_mit/research/m8_5b_adjudication/M85B-ADJ-04/run_step3.py
@@ -1,0 +1,52 @@
+"""M85B-ADJ-04, § 4.1 step 3: run both frozen routes, commit raw outputs, stop.
+
+Adjudication-side driver. It adds no logic: Packet I in, the two frozen
+producers at their frozen defaults, the frozen step-3 runner's route-local
+validation, canonical bytes out. Cross-route questions belong to step 5 and
+are not asked here.
+"""
+import hashlib
+import json
+import pathlib
+import sys
+
+HERE = pathlib.Path(__file__).parent
+TREE = HERE / "../../m8_5b"
+sys.path.insert(0, str((TREE / "production").resolve()))
+sys.path.insert(0, str((TREE / "gates").resolve()))
+sys.path.insert(0, str((TREE / "pilot").resolve()))
+
+import numpy as np                                          # noqa: E402
+import route_a_producer as route_a                          # noqa: E402
+import route_b_producer as route_b                          # noqa: E402
+import step3_runner as runner                               # noqa: E402
+from route_a_twosided import close_pairs                    # noqa: E402
+
+# the rehearsal's certification resolution: top rung of the frozen ladder
+CERTIFICATION_SEEDS = 480
+
+PACKET_I = pathlib.Path(sys.argv[1])
+COMMITTED = "52eabe3fc1d045bde8efad888e23f6302123fafa4e0ef151b31382f4cd1307c2"
+
+raw = PACKET_I.read_bytes()
+got = hashlib.sha256(raw).hexdigest()
+assert got == COMMITTED, f"Packet I hash {got} != adopted commitment"
+packet = json.loads(raw)
+assert packet["case_id"] == "M85B-ADJ-04"
+pairs = [(np.array(u, dtype=float), np.array(v, dtype=float))
+         for u, v in packet["generators"]]
+
+pairs_a = close_pairs(pairs)
+art_a = route_a.produce(pairs_a, "adj04-step3-a", "m8_5b-v1", "M85B-ADJ-04",
+                        seeds=CERTIFICATION_SEEDS, adjudication=True)
+art_b = route_b.produce(pairs, "adj04-step3-b", "m8_5b-v1", "M85B-ADJ-04",
+                        adjudication=True)
+
+def writer(label, raw_bytes):
+    (HERE / f"route_{label}.step3.json").write_bytes(raw_bytes)
+
+summary = runner.run(art_a, art_b, pairs, writer=writer)
+(HERE / "STEP3_RUNNER_SUMMARY.json").write_text(
+    json.dumps(summary, indent=2, sort_keys=True) + "\n")
+print(json.dumps(summary["committed"], indent=2, sort_keys=True))
+print("step 3 complete; stopped before any cross-route question")


### PR DESCRIPTION
The first real M8.5-B adjudication case ran, stopped pre-reveal on a latent route (a) defect, and forced the repair this branch carries. No adjudication occurred: Packet II was never opened, no route output was committed, and no reference value was consulted, so nothing here scores the external test.

The four commits are the argument, in ancestry order:

1. `78117280` adopts Addendum 12.2: the case commitment, two packet hashes sealed by an isolated unit before either production route saw them.
2. `5b6100c1` records the STOP. At § 4.1 step 3, route (a) refused before producing output: its multiplication-table lookup wanted sign-exact pair equality while the effective-group closure picks representatives modulo the central kernel `(u,v) ~ (-u,-v)`. The § 6.1 tuning case `L(7;1,2)` fails identically, so the defect is latent machinery, not case-induced. It survived qualification because every case that previously reached the stencil path was sign-exact closed by accident: the rehearsal case is homogeneous and the pilot's binary groups contain `-1` natively.
3. `eb354b6f` adopts Addendum 12.3, which confines the permitted repair to the one equality relation and retires `M85B-ADJ-04` as the pre-reveal bug-discovery case, Packet II sealed indefinitely.
4. `e7ae795b` is the repair and its requalification.

The repair is one matcher: lookup now identifies `(u,v)` with `(-u,-v)`, and a product matching no element in either sign is still refused. The new `route_a_closure_battery.py` (door step 4c) is the coverage whose absence let this survive: every `L(7;1,2)` table entry checked against the sign-free SO(4) action, a locally rebuilt pre-repair matcher required to fail, truncation required to refuse, cloud cardinality at effective order with no coincident points, route (a) end to end through the previously failing path, and route (b) proven unaffected two ways, a runtime dependency-closure probe through `produce()` and an independent character-sum reconstruction of its scalar records.

One command reproduces everything, from a clone or an exported archive:

    python3 openwave/xperiments/m8_mit/research/m8_5b/run_qualification.py

23 PASS, exit 0. Accounting is 40 tracked, 37 pinned, 3 excluded; no export-ignored file is manifest-pinned. The freeze record and the runner's closing verdict now state only what qualification establishes, naming the ADJ-04 invocation rather than denying it.

Unchanged: packet schemas, comparators, spectral formulas, indexing rules, thresholds, and both sealed packet commitments. Per Addendum 12.3, the next fresh case is selected only after this review and re-freeze.