### PR TITLE
M9: record the column as registered and dormant

### DIFF
--- a/openwave/xperiments/m9_emergent_gravity/__M9_model_briefing.md
+++ b/openwave/xperiments/m9_emergent_gravity/__M9_model_briefing.md
@@ -16,7 +16,7 @@
 | Model ID | M9 |
 | Name | NSM (New Standard Model): gravity as entanglement bookkeeping on SM + Einstein-Cartan |
 | Author | Dr. Robert W. McGwier, PhD, CTO, Cohere Technology Group (sole author) |
-| Author contact | GitHub [@n4hy](https://github.com/n4hy), for author-gated questions (definitions, intent, what the model does and does not claim); routing convention in [`dev_docs/CROSS_MODEL_TESTING.md`](../../../dev_docs/CROSS_MODEL_TESTING.md) § 6 |
+| Author contact | GitHub [@n4hy](https://github.com/n4hy), for author-gated questions (definitions, intent, what the model does and does not claim); routing convention in [`dev_docs/CROSS_MODEL_TESTING.md`](../../../dev_docs/CROSS_MODEL_TESTING.md) § 6. ⚠️ Channel unconfirmed since 2026-09-02: the collaborator invitation was issued twice and expired unaccepted, and the author last posted 2026-08-20, so a § 6 Q&A discussion may go unanswered. Treat an M9 author-gated question as open, not as pending an answer |
 | Lineage | Faulkner-Guica-Hartman-Myers-Van Raamsdonk 2014; Casini-Huerta-Myers; Einstein-Cartan-Sciama-Kibble; Hehl-Datta 1971; Jacobson entanglement equilibrium |
 | Primary sources | Author repo [github.com/n4hy/New_Model_Emergent_Gravity](https://github.com/n4hy/New_Model_Emergent_Gravity) (CC-BY-4.0 PDFs under `research/`); registry in [`theory/_CITATIONS.md`](theory/_CITATIONS.md). Specification of the first task: Paper III action (2) |
 | In-repo | Headless only. No launcher. First task: [`research/scripts/hehl_datta.py`](research/scripts/hehl_datta.py) |

--- a/openwave/xperiments/m9_emergent_gravity/research/m9_roadmap.md
+++ b/openwave/xperiments/m9_emergent_gravity/research/m9_roadmap.md
@@ -27,13 +27,14 @@
 | M9.7 | Jacobson substitute | Parked. Not [P]. Record at `a5640709` | author per-task PR |
 | M9.8+ | Entanglement-gravity campaign | Parked. Papers 14 to 73 (A1/A2 ansatz, first law, Gauss and enclosed-energy results, vacuum-energy negatives); the author registers each as a task row before its PR. Record at `a5640709` | author per-task PR |
 
-## STATUS AT A GLANCE (2026-08-22)
+## STATUS AT A GLANCE (2026-09-02)
 
 | Question | Answer |
 | --- | --- |
 | Where is M9? | Registered column (admission: discussion #442, 2026-08-15; activation merge: PR #441). MODELS.md column present, Hehl-Datta certification at ⚠️, every other cell 🚧 |
 | What kind of column? | Gravity-certification EFT. Matter installed. Closer to M8 than M5 |
 | What decides the first cell? | An in-platform gravity result against a pre-registered gate, landed by a per-task PR. M9.2 C1 passed only as inherited Newton, C2 failed, so the Newton cell stays 🚧 |
+| Is the column staffed? | No. The collaborator invitation was issued twice and expired unaccepted, and the author last posted 2026-08-20, so the column is registered and dormant. The registered slice stands on maintainer reruns of both gates, so no result here waits on contact |
 
 ## CONVENTIONS
 
@@ -60,6 +61,13 @@ neighbors record \(I_B\) / axial negatives. Official M9.2 is Newton only.
 | [M9.2](tasks/m9_2_task_details.md) | Newton limit | ⚠️ Closed 2026-08-15. C1 PASS, C2 FAIL (Dirichlet images). Inherited Einstein, not GEM; the MODELS.md Newton cell stays 🚧. [note](findings/m9_2_newton_note.md) | 2026-08-15 |
 
 ## CHANGE-LOG
+
+2026-09-02. Column dormant. The collaborator invitation was issued at
+admission and re-issued at activation; both expired unaccepted, so the
+author holds no repository role. No author activity since the 2026-08-20
+comment on PR #441. Backlog rows stay parked and return as per-task PRs
+whenever the author resumes. Nothing is withdrawn and nothing is waiting
+on the maintainer side.
 
 2026-08-22. Activation merge (PR #441) trimmed to the onboarding slice:
 scaffold, M9.1, M9.2. Campaign records M9.3 to M9.73, latex and the


### PR DESCRIPTION
Two maintainer edits recording that M9 is registered but unstaffed. Nothing is withdrawn, no contributor work is touched, and no cell changes.

| Edit | What |
| --- | --- |
| `m9_roadmap.md` | STATUS snapshot re-dated, new `Is the column staffed?` row, and a CHANGE-LOG entry for the dormancy |
| `__M9_model_briefing.md` | `Author contact` row flags the channel as unconfirmed, so a `CROSS_MODEL_TESTING.md` § 6 Q&A discussion is not opened into silence |

The facts behind it: the collaborator invitation was issued at admission and re-issued at activation, both expired unaccepted, so the author holds no repository role; the last author post anywhere in the org is the 2026-08-20 comment on #441.

Nothing on the platform depends on reaching the author. The registered slice was rerun here before merge (Hehl-Datta gate `r = 3/16` on both signatures, `NEWTON_INHERITED_PASS` with C1 PASS and C2 FAIL), so the one ⚠️ cell stands on maintainer verification. The parked M9.3 to M9.8+ rows keep their `author per-task PR` gate and return whenever the author resumes.
