### PR TITLE
docs(MODELS): M4 Gravity local metric phenomena cell 🚧 → ⚠️ (extension named)

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -32,9 +32,9 @@ Every file reference is an active link to the file in this repository (under `op
 | **MODEL SCORE-BOARD** | [Liquid Crystal<br>(M5)](openwave/xperiments/m5_liquid_crystal/__M5_model_briefing.md) | [HydroBoros<br>(M7)](openwave/xperiments/m7_hydroboros/__M7_model_briefing.md) | [EWT<br>(M4)](openwave/xperiments/m4_ewt/__M4_model_briefing.md) | [Ouroboros<br>(M6)](openwave/xperiments/m6_ouroboros/__M6_model_briefing.md) | [MIT<br>(M8)](openwave/xperiments/m8_mit/__M8_model_briefing.md) | [NSM<br>(M9)](openwave/xperiments/m9_emergent_gravity/__M9_model_briefing.md) |
 | --- | --- | --- | --- | --- | --- | --- |
 | ✅ validated in-platform | 9 | 0 | 0 | 3 | 0 | 0 |
-| ⚠️ partial / with caveats | 11 | 10 | 8 | 2 | 1 | 1 |
+| ⚠️ partial / with caveats | 11 | 10 | 9 | 2 | 1 | 1 |
 | ❌ honest negative | 2 | 0 | 3 | 3 | 0 | 0 |
-| 🚧 planned / not tested | 9 | 21 | 20 | 23 | 30 | 30 |
+| 🚧 planned / not tested | 9 | 21 | 19 | 23 | 30 | 30 |
 | **Total criteria** | **31** | **31** | **31** | **31** | **31** | **31** |
 
 ### Summary Status
@@ -80,7 +80,7 @@ Each criterion's simplest passing test sits in its own companion table right bel
 | Weak force: muon decay | ⚠️ | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 | dynamic |
 | Weak force: beta decay (n → p) | ❌ | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 | dynamic |
 | Gravity: Newton limit (GEM) | ⚠️ | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 | both |
-| Gravity: local metric phenomena | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 | ⚠️ | both |
+| Gravity: local metric phenomena | 🚧 | 🚧 | ⚠️ | 🚧 | 🚧 | ⚠️ | both |
 | Cosmology: Λ / cosmic acceleration | 🚧 | 🚧 | 🚧 | 🚧 | ⚠️ | 🚧 | static |
 | | | | | | | | |
 | **WAVES + QUANTUM EMERGENCE** | | | | | | | |
@@ -277,7 +277,7 @@ Deep dive: [`0_STATUS.md`](openwave/xperiments/m3_wolff_lafreniere/research/0_ST
 | Weak force: muon decay | 🚧 [not yet tested]<br>Expected to be a result of particle formation/instability and not a true force; not modeled<br>(none yet) |
 | Weak force: beta decay (n → p) | 🚧 [not yet tested]<br>Not modeled (no in-sim neutron)<br>(none yet) |
 | Gravity: Newton limit (GEM) | 🚧 [not yet tested]<br>Not modeled<br>(none yet) |
-| Gravity: local metric phenomena | 🚧 [not yet tested]<br>Not modeled<br>(none yet) |
+| Gravity: local metric phenomena | ⚠️ [partially validated]<br>Enhanced EWT extension (Ł. Smoliński): the weak-field EMC density deficit encoded as `n(r) = (N_ν/N_stat)^(-1/2)` gives the solar-limb bending 1.751728 arcsec (M4.3), and the clock-speed encoding `v_clock = sqrt(η)` reproduces the exact Schwarzschild redshift factor (M4.4). The encoding is derived in the extension's manuscript, not in-platform; Shapiro delay not computed<br>[`m4_3_light_bending_emc_displacement.py`](openwave/xperiments/m4_ewt/research/scripts/m4_3_light_bending_emc_displacement.py), [`m4_4_gravitational_time_dilation.py`](openwave/xperiments/m4_ewt/research/scripts/m4_4_gravitational_time_dilation.py) |
 | Cosmology: Λ / cosmic acceleration | 🚧 [not yet tested]<br>Not modeled<br>(none yet) |
 | | |
 | **WAVES + QUANTUM EMERGENCE** | |


### PR DESCRIPTION
Lands the model-author decision from [PR #466](https://github.com/openwave-labs/openwave/pull/466): @jeffsyee supports moving the M4 `Gravity: local metric phenomena` cell from 🚧 to ⚠️ on the combined M4.3 + M4.4 evidence.

| Change | Detail |
| --- | --- |
| M4 cell | ⚠️ partially validated, extension named (Enhanced EWT, Ł. Smoliński), M4.3 bending + M4.4 redshift cited, gaps stated: encoding derived in the manuscript not in-platform, Shapiro delay not computed |
| Scoreboard | M4 ⚠️ 8 → 9, 🚧 20 → 19; column order unchanged |
| Checker | `dev_docs/utils/check_models_md.py` clean: 31 criteria, 186 cells, max 65 words |

Why ⚠️ and not ✅: both artifacts compute their observable from the postulated weak-field encoding `η = 1 − r_s/r`; the derivation of that encoding from lattice elasticity lives in the extension's cited manuscript (v4.5.6), not in-platform. On the matrix's own semantics that is a structural relation with the gaps named.

@jeffsyee FYI, this is your call as recorded on #466; nothing further needed. @lsmolinski FYI: the cell now carries your extension by name.
