### PR TITLE
CONTRIBUTING: a computed verdict that still exits 0 is the fourth shape

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,13 +96,14 @@ See `/dev_docs` for coding standards and development guidelines
 
 ### Self-checks a script prints
 
-A line a script prints as `PASS`, `CONFIRMED`, or `-> arm goes red` is a claim about the run, and a later reader cannot tell a verified claim from an unfalsifiable one by reading the output. So before shipping a script, break the thing each such line checks and confirm the line actually goes red. Three shapes keep getting through:
+A line a script prints as `PASS`, `CONFIRMED`, or `-> arm goes red` is a claim about the run, and a later reader cannot tell a verified claim from an unfalsifiable one by reading the output. So before shipping a script, break the thing each such line checks and confirm the line actually goes red. Four shapes keep getting through:
 
 | Shape | Why it never fails | The fix |
 | --- | --- | --- |
 | Both sides of the comparison evaluate the same expression | The check is an identity, so replacing the rule under test with nonsense still prints `PASS` | Compare against something computed by a different route: an exact reference, an independent implementation, or a closed form |
 | The verdict word is printed unconditionally beside the number | Only the number moves; the label says the same thing whatever the run did | Compute the verdict, then print it: `ok = err < tol and mutation > 1e3 * err` |
 | A harness asserts a label appears in the output | `"my check" in out` is satisfied whether it printed `PASS my check` or `FAIL my check` | Match the prefixed form, `"PASS  my check"` |
+| The verdict is computed and printed, and the script still exits 0 | Anything reading exit status rather than stdout records a green run for a failed check, including your own rerun sweep and the record it writes | Carry the verdict in the exit status too, `sys.exit(0 if ok else 1)`, so the run is falsifiable without a human reading the output |
 
 Where a quantity has no independent target to compare against, the honest label is **asserted**, not a self-check. An asserted value is a perfectly good contribution; a self-check that cannot discriminate is not, because it reads exactly like a verified result.
 


### PR DESCRIPTION
Maintainer commit. One row added to `CONTRIBUTING.md` § "Self-checks a script prints", and the header count moved from three shapes to four.

The section already covered the three shapes that had cost review rounds. [#496](https://github.com/openwave-labs/openwave/pull/496) added a fourth, and it is the half the existing text does not reach: `jacobian_check.py` printed two verdict labels unconditionally, and the fix that computed them correctly still left the script exiting 0 either way, until the exit status carried the verdict too.

That matters on its own terms, because the section's own advice sends a contributor to a rerun sweep, and a sweep reading exit codes writes a green record for a failed check without a human ever seeing the label. In #496 the § 14 package recorded "all exit 0" as the evidence for the design-input reruns, so the record would have carried a green earned by a check that could not fail.

| Shape | Why it never fails | The fix |
| --- | --- | --- |
| The verdict is computed and printed, and the script still exits 0 | Anything reading exit status rather than stdout records a green run for a failed check, including your own rerun sweep and the record it writes | Carry the verdict in the exit status too, `sys.exit(0 if ok else 1)`, so the run is falsifiable without a human reading the output |

Worked example, contributed by the author of #496 and used with permission: both labels computed, the mutation scored against the parent at a `1e3` ratio, and `sys.exit(0 if (kern_ok and mut_ok) else 1)`. Neutralizing the gauge-breaking coefficient now prints `-> arm did NOT fire (broken arm)` and exits 1.

No other file touched. The reviewer's side, `PR_REVIEW_STANDARDS.md` rows D10 and D11, already carries this and needs no edit.
