### PR TITLE
M8.9 archive: close the two review notes from #485 on the commissions…

### DIFF
--- a/openwave/xperiments/m8_mit/research/m8_9/s1b/archive/commissions/README.md
+++ b/openwave/xperiments/m8_mit/research/m8_9/s1b/archive/commissions/README.md
@@ -19,6 +19,22 @@ the closeout's account of it.
 | `qualification_ROOM_MANIFEST.json` | that room's INPUT manifest, 82 entries |
 | `adjudication_ROOM_MANIFEST.json` | the adjudication room's manifest, 29 entries |
 
+## These copies are verbatim bytes, so do not reformat them
+
+**Leave every file above untouched by any style or cleanup pass. This page is the only file here
+that may be edited.** The four briefs and the gate are byte-identical to the entries that
+authenticate them: `qualification_TASK.md`, `round1_TASK.md` and `qualification_room_import_gate.py`
+against the qualification manifest's `TASK.md`, `prior/TASK_ROUND1.md` and `room_import_gate.py`,
+and `adjudication_TASK.md` against the adjudication manifest's `TASK.md`. The two manifests are
+themselves verbatim output of the gate's writer, `json.dumps(indent=1, sort_keys=True)` with a
+trailing newline, so a reformatter that prefers a different indent would break them the same way a
+rewrap breaks a brief.
+
+That byte-identity is the only thing that makes this directory worth having, because it is what lets
+a reader see what the units were actually given rather than a retelling. A later rewrap,
+fence-language fix, punctuation sweep, or JSON prettify would silently break the match and take the
+property with it.
+
 ## Why the import gate is here
 
 Several provenance defects the addenda describe were found BY this gate rather than by reading:
@@ -26,6 +42,11 @@ a missing `route_gates` dependency on the room's first build, a further `packet_
 under it, and a false-green in which modules calling `sys.exit(0)` at import terminated the checker
 with status 0 and no output, so the gate reported nothing and looked fine. It is archived as the
 instrument that caught them.
+
+**Archived, not for execution here.** The gate resolves its root as its own parent directory and
+writes a `ROOM_MANIFEST.json` beside itself, so running this copy in place would hash the archive
+instead of a room and leave a third manifest here that authenticates nothing. Read it; run it only
+from a room it was staged into.
 
 ## Provenance of these copies
 


### PR DESCRIPTION
… README

Both notes were comment tier, no round, marked "on next touch" in the #485 review. This is that touch. README only; the six archived files are byte unchanged, verified against upstream/main.

Note 1, the gate is archived and not for execution here. It resolves ROOT = Path(__file__).parent.resolve() and writes ROOM_MANIFEST.json into ROOT, so running the archived copy in place would hash the archive instead of a room and leave a third manifest in a directory whose whole point is that it authenticates nothing.

Note 2, the archived copies are correct only as verbatim bytes, so a future style pass has to skip this directory. Recomputed rather than restated before writing it down: qualification_TASK.md, round1_TASK.md and qualification_room_import_gate.py are byte-identical to the qualification manifest's TASK.md, prior/TASK_ROUND1.md and room_import_gate.py, and adjudication_TASK.md to the adjudication manifest's TASK.md, 4/4.

Beyond the note as written: the two ROOM_MANIFEST.json files are themselves byte-exact output of the gate's own writer, json.dumps(indent=1, sort_keys=True) with a trailing newline, confirmed for both. A JSON prettify would break them exactly as a rewrap breaks a brief, so the warning covers all six files rather than the four the note named, and says this README is the only file here that may be edited.

The README is safe to edit under that rule: it appears in neither manifest, its hash occurs nowhere in the repo, and nothing outside the archive references the path.