### PR TITLE
models: codify the Lambda practice in the metric-phenomena definition

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -124,7 +124,7 @@ The cheapest concrete experiment that would earn each row, so every claim and ev
 | Weak force: muon decay | μ relaxes to e + neutral ejecta |
 | Weak force: beta decay (n → p) | n → p + e + ν̄, parity-violating (needs a neutron) |
 | Gravity: Newton limit (GEM) | attractive 1/r² between masses, via the GEM route |
-| Gravity: metric phenomena | light bending, time dilation, Λ |
+| Gravity: metric phenomena | light bending, time dilation; Λ credited only when derived from the model's own mechanism, never fitted |
 | | |
 | **WAVES + QUANTUM EMERGENCE** | |
 | EM waves (Maxwell) | Maxwell recovered; transverse waves at c |


### PR DESCRIPTION
Issue #463 (Smolinski) proposed removing Lambda from the Gravity: metric phenomena criterion as a parameter-fitting gate. Resolution: the row stays; the definition cell now states what applied practice already was, Lambda credited only when derived from the model's own mechanism, never fitted (M8.1 is the worked example). No cell state moves. check_models_md.py clean.