### PR TITLE
Declare black in a dev extra; point conda env references at master312

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ See `/dev_docs` for coding standards and development guidelines
     conda activate openwave
 
 # Install OpenWave & Dependencies for Development (-e = edit mode)
-   pip install -e .  # installs dependencies from pyproject.toml
+   pip install -e ".[dev]"  # dependencies from pyproject.toml, plus the formatter below
 
 # Activate the auto-DCO-sign-off git hook (one-time per clone)
    git config core.hooksPath .githooks
@@ -87,7 +87,7 @@ See `/dev_docs` for coding standards and development guidelines
 ## Code Style & Quality
 
 - Follow [PEP 8](https://peps.python.org/pep-0008/).
-- Use [Black](https://black.readthedocs.io/) and [isort](https://pycqa.github.io/isort/) for formatting.
+- Use [Black](https://black.readthedocs.io/) and [isort](https://pycqa.github.io/isort/) for formatting. Black is configured at `line-length = 99` in `pyproject.toml` and ships in the `dev` extra installed above, so `black .` from the repo root is already set up. isort is not yet configured or bundled; if you run it, pass `--profile black` so its import ordering does not fight the formatter.
 - Run tests before committing:
 
 ```python

--- a/openwave/xperiments/m5_liquid_crystal/research/findings/m5_11_pmns_findings.md
+++ b/openwave/xperiments/m5_liquid_crystal/research/findings/m5_11_pmns_findings.md
@@ -83,7 +83,7 @@ So the 0.28% is consistent with the projection picture, and the scale (0.28% ≪
 
 ## Reproduce
 
-| Output | Command (env `openwave312`) |
+| Output | Command (env `master312`) |
 | --- | --- |
 | PMNS SO(3) prediction + NuFIT comparison + δ_CP test + 0.28% framework | `python3 m5_11_pmns_so3.py` |
 | Writes | `data/m5_11_pmns_summary.json`, `plots/m5_11_pmns_so3.png` |

--- a/openwave/xperiments/m5_liquid_crystal/research/findings/m5_11_theta13_findings.md
+++ b/openwave/xperiments/m5_liquid_crystal/research/findings/m5_11_theta13_findings.md
@@ -75,7 +75,7 @@ The calibration thread (#217) found the core potential V is **rotation-invariant
 
 ## Reproduce
 
-| Output | Command (env `openwave312`) |
+| Output | Command (env `master312`) |
 | --- | --- |
 | θ₁₃ vs correction + which-plane + 2D best-fit + δ_CP vs phase | `python3 m5_11_theta13_breaking.py` |
 | Writes | `data/m5_11_theta13_summary.json`, `plots/m5_11_theta13_breaking.png` |

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_12_audit_b13_hdrift.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_12_audit_b13_hdrift.py
@@ -16,7 +16,7 @@ Checks, with MY OWN H (block-11 audit lib, ALL pairs +):
      the denominator is pure quadrature choice
   4. the honest metric: absolute swing per rung: does 10x/rung survive?
 
-Run: /opt/anaconda3/envs/openwave312/bin/python m5_12_audit_b13_hdrift.py
+Run: /opt/anaconda3/envs/master312/bin/python m5_12_audit_b13_hdrift.py
 """
 from __future__ import annotations
 

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_12_audit_b13_rescale.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_12_audit_b13_rescale.py
@@ -16,7 +16,7 @@ Attacks:
 
 All functionals are the INDEPENDENT block-11 audit implementations.
 
-Run: /opt/anaconda3/envs/openwave312/bin/python m5_12_audit_b13_rescale.py
+Run: /opt/anaconda3/envs/master312/bin/python m5_12_audit_b13_rescale.py
 """
 from __future__ import annotations
 

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_12_audit_b13_seed.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_12_audit_b13_seed.py
@@ -16,7 +16,7 @@ rank-one + phase. LSMR requires a consistent adjoint pair. Test
 <A v, u> == <v, A^T u> on random vectors at the r4 endpoint, with the
 claimant's exact scaling (Dscale) replicated.
 
-Run: /opt/anaconda3/envs/openwave312/bin/python m5_12_audit_b13_seed.py
+Run: /opt/anaconda3/envs/master312/bin/python m5_12_audit_b13_seed.py
 """
 from __future__ import annotations
 

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_12_audit_b13_verdicts.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_12_audit_b13_verdicts.py
@@ -6,7 +6,7 @@ verdicts {L1..L5}. All numbers cited in the verdicts are produced by the
 b13 audit scripts (independent block-11-lib functionals) or are arithmetic
 on the claimant's own published records (marked as such).
 
-Run: /opt/anaconda3/envs/openwave312/bin/python m5_12_audit_b13_verdicts.py
+Run: /opt/anaconda3/envs/master312/bin/python m5_12_audit_b13_verdicts.py
 """
 from __future__ import annotations
 

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_12_audit_b13_verify.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_12_audit_b13_verify.py
@@ -13,7 +13,7 @@ For every block-12 ladder endpoint state (r1,r2,r4,r8,x2,x4):
   - recompute the endpoint |F| (residual on free DOF + phase row) for the
     L3 absolute-floor table (claimant instrument residual, audited BG-gated)
 
-Run: /opt/anaconda3/envs/openwave312/bin/python m5_12_audit_b13_verify.py
+Run: /opt/anaconda3/envs/master312/bin/python m5_12_audit_b13_verify.py
 """
 from __future__ import annotations
 

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_23_2_render_selftest.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_23_2_render_selftest.py
@@ -15,7 +15,7 @@ per-gap (the M5.24 selftest pattern):
   D — arm (2), the J/mu twist demo: the rod-sample eigenframe advances at
       the M5.23.1 visible rate under SET-J on the demo xparameter flow.
 
-Run:  cd openwave && /opt/anaconda3/envs/openwave312/bin/python \
+Run:  cd openwave && /opt/anaconda3/envs/master312/bin/python \
       openwave/xperiments/m5_liquid_crystal/research/scripts/m5_23_2_render_selftest.py
 """
 

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r0_audit_notebook.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r0_audit_notebook.py
@@ -49,7 +49,7 @@ as 1/(R^3 d), whose radial integral is logarithmic, so E_int(d) should carry a (
 with coefficient 2 * 4 pi * (2/3) * (1/d) per hedgehog pair = 32 pi / 3 / d, not a pure 1/d.
 
 Outputs: ``research/data/m5_32_r0_audit_notebook.json``.
-Run: ``/opt/anaconda3/envs/openwave312/bin/python3 m5_32_r0_audit_notebook.py``
+Run: ``/opt/anaconda3/envs/master312/bin/python3 m5_32_r0_audit_notebook.py``
 """
 
 from __future__ import annotations

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r11_a_samesign.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r11_a_samesign.py
@@ -52,7 +52,7 @@ H-c  (F_abcd F^abcd)^2 = R8's Q_I1sq (class C5 in the plan's vocabulary; NOT
      box ladder; deformation ratio > 1 at the threshold.
 
 Outputs: ../data/m5_32_r11_samesign.json, ../plots/m5_32_r11_samesign.png
-Run: nice -n 10 /opt/anaconda3/envs/openwave312/bin/python3 m5_32_r11_a_samesign.py
+Run: nice -n 10 /opt/anaconda3/envs/master312/bin/python3 m5_32_r11_a_samesign.py
 """
 from __future__ import annotations
 

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r12_a_ring.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r12_a_ring.py
@@ -75,7 +75,7 @@ H12-c  Clock: the RIGID inertia of the relaxed ring is of the hedgehog's
 
 Outputs: ../data/m5_32_r12_ring.json, ../plots/m5_32_r12_ring.png,
          ../checkpoints/m5_32_r12/*.npy (local, gitignored)
-Run: nice -n 10 /opt/anaconda3/envs/openwave312/bin/python3 m5_32_r12_a_ring.py
+Run: nice -n 10 /opt/anaconda3/envs/master312/bin/python3 m5_32_r12_a_ring.py
 """
 from __future__ import annotations
 

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r13w_audit.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r13w_audit.py
@@ -25,7 +25,7 @@ CLI:  python3 m5_32_r13w_audit.py w012          (this audit; writes key "w012")
       python3 m5_32_r13w_audit.py w3            (W3 audit, key "w3": groups A to J of the W3 brief)
       python3 m5_32_r13w_audit.py w3_ctrl       (the same-seed-maturity L control, 28 min; key "w3_ctrl")
 Out:  ../data/m5_32_r13w_audit.json  (merged by top-level key)
-Run:  /opt/anaconda3/envs/openwave312/bin/python3 m5_32_r13w_audit.py w012
+Run:  /opt/anaconda3/envs/master312/bin/python3 m5_32_r13w_audit.py w012
 """
 from __future__ import annotations
 

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r13w_w0.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r13w_w0.py
@@ -76,7 +76,7 @@ AUDIT NOTES CARRIED (2026-09-02, the independent W0-W2 audit, m5_32_r13w_audit.p
     on block-diagonal fields; a boost generator over the same twist gives kin < 0.
 
 Out: ../data/m5_32_r13w_w0.json
-Run: /opt/anaconda3/envs/openwave312/bin/python3 m5_32_r13w_w0.py
+Run: /opt/anaconda3/envs/master312/bin/python3 m5_32_r13w_w0.py
 """
 from __future__ import annotations
 

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r13w_w1.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r13w_w1.py
@@ -21,7 +21,7 @@ CONTROL      the ORIENTATION wall (the vacuum rotated by Delta q in the (2,3) pl
 Numerical representation: FIRE dt0 0.01, dt_max 0.1, 12000 iterations or fmax < 1e-6.
 
 Out: ../data/m5_32_r13w_w1.json, ../plots/m5_32_r13w_w1.png
-Run: /opt/anaconda3/envs/openwave312/bin/python3 m5_32_r13w_w1.py
+Run: /opt/anaconda3/envs/master312/bin/python3 m5_32_r13w_w1.py
 """
 from __future__ import annotations
 

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r13w_w2.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r13w_w2.py
@@ -30,7 +30,7 @@ CONTROLS (post-W0, logged as deviations from the packet, not pre-registered):
 Numerical representation: FIRE dt0 0.01, dt_max 0.1, 12000 iterations or fmax < 1e-6.
 
 Out: ../data/m5_32_r13w_w2.json, ../plots/m5_32_r13w_w2.png
-Run: /opt/anaconda3/envs/openwave312/bin/python3 m5_32_r13w_w2.py
+Run: /opt/anaconda3/envs/master312/bin/python3 m5_32_r13w_w2.py
 """
 from __future__ import annotations
 

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r13w_w3.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r13w_w3.py
@@ -36,7 +36,7 @@ W0 PREDICTION (S5, S6): the shell SURVIVES (kinetic reward >> V4 cost) and the
 
 Modes:  run n L Rs J maxit      one relaxation (cached in ../checkpoints/m5_32_r13w/)
         collect                  assemble ../data/m5_32_r13w_w3.json + ../plots/m5_32_r13w_w3.png
-Run:    /opt/anaconda3/envs/openwave312/bin/python3 m5_32_r13w_w3.py run 32 48 9 200 3000
+Run:    /opt/anaconda3/envs/master312/bin/python3 m5_32_r13w_w3.py run 32 48 9 200 3000
 """
 from __future__ import annotations
 

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r14_overnight_audit.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r14_overnight_audit.py
@@ -25,7 +25,7 @@ R = sum_{ij} F_ij[j, i], R_G = G_cd T^cd, K_lambda from the sorted spectrum; gra
 the registries, gated by finite differences of the OWN energies; own FIRE and own plain
 gradient descent (at most 100 steps); own localization diagnostic.
 
-Run:  /opt/anaconda3/envs/openwave312/bin/python3 m5_32_r14_overnight_audit.py [--stage d2|b2|all]
+Run:  /opt/anaconda3/envs/master312/bin/python3 m5_32_r14_overnight_audit.py [--stage d2|b2|all]
 Out:  ../data/m5_32_r14_overnight_audit.json
 """
 import sys

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r15_h_audit.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r15_h_audit.py
@@ -7,7 +7,7 @@ theta_t -> e*tht, theta_z -> e*thz), which avoids sympy `series` on the
 projector trig products.
 
 Run:
-    /opt/anaconda3/envs/openwave312/bin/python3 m5_32_r15_h_audit.py
+    /opt/anaconda3/envs/master312/bin/python3 m5_32_r15_h_audit.py
 Writes ../data/m5_32_r15_h_audit.json.
 """
 

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r16_2_audit.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r16_2_audit.py
@@ -20,7 +20,7 @@ Audit routes (all second differences of the ENERGY, no producer operator):
   core  the 10x10 symmetric-block Hessian on the 8 innermost cells
 
 Run (research dir):
-  OMP_NUM_THREADS=2 /opt/anaconda3/envs/openwave312/bin/python3 \
+  OMP_NUM_THREADS=2 /opt/anaconda3/envs/master312/bin/python3 \
       scripts/m5_32_r16_2_audit.py
 Output: data/m5_32_r16_2_audit.json (relative paths only).
 """

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r16_4_audit.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r16_4_audit.py
@@ -10,7 +10,7 @@ certified stencil helpers d1 / branches / coords are imported from
 m5_21_3_a_4d.py.
 
 Run (research dir):
-    OMP_NUM_THREADS=2 /opt/anaconda3/envs/openwave312/bin/python3 \
+    OMP_NUM_THREADS=2 /opt/anaconda3/envs/master312/bin/python3 \
         scripts/m5_32_r16_4_audit.py
 Output: data/m5_32_r16_4_audit.json (relative paths only) + a terminal table.
 """

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r3_audit_ansatz.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r3_audit_ansatz.py
@@ -48,7 +48,7 @@ block of F is O(m^2) and its time row O(m^3): S ~ m^4, T ~ m^6, T/S ~ m^2 in the
 regime; at m ~ 1 the expansion fails and T/S is measured, not predicted.
 
 Outputs: ../data/m5_32_r3_audit_ansatz.json
-Run: nice -n 10 /opt/anaconda3/envs/openwave312/bin/python3 m5_32_r3_audit_ansatz.py
+Run: nice -n 10 /opt/anaconda3/envs/master312/bin/python3 m5_32_r3_audit_ansatz.py
 """
 from __future__ import annotations
 

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r3_i_ansatz.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r3_i_ansatz.py
@@ -74,7 +74,7 @@ m = 0 vacuum and null pair per (M0, box). Every field evaluation returns the
 h^3 sums of I1, I1_h, S, T, V4, so all lambda are read from one evaluation.
 
 Out: ../data/m5_32_r3_ansatz.json, ../plots/m5_32_r3_ansatz.png
-Run: /opt/anaconda3/envs/openwave312/bin/python3 m5_32_r3_i_ansatz.py [--smoke] [--workers N]
+Run: /opt/anaconda3/envs/master312/bin/python3 m5_32_r3_i_ansatz.py [--smoke] [--workers N]
 """
 from __future__ import annotations
 

--- a/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r6_audit.py
+++ b/openwave/xperiments/m5_liquid_crystal/research/scripts/m5_32_r6_audit.py
@@ -63,7 +63,7 @@ D5 orbit blindness (three lines). For Q in O(1,3), Q^T eta Q = eta:
     symmetric sector point; report max relative variation of V4, det(M),
     tr((M eta)^p); Euclidean control tr(M^2) must NOT be invariant.
 
-Run: /opt/anaconda3/envs/openwave312/bin/python3 m5_32_r6_audit.py
+Run: /opt/anaconda3/envs/master312/bin/python3 m5_32_r6_audit.py
 Out: ../data/m5_32_r6_audit.json
 """
 from __future__ import annotations

--- a/openwave/xperiments/m5_liquid_crystal/research/tasks/m5_23_task_details.md
+++ b/openwave/xperiments/m5_liquid_crystal/research/tasks/m5_23_task_details.md
@@ -76,7 +76,7 @@ The headless preview (the selftest's render of the 162-glyph shell around the bi
 
 ![](../plots/m5_23_shell_selftest.png)
 
-The hedgehog signature is exactly the expected one: every shaft radial (the topological "hedgehog" made visible in one glance), the delta bars tangent on the shell. Live look: run the launcher (`python -m openwave.xperiments.m5_liquid_crystal._launcher` in the `openwave312` env) and check `Ellipsoids (1 /angle)`.
+The hedgehog signature is exactly the expected one: every shaft radial (the topological "hedgehog" made visible in one glance), the delta bars tangent on the shell. Live look: run the launcher (`python -m openwave.xperiments.m5_liquid_crystal._launcher` in the `master312` env) and check `Ellipsoids (1 /angle)`.
 
 ## STAGE B FINDINGS (2026-07-19)
 

--- a/openwave/xperiments/m5_liquid_crystal/research/tasks/m5_24_task_details.md
+++ b/openwave/xperiments/m5_liquid_crystal/research/tasks/m5_24_task_details.md
@@ -30,7 +30,7 @@
 
 **Research body**: audit inventory + gap table + findings live in THIS doc; scripts `../scripts/m5_24_*.py`; plots `../plots/m5_24_*.png`; checkpoint `../checkpoints/m5_24_progress.md`. Feeds [M5.23.2](m5_23_2_task_details.md) (gated on the certified 4D production physics this task delivers).
 
-**Stages**: A inventory sweep → B gap table → C port batch 1 → D smoke + regression. Preconditions: taichi via the conda env `openwave312`; canonical registry fresh-read at EXECUTE.
+**Stages**: A inventory sweep → B gap table → C port batch 1 → D smoke + regression. Preconditions: taichi via the conda env `master312`; canonical registry fresh-read at EXECUTE.
 
 ## STAGE A FINDINGS: the production physics inventory (2026-07-19)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,21 @@ dependencies = [
   "pytest>=8.0,<10.0",
 ]
 
+# Formatting tools, which CONTRIBUTING.md makes a condition of a pull request rather than a
+# suggestion. This repo has no CI, so a contributor's own machine is the entire enforcement
+# surface: a tool the project gates merges on has to be installable from the project's own
+# metadata, or every contributor has to work out separately that they need it. Install with
+# `pip install -e ".[dev]"`.
+#
+# pytest deliberately stays in the runtime list above rather than moving here, so that a
+# plain `pip install -e .` leaves the `pytest` invocation in CONTRIBUTING.md runnable. With
+# no CI there is nothing else that would catch a contributor whose install silently lacks
+# the runner, and demoting it to an extra would make that failure look like a broken repo.
+[project.optional-dependencies]
+dev = [
+  "black>=24.0",
+]
+
 [project.scripts]
 openwave = "openwave.i_o.cli:cli_main"
 
@@ -82,3 +97,10 @@ norecursedirs = [
 
 [tool.black]
 line-length = 99
+
+# Pinned to the interpreter floor in `requires-python`. Without it Black 26 infers a target
+# from the source and warns on every run that a 3.12 interpreter cannot verify code it
+# formatted for a newer Python, because its safety check re-parses the output with the
+# running CPython. Naming the floor makes the formatter agree with the version contract the
+# project already publishes, and silences the warning without --fast skipping the check.
+target-version = ["py312"]


### PR DESCRIPTION
The repo gates pull requests on Black via CONTRIBUTING.md and the TUTORIAL checklist but never declared it, so a contributor following the setup got no formatter. With no CI the contributor's own install is the whole enforcement surface, and a tool the project gates merges on has to come from the project's own metadata. Adds [project.optional-dependencies] dev and points the setup command at it. pytest stays in the runtime list so the CONTRIBUTING invocation keeps working on a plain editable install.

Pins tool.black target-version to py312, matching requires-python. Without it Black 26 warns on every run that a 3.12 interpreter cannot verify code it formatted for a newer Python.

Renames the shared conda env in forward-looking USAGE and Run blocks. Recorded run provenance keeps the old name: the data/*.json command fields, the checkpoint Env rows, and the v10_00_design Env section pin versions the new env has never had, so rewriting them would falsify the record.