### PR TITLE
Adopt CalVer and bump version to 26.9.7

### DIFF
--- a/dev_docs/VERSION_MANAGEMENT.md
+++ b/dev_docs/VERSION_MANAGEMENT.md
@@ -39,13 +39,13 @@ When bumping the version, update **both** files:
 1. Edit `openwave/__init__.py`:
 
    ```python
-   __version__ = "0.2.0"  # Update this
+   __version__ = "26.9.7"  # Update this to today's date
    ```
 
 1. Edit `pyproject.toml`:
 
    ```toml
-   version = "0.2.0"  # Update this to match
+   version = "26.9.7"  # Update this to match
    ```
 
 ### Why This Works with Editable Installs
@@ -57,12 +57,40 @@ Both installation methods will see the same version number.
 
 ## Version Numbering
 
-OpenWave follows [Semantic Versioning (SemVer)](https://semver.org/):
+OpenWave uses **calendar versioning (CalVer)** in the form `YY.M.D`: the date the release was
+cut. `26.9.7` is 7 September 2026. Adopted 2026-09-07, replacing SemVer at `1.6.10`.
 
-- **MAJOR**: Breaking changes (incompatible API changes)
-- **MINOR**: New features (backward-compatible)
-- **PATCH**: Bug fixes (backward-compatible)
-- **0.x**: Pre-release versions (API still evolving)
+### Why not SemVer
+
+A SemVer number is a backward-compatibility promise addressed to a dependency resolver. This
+project has no resolver to make one to: it is not published to PyPI, nothing pins a version
+range against it, and with no CI there is nothing that could check such a promise even in
+principle. `MINOR` versus `PATCH` was a judgment call made on every release for no reader.
+
+A date is a fact the project can keep. It also carries information the old scheme did not: a
+reader of a dated finding, method note or run record can tell at a glance whether the engine
+predates or postdates it, which matters in a repository where results cite the version they
+were produced with.
+
+The tradeoff, stated plainly: CalVer says nothing about compatibility, and it makes a release
+gap visible on the front page. Both are accepted. The compatibility signal was never verified,
+and "last released September 2026" is useful to anyone deciding whether to build on the engine.
+
+### Rules
+
+| Rule | Reason |
+| --- | --- |
+| No zero padding: `26.9.7`, never `26.09.07` | PEP 440 strips leading zeros, so the padded form installs as `26.9.7` and stops matching its own tag |
+| No `v` in `__init__.py` or `pyproject.toml` | PEP 440 strips it too. The `v` prefix belongs on the git tag alone, which is where the existing convention already puts it |
+| A second release on a day already used adds a fourth component: `26.9.7.1` | ⚠️ NOT a letter suffix. PEP 440 reads `26.9.7b` as a **beta** of `26.9.7`, which sorts BEFORE it and which `pip install` skips by default, so an emergency fix numbered that way would be both invisible and considered older than the release it fixes |
+| One release per day is the norm | Four days in the pre-CalVer history carried two releases (2026-01-20, 2026-07-02, 2026-07-20, 2026-07-29). The fourth component exists for that case and is expected to stay rare |
+
+### Ordering
+
+`YY.M.D` sorts correctly under PEP 440 because each component is compared as an integer, not as
+text: `26.9.7 < 26.10.1 < 27.1.3`. The switch also moved forward, never back, since
+`1.6.10 < 26.9.7`. That makes it a one-way change: returning to SemVer would require a version
+decrease, which no installer would select.
 
 ## Implementation Details
 
@@ -134,23 +162,24 @@ This ensures:
 git add .
 git commit -m "Add new feature X"
 
-# 2. Bump the version
-# Edit: openwave/__init__.py → __version__ = "0.2.0"
-# Edit: pyproject.toml → version = "0.2.0"
+# 2. Bump the version to today's date, YY.M.D with no zero padding
+date +%y.%-m.%-d          # prints the version to use, e.g. 26.9.7
+# Edit: openwave/__init__.py → __version__ = "26.9.7"
+# Edit: pyproject.toml → version = "26.9.7"
 
 # 3. Commit the version bump
 git add openwave/__init__.py pyproject.toml
-git commit -m "Bump version to 0.2.0"
+git commit -m "Bump version to 26.9.7"
 
 # 4. Create a git tag
-git tag -a v0.2.0 -m "Release version 0.2.0"
+git tag -a v26.9.7 -m "Release version 26.9.7"
 
 # 5. Push everything
 git push origin main
-git push origin v0.2.0
+git push origin v26.9.7
 
 # 6. Create GitHub release (via UI or gh cli)
-gh release create v0.2.0 --title "v0.2.0" --notes "Release notes here"
+gh release create v26.9.7 --title "v26.9.7" --notes "Release notes here"
 
 # 7. (Optional) Publish to PyPI
 python -m build
@@ -168,9 +197,9 @@ git commit -m "Fix bug Y"
 git commit -m "Update docs"
 
 # Then bump version as last commit before tag
-# Edit version files...
-git commit -m "Bump version to 0.2.0"
-git tag -a v0.2.0 -m "Release v0.2.0"
+# Edit version files to today's date...
+git commit -m "Bump version to 26.9.7"
+git tag -a v26.9.7 -m "Release v26.9.7"
 ```
 
 ### What NOT to Do
@@ -179,71 +208,59 @@ git tag -a v0.2.0 -m "Release v0.2.0"
 - **Don't commit version bumps on every commit**: Creates noise in git history
 - **Don't leave version bumps uncommitted**: Other developers won't see the new version
 
-### When to Bump Which Number?
+### Which Number to Use
 
-Following Semantic Versioning (SemVer):
+Read a calendar. There is no judgment call to make and no need to look up the previous
+version:
 
-#### MAJOR version (X.0.0) - Breaking Changes
+```bash
+date +%y.%-m.%-d          # 26.9.7
+```
 
-Increment when making incompatible API changes:
-
-- Remove or rename public functions
-- Change function signatures
-- Remove deprecated features
-- Restructure modules/packages
-
-#### MINOR version (0.X.0) - New Features
-
-Increment when adding functionality in a backward-compatible manner:
-
-- Add new functions/classes
-- Add new optional parameters
-- New capabilities that don't break existing code
-- New experimental features
-
-#### PATCH version (0.0.X) - Bug Fixes
-
-Increment when making backward-compatible bug fixes:
-
-- Fix broken functionality
-- Performance improvements
-- Documentation updates
-- Internal refactoring
+The only decision left is the rare one: if that exact version was already released today, add
+a fourth component (`26.9.7.1`, then `26.9.7.2`).
 
 ### Pre-release Versions
 
-For development versions between releases, use pre-release suffixes:
+⚠️ SemVer-style suffixes such as `0.2.0-dev` or `0.2.0-alpha.1` are NOT canonical PEP 440 and
+silently mutate on install. Python rewrites them:
+
+| Written | What pip records |
+| --- | --- |
+| `26.9.7-dev` | `26.9.7.dev0` |
+| `26.9.7-alpha.1` | `26.9.7a1` |
+| `26.9.7-beta.1` | `26.9.7b1` |
+| `26.9.7-rc.1` | `26.9.7rc1` |
+
+Write the canonical form directly if a pre-release is ever needed:
 
 ```python
-__version__ = "0.2.0-dev"       # Development (ongoing work)
-__version__ = "0.2.0-alpha.1"   # Alpha release (early testing)
-__version__ = "0.2.0-beta.1"    # Beta release (feature complete)
-__version__ = "0.2.0-rc.1"      # Release candidate (final testing)
-__version__ = "0.2.0"           # Final release
+__version__ = "26.9.7.dev0"   # Development (ongoing work)
+__version__ = "26.9.7a1"      # Alpha (early testing)
+__version__ = "26.9.7b1"      # Beta (feature complete)
+__version__ = "26.9.7rc1"     # Release candidate (final testing)
+__version__ = "26.9.7"        # Final release
 ```
+
+⚠️ All four sort BEFORE `26.9.7`, and `pip install` skips them unless asked for with
+`--pre`. That is what they are for. It is also why a same-day hotfix must never be numbered
+`26.9.7b`: it would be treated as a beta of a release that already shipped.
+
+In practice a date-based scheme has little use for these. The working version between releases
+is simply the last released version until the day a new one is cut.
 
 ### Automation Options
 
-Consider automating version bumping with tools:
-
-- **bump2version** / **bumpver**: CLI tools for version management
-- **semantic-release**: Automatically determines version from commit messages
-- **GitHub Actions**: Automate bumping on merge to main
-
-Example using `bumpver`:
+Version bumping needs no tool now that the number is a date, and `bumpver update --patch`
+style commands no longer map onto anything. If any automation is added later, the useful
+target is checking that the two files agree and that the tag matches, not computing the number:
 
 ```bash
-# Install
-pip install bumpver
-
-# Bump patch version (0.1.1 → 0.1.2)
-bumpver update --patch
-
-# Bump minor version (0.1.2 → 0.2.0)
-bumpver update --minor
-
-# Bump major version (0.2.0 → 1.0.0)
-bumpver update --major
+# Verify the two version strings are in sync before tagging
+python -c "import tomllib,re,sys; \
+t=tomllib.load(open('pyproject.toml','rb'))['project']['version']; \
+i=re.search(r'__version__ = \"([^\"]+)\"',open('openwave/__init__.py').read()).group(1); \
+sys.exit(0 if t==i else f'version mismatch: pyproject {t} vs __init__ {i}')"
 ```
 
 ## Best Practices Summary
@@ -252,7 +269,7 @@ bumpver update --major
 1. Bump version BEFORE creating git tags and releases
 1. Use the pattern shown above when accessing version in code
 1. Keep version numbers synchronized between source and build config
-1. Follow semantic versioning guidelines strictly
+1. Use today's date, `YY.M.D`, with no zero padding and no `v` prefix in the files
 1. Create dedicated version bump commits
 1. Document version changes in commit messages and release notes
-1. Use pre-release suffixes for development versions
+1. Reserve a fourth component (`26.9.7.1`) for a second release on the same day

--- a/openwave/__init__.py
+++ b/openwave/__init__.py
@@ -5,4 +5,9 @@ to study particle and force emergence. GPU-accelerated.
 
 """
 
-__version__ = "1.6.10"
+# Calendar versioning, YY.M.D: the date the release was cut. No zero padding, because
+# PEP 440 strips it and "26.09.07" would install as "26.9.7", silently unmatching its tag.
+# A second release on a day already used takes a fourth component, "26.9.7.1". NOT a letter
+# suffix: PEP 440 reads "26.9.7b" as beta, which sorts BEFORE 26.9.7 and is skipped by a
+# default pip install. Keep this in sync with pyproject.toml. See dev_docs/VERSION_MANAGEMENT.md.
+__version__ = "26.9.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,18 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "OPENWAVE"
 
-# Semantic Versioning (SemVer): MAJOR.MINOR.PATCH
-# - MAJOR: Breaking changes (incompatible API changes)
-# - MINOR: New features (backward-compatible)
-# - PATCH: Bug fixes (backward-compatible)
-version = "1.6.10"
+# Calendar versioning (CalVer), YY.M.D: the date the release was cut. Adopted 2026-09-07,
+# replacing SemVer at 1.6.10. SemVer encodes a backward-compatibility promise to a dependency
+# resolver, and this project has no resolver to make one to: it is not on PyPI, nothing pins a
+# range against it, and with no CI there is nothing that could verify such a promise. A date is
+# a fact the project can actually keep. It also lets a reader of a dated finding or method note
+# tell at a glance whether the engine predates it.
+#
+# Rules: no zero padding (PEP 440 strips it, so "26.09.07" installs as "26.9.7" and stops
+# matching its own tag). No "v" here; that prefix belongs on the git tag alone. A second release
+# on a day already used takes a fourth component, "26.9.7.1", NOT a letter suffix, because
+# PEP 440 reads "26.9.7b" as a beta that sorts BEFORE 26.9.7 and that pip skips by default.
+version = "26.9.7"
 
 requires-python = ">=3.12"
 


### PR DESCRIPTION
Switches project versioning from SemVer to date-based CalVer (YY.M.D) in both `pyproject.toml` and `openwave/__init__.py`. Adds explicit PEP 440 guidance (no zero-padding, no letter suffixes, optional fourth segment for same-day rereleases) and documents why CalVer better fits the project’s release model.